### PR TITLE
#402 Remove intermediary switchOff variable in Network CPP bus model …

### DIFF
--- a/dynawo/sources/Modeler/Common/DYNModel.h
+++ b/dynawo/sources/Modeler/Common/DYNModel.h
@@ -314,7 +314,7 @@ class Model {
    * @brief print informations about the model
    *
    */
-  virtual void printModele() = 0;
+  virtual void printModel() = 0;
 
   /**
    * @brief print initial values of the model

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
@@ -250,7 +250,6 @@ void
 ModelMulti::init(const double& t0) {
   Timer timer1("ModelMulti::init");
 
-  zSave_.resize(sizeZ(), 0.);
   zSave_.assign(zLocal_, zLocal_ + sizeZ());
 
   // (1) initialising each sub-model

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.h
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.h
@@ -236,9 +236,9 @@ class ModelMulti : public Model, private boost::noncopyable {
   void initBuffers();
 
   /**
-   * @copydoc Model::printModele()
+   * @copydoc Model::printModel()
    */
-  void printModele();
+  void printModel();
 
   /**
    * @copydoc Model::printInitValues(const std::string & directory)

--- a/dynawo/sources/Modeler/Common/DYNSubModel.cpp
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.cpp
@@ -946,7 +946,7 @@ SubModel::addParameterCurve(shared_ptr<curves::Curve>& curve) {
 }
 
 void
-SubModel::printModele() {
+SubModel::printModel() {
   Trace::debug("MODELER") << DYNLog(ModelName) << std::setw(25) << std::left << modelType() << "=>" << name() << Trace::endline;
   Trace::debug("MODELER") << "         Y : [" << std::setw(6) << yDeb_ << " ; " << std::setw(6) << yDeb_ + sizeY() << "[" << Trace::endline;
   Trace::debug("MODELER") << "         F : [" << std::setw(6) << fDeb_ << " ; " << std::setw(6) << fDeb_ + sizeF() << "[" << Trace::endline;

--- a/dynawo/sources/Modeler/Common/DYNSubModel.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.h
@@ -551,7 +551,7 @@ class SubModel {
    * @brief print some data for the subModel (size,index, etc...)
    *
    */
-  void printModele();
+  void printModel();
 
   /**
    * @brief load parameters from a previous save

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.h
@@ -324,7 +324,8 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
    * @brief switch on the bus
    */
   inline void switchOn() {
-    switchOff_ = false;
+    assert(z_!= NULL);
+    z_[switchOffNum_] = fromNativeBool(false);
   }  // switch on the bus
 
   /**
@@ -332,7 +333,8 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
    * @return @b true if the bus is switched off, @b false otherwise
    */
   inline bool getSwitchOff() const {
-    return switchOff_;
+    assert(z_ != NULL);
+    return toNativeBool(z_[switchOffNum_]);
   }  // get information about whether the bus is switched off
 
   /**
@@ -494,8 +496,7 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
   bool stateUmax_;  ///< whether U > UMax
   bool stateUmin_;  ///< whether U < UMin
 
-  bool switchOff_;  ///< whether the bus was switched off
-  // equivalent to switchOff but with discrete variable, to be able to switch off a node thanks to an outside event
+  // equivalent to z_[switchOffNum_] but with discrete variable, to be able to switch off a node thanks to an outside event
   State connectionState_;  ///< "internal" bus connection status, evaluated at the end of evalZ to detect if the state was modified by another component
   bool topologyModified_;  ///< true if the bus connection state was modified
   double irConnection_;  ///< real current injected

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLine.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLine.cpp
@@ -728,7 +728,7 @@ ModelLine::evalZ(const double& t) {
       Trace::error() << DYNLog(UnableToCloseLineSide2, id_) << Trace::endline;
     } else {
       topologyModified_ = true;
-      Trace::debug() << DYNLog(LineStateChange, id_, currState, getConnectionState()) << Trace::endline;
+      Trace::debug() << DYNLog(LineStateChange, id_, getConnectionState(), currState) << Trace::endline;
       switch (currState) {
       // z_[0] represents the actual state
       // getConnectionState() represents the previous state

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLoad.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLoad.cpp
@@ -702,7 +702,7 @@ NetworkComponent::StateChange_t
 ModelLoad::evalZ(const double& /*t*/) {
   State currState = static_cast<State>(z_[0]);
   if (currState != getConnected()) {
-    Trace::debug() << DYNLog(LoadStateChange, id_, z_[0], getConnected()) << Trace::endline;
+    Trace::debug() << DYNLog(LoadStateChange, id_, getConnected(), z_[0]) << Trace::endline;
     if (currState == OPEN) {
       network_->addEvent(id_, DYNTimeline(LoadDisconnected));
       modelBus_->getVoltageLevel()->disconnectNode(modelBus_->getBusIndex());

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelShuntCompensator.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelShuntCompensator.cpp
@@ -228,7 +228,7 @@ ModelShuntCompensator::evalZ(const double& t) {
   State currState = static_cast<State>(z_[connectionStateNum_]);
   if (currState != getConnected()) {
     stateModified_ = true;
-    Trace::debug() << DYNLog(ShuntStateChange, id_, currState, getConnected()) << Trace::endline;
+    Trace::debug() << DYNLog(ShuntStateChange, id_, getConnected(), currState) << Trace::endline;
     if (currState == OPEN) {
       network_->addEvent(id_, DYNTimeline(ShuntDisconnected));
       tLastOpening_ = t;

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.cpp
@@ -111,7 +111,7 @@ ModelSwitch::evalZ(const double& /*t*/) {
   State currState = static_cast<State>(z_[0]);
   if (currState != getConnectionState()) {
     topologyModified_ = true;
-    Trace::debug() << DYNLog(SwitchStateChange, id_, currState, getConnectionState()) << Trace::endline;
+    Trace::debug() << DYNLog(SwitchStateChange, id_, getConnectionState(), currState) << Trace::endline;
     if (currState == CLOSED) {
       network_->addEvent(id_, DYNTimeline(SwitchClosed));
     } else if (currState == OPEN) {

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
@@ -1246,7 +1246,7 @@ ModelTwoWindingsTransformer::evalZ(const double& t) {
       Trace::error() << DYNLog(UnableToCloseTfoSide2, id_) << Trace::endline;
     } else {
       topologyModified_ = true;
-      Trace::debug() << DYNLog(TfoStateChange, id_, currState, getConnectionState()) << Trace::endline;
+      Trace::debug() << DYNLog(TfoStateChange, id_, getConnectionState(), currState) << Trace::endline;
       switch (currState) {
       // z_[0] represents the actual state
       // getConnectionState() represents the previous state

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestBus.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestBus.cpp
@@ -88,6 +88,9 @@ TEST(ModelsModelNetwork, ModelNetworkSubNetwork) {
   std::pair<shared_ptr<ModelBus>, shared_ptr<ModelVoltageLevel> > p = createModelBus(false);
   shared_ptr<ModelBus> bus = p.first;
   sub.addBus(bus);
+  bus->initSize();
+  std::vector<double> z(bus->sizeZ(), 0.);
+  bus->setReferenceZ(&z[0], 0);
   ASSERT_EQ(sub.nbBus(), 1);
   ASSERT_EQ(bus, sub.bus(0));
 
@@ -101,6 +104,9 @@ TEST(ModelsModelNetwork, ModelNetworkSubNetwork) {
 TEST(ModelsModelNetwork, ModelNetworkBusInitialization) {
   std::pair<shared_ptr<ModelBus>, shared_ptr<ModelVoltageLevel> > p = createModelBus(false);
   shared_ptr<ModelBus> bus = p.first;
+  bus->initSize();
+  std::vector<double> z(bus->sizeZ(), 0.);
+  bus->setReferenceZ(&z[0], 0);
   ASSERT_EQ(bus->id(), "MyBus1");
   ASSERT_FALSE(bus->getSwitchOff());
   ASSERT_DOUBLE_EQUALS_DYNAWO(bus->getAngle0(), M_PI/2);
@@ -253,14 +259,11 @@ TEST(ModelsModelNetwork, ModelNetworkBusDiscreteVariables) {
   ASSERT_DOUBLE_EQUALS_DYNAWO(z[2], CLOSED);
 
   z[0] = 42;
-  z[1] = fromNativeBool(!bus->getSwitchOff());
   z[2] = OPEN;
-  ASSERT_FALSE(bus->getSwitchOff());
   ASSERT_EQ(bus->getConnectionState(), CLOSED);
   g[0] = ROOT_UP;
   g[1] = ROOT_UP;
   bus->evalZ(0.);
-  ASSERT_TRUE(bus->getSwitchOff());
   ASSERT_EQ(bus->getConnectionState(), OPEN);
   unsigned i = 0;
   for (constraints::ConstraintsCollection::const_iterator it = constraints->cbegin(),
@@ -431,8 +434,7 @@ TEST(ModelsModelNetwork, ModelNetworkBusContinuousVariablesInitModel) {
 
   // test setFequations
   std::map<int, std::string> fEquationIndex;
-  ASSERT_NO_THROW(bus->setFequations(fEquationIndex));
-  ASSERT_EQ(fEquationIndex.size(), nbF);
+  EXPECT_ASSERT_DYNAWO(bus->setFequations(fEquationIndex));  // bus->z_ is null as nbZ == 0
 }
 
 TEST(ModelsModelNetwork, ModelNetworkBusDefineInstantiate) {

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestSwitch.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestSwitch.cpp
@@ -432,6 +432,25 @@ TEST(ModelsModelNetwork, ModelNetworkSwitchDefineInstantiate) {
 TEST(ModelsModelNetwork, ModelNetworkSwitchJt) {
   shared_ptr<ModelSwitch> sw = createModelSwitch(false, false);
   sw->initSize();
+
+  shared_ptr<ModelBus> bus1 = sw->getModelBus1();
+  bus1->initSize();
+  std::vector<double> y1(bus1->sizeY(), 0.);
+  std::vector<double> yp1(bus1->sizeY(), 0.);
+  std::vector<double> f1(bus1->sizeF(), 0.);
+  std::vector<double> z1(bus1->sizeZ(), 0.);
+  bus1->setReferenceZ(&z1[0], 0);
+  bus1->setReferenceY(&y1[0], &yp1[0], &f1[0], 0, 0);
+
+  shared_ptr<ModelBus> bus2 = sw->getModelBus2();
+  bus2->initSize();
+  std::vector<double> y2(bus2->sizeY(), 0.);
+  std::vector<double> yp2(bus2->sizeY(), 0.);
+  std::vector<double> f2(bus2->sizeF(), 0.);
+  std::vector<double> z2(bus2->sizeZ(), 0.);
+  bus2->setReferenceZ(&z2[0], 0);
+  bus2->setReferenceY(&y2[0], &yp2[0], &f2[0], 0, 0);
+
   SparseMatrix smj;
   int size = sw->sizeY();
   smj.init(size, size);

--- a/dynawo/sources/Simulation/DYNSimulation.cpp
+++ b/dynawo/sources/Simulation/DYNSimulation.cpp
@@ -1152,7 +1152,7 @@ Simulation::loadState(const string & fileName) {
 
 void
 Simulation::printDebugInfo() {
-  model_->printModele();
+  model_->printModel();
   Trace::debug() << DYNLog(NbVar, model_->sizeY()) << Trace::endline;
   Trace::debug() << DYNLog(NbRootFunctions, model_->sizeG()) << Trace::endline;
 }


### PR DESCRIPTION
…and add a routine during the model initialization to propagate the potential modifications of discrete variables during the initialization (i.e. opening buses if several subnetworks exist)