### PR TITLE
#164 Add a preassembled model for node fault

### DIFF
--- a/dynawo/sources/Models/Modelica/PreassembledModels/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/PreassembledModels/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(MODELICA_PREASSEMBLED_MODELS
     LoadAlphaBeta.xml
     LoadOneTransformer.xml
     LoadTwoTransformers.xml
+    NodeFault.xml
     PhaseShifterI.xml
     PhaseShifterP.xml
     SetPoint.xml

--- a/dynawo/sources/Models/Modelica/PreassembledModels/NodeFault.xml
+++ b/dynawo/sources/Models/Modelica/PreassembledModels/NodeFault.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+    Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+    See AUTHORS.txt
+    All rights reserved.
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, you can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+    This file is part of Dynawo, an hybrid C++/Modelica open source time domain
+    simulation tool for power systems.
+-->
+<dyn:dynamicModelsArchitecture xmlns:dyn="http://www.rte-france.com/dynawo">
+  <!-- Short circuit on a node -->
+  <dyn:modelicaModel id="NodeFault">
+    <dyn:unitDynamicModel id="fault" name="Dynawo.Electrical.Events.NodeFault"/>
+  </dyn:modelicaModel>
+</dyn:dynamicModelsArchitecture>


### PR DESCRIPTION
Add a preassembled model to do short circuit on nodes.

The non regression test associated will be pushed with newer IEEE14 test cases