### PR TITLE
#271 delay times as parameters for PhaseTapChangers

### DIFF
--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
@@ -1804,7 +1804,7 @@ ModelTwoWindingsTransformer::setSubModelParameters(const boost::unordered_map<st
       currentLimits2_->setMaxTimeOperation(maxTimeOperation);
   }
   try {
-    if (modelRatioChanger_) {
+    if (modelRatioChanger_ || modelPhaseChanger_) {
       // model tap changer parameter
       vector<string> ids;
       ids.push_back(id_);
@@ -1822,15 +1822,26 @@ ModelTwoWindingsTransformer::setSubModelParameters(const boost::unordered_map<st
       const bool bus2HV = (vNom2_ >= HV_THRESHOLD && vNom2_ < VHV_THRESHOLD);
 
       // set modelTapChanger parameters
-      if ((bus1VHV && bus2HV) || (bus2VHV && bus1HV)) {
-        modelRatioChanger_->setTFirst(t1stTHT);
-        modelRatioChanger_->setTNext(tNextTHT);
-      } else {
-        modelRatioChanger_->setTFirst(t1stHT);
-        modelRatioChanger_->setTNext(tNextHT);
+      if (modelRatioChanger_) {
+        if ((bus1VHV && bus2HV) || (bus2VHV && bus1HV)) {
+          modelRatioChanger_->setTFirst(t1stTHT);
+          modelRatioChanger_->setTNext(tNextTHT);
+        } else {
+          modelRatioChanger_->setTFirst(t1stHT);
+          modelRatioChanger_->setTNext(tNextHT);
+        }
+        if (modelBusMonitored_)
+          modelRatioChanger_->setTolV(tolV * modelBusMonitored_->getVNom());
       }
-      if (modelBusMonitored_)
-        modelRatioChanger_->setTolV(tolV * modelBusMonitored_->getVNom());
+      if (modelPhaseChanger_) {
+        if ((bus1VHV && bus2HV) || (bus2VHV && bus1HV)) {
+          modelPhaseChanger_->setTFirst(t1stTHT);
+          modelPhaseChanger_->setTNext(tNextTHT);
+        } else {
+          modelPhaseChanger_->setTFirst(t1stHT);
+          modelPhaseChanger_->setTNext(tNextHT);
+        }
+      }
     }
   } catch (const DYN::Error& e) {
     Trace::error() << e.what() << Trace::endline;


### PR DESCRIPTION
Now PhaseTapchangers delay times are deternmined after network parameters TFO_t1st_HT, TFO_t1st_THT, TFO_tNext_HT, TFO_tNext_THT, as it is for ratioTapChangers.