### PR TITLE
WIP #968 Create hvdc model from only one interface component

### DIFF
--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.cpp
@@ -235,7 +235,7 @@ DataInterfaceIIDM::initFromIIDM() {
   //===========================
   IIDM::Contains<IIDM::HvdcLine>::iterator itHvdcLine = networkIIDM_.hvdclines().begin();
   for (; itHvdcLine != networkIIDM_.hvdclines().end(); ++itHvdcLine) {
-    shared_ptr<HvdcLineInterfaceIIDM> hvdc(new HvdcLineInterfaceIIDM(*itHvdcLine));
+    shared_ptr<HvdcLineInterface> hvdc = importHvdcLine(*itHvdcLine);
     network_->addHvdcLine(hvdc);
     components_[hvdc->getID()] = hvdc;
   }
@@ -873,6 +873,20 @@ DataInterfaceIIDM::importLccConverter(IIDM::LccConverterStation& lccIIDM) {
   return lcc;
 #endif
 }
+
+shared_ptr<HvdcLineInterface>
+DataInterfaceIIDM::importHvdcLine(IIDM::HvdcLine& hvdcLineIIDM) {
+  shared_ptr<ConverterInterface> conv1 = dynamic_pointer_cast<ConverterInterface>(findComponent(hvdcLineIIDM.converterStation1()));
+  shared_ptr<ConverterInterface> conv2 = dynamic_pointer_cast<ConverterInterface>(findComponent(hvdcLineIIDM.converterStation2()));
+
+  shared_ptr<HvdcLineInterfaceIIDM> hvdcLine(new HvdcLineInterfaceIIDM(hvdcLineIIDM, conv1, conv2));
+#ifdef LANG_CXX11
+  return std::move(hvdcLine);
+#else
+  return hvdcLine;
+#endif
+}
+
 
 shared_ptr<NetworkInterface>
 DataInterfaceIIDM::getNetwork() const {

--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.h
@@ -63,6 +63,7 @@ class DanglingLineInterface;
 class TwoWTransformerInterface;
 class ThreeWTransformerInterface;
 class LineInterface;
+class HvdcLineInterface;
 
 class DataInterfaceIIDM : public DataInterface {
  public:
@@ -310,6 +311,14 @@ class DataInterfaceIIDM : public DataInterface {
    * @return the instance of lccConverterInterface created
    */
   boost::shared_ptr<LccConverterInterface> importLccConverter(IIDM::LccConverterStation& lccIIDM);
+
+   /**
+   * @brief import and create a hvdc line interface thanks to the IIDM instance
+   *
+   * @param hvdcLineIIDM IIDM instance to use to create hvdc line Interface
+   * @return the instance of HvdcLineInterface created
+   */
+  boost::shared_ptr<HvdcLineInterface> importHvdcLine(IIDM::HvdcLine& hvdcLineIIDM);
 
   /**
    * @brief configure the bus criteria

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterface.h
@@ -28,6 +28,7 @@ namespace DYN {
 class BusInterface;
 class CurrentLimitInterface;
 class VoltageLevelInterface;
+class ConverterInterface;
 
 /**
  * class HvdcLineInterface
@@ -104,6 +105,18 @@ class HvdcLineInterface : public ComponentInterface {
    * @return The converter 2 id
    */
   virtual std::string getIdConverter2() const = 0;
+
+  /**
+   * @brief Getter for converter 1
+   * @return converter 1
+   */
+  virtual boost::shared_ptr<ConverterInterface> getConverter1() const = 0;
+
+  /**
+   * @brief Getter for converter 2
+   * @return converter 2
+   */
+  virtual boost::shared_ptr<ConverterInterface> getConverter2() const = 0;
 };
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterface.h
@@ -110,13 +110,13 @@ class HvdcLineInterface : public ComponentInterface {
    * @brief Getter for converter 1
    * @return converter 1
    */
-  virtual boost::shared_ptr<ConverterInterface> getConverter1() const = 0;
+  virtual const boost::shared_ptr<ConverterInterface>& getConverter1() const = 0;
 
   /**
    * @brief Getter for converter 2
    * @return converter 2
    */
-  virtual boost::shared_ptr<ConverterInterface> getConverter2() const = 0;
+  virtual const boost::shared_ptr<ConverterInterface>& getConverter2() const = 0;
 };
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.cpp
@@ -31,7 +31,9 @@ using std::vector;
 
 namespace DYN {
 
-HvdcLineInterfaceIIDM::HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine, shared_ptr<ConverterInterface>& conv1, shared_ptr<ConverterInterface>& conv2) :
+HvdcLineInterfaceIIDM::HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine,
+                                             const shared_ptr<ConverterInterface>& conv1,
+                                             const shared_ptr<ConverterInterface>& conv2) :
 hvdcLineIIDM_(hvdcLine),
 conv1_(conv1),
 conv2_(conv2) {
@@ -124,12 +126,12 @@ HvdcLineInterfaceIIDM::getComponentVarIndex(const std::string& varName) const {
   return index;
 }
 
-shared_ptr<ConverterInterface>
+const shared_ptr<ConverterInterface>&
 HvdcLineInterfaceIIDM::getConverter1() const {
   return conv1_;
 }
 
-shared_ptr<ConverterInterface>
+const shared_ptr<ConverterInterface>&
 HvdcLineInterfaceIIDM::getConverter2() const {
   return conv2_;
 }

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.cpp
@@ -31,9 +31,18 @@ using std::vector;
 
 namespace DYN {
 
-HvdcLineInterfaceIIDM::HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine) :
-hvdcLineIIDM_(hvdcLine) {
+HvdcLineInterfaceIIDM::HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine, shared_ptr<ConverterInterface>& conv1, shared_ptr<ConverterInterface>& conv2) :
+hvdcLineIIDM_(hvdcLine),
+conv1_(conv1),
+conv2_(conv2) {
   setType(ComponentInterface::HVDC_LINE);
+  stateVariables_.resize(6);
+  stateVariables_[VAR_P1] = StateVariable("p1", StateVariable::DOUBLE);  // P1
+  stateVariables_[VAR_P2] = StateVariable("p2", StateVariable::DOUBLE);  // P2
+  stateVariables_[VAR_Q1] = StateVariable("q1", StateVariable::DOUBLE);  // Q1
+  stateVariables_[VAR_Q2] = StateVariable("q2", StateVariable::DOUBLE);  // Q2
+  stateVariables_[VAR_STATE1] = StateVariable("state1", StateVariable::INT);   // connectionState1
+  stateVariables_[VAR_STATE2] = StateVariable("state2", StateVariable::INT);   // connectionState2
 }
 
 HvdcLineInterfaceIIDM::~HvdcLineInterfaceIIDM() {
@@ -41,12 +50,12 @@ HvdcLineInterfaceIIDM::~HvdcLineInterfaceIIDM() {
 
 void
 HvdcLineInterfaceIIDM::exportStateVariablesUnitComponent() {
-  // no state variable
+  // to do
 }
 
 void
 HvdcLineInterfaceIIDM::importStaticParameters() {
-  // no static parameter
+  // to do
 }
 
 string
@@ -98,8 +107,31 @@ HvdcLineInterfaceIIDM::getIdConverter2() const {
 }
 
 int
-HvdcLineInterfaceIIDM::getComponentVarIndex(const std::string& /*varName*/) const {
-  return -1;
+HvdcLineInterfaceIIDM::getComponentVarIndex(const std::string& varName) const {
+  int index = -1;
+  if ( varName == "p1" )
+    index = VAR_P1;
+  else if ( varName == "q1" )
+    index = VAR_Q1;
+  else if ( varName == "p2" )
+    index = VAR_P2;
+  else if ( varName == "q2" )
+    index = VAR_Q2;
+  else if ( varName == "state1" )
+    index = VAR_STATE1;
+  else if ( varName == "state2" )
+    index = VAR_STATE2;
+  return index;
+}
+
+shared_ptr<ConverterInterface>
+HvdcLineInterfaceIIDM::getConverter1() const {
+  return conv1_;
+}
+
+shared_ptr<ConverterInterface>
+HvdcLineInterfaceIIDM::getConverter2() const {
+  return conv2_;
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.cpp
@@ -26,6 +26,7 @@
 #include "DYNModelConstants.h"
 
 using boost::shared_ptr;
+using boost::dynamic_pointer_cast;
 using std::string;
 using std::vector;
 
@@ -52,7 +53,22 @@ HvdcLineInterfaceIIDM::~HvdcLineInterfaceIIDM() {
 
 void
 HvdcLineInterfaceIIDM::exportStateVariablesUnitComponent() {
-  // to do
+  switch (conv1_->getType()) {
+    case ComponentInterface::VSC_CONVERTER:
+      {
+      const shared_ptr<VscConverterInterface>& vsc1 = dynamic_pointer_cast<VscConverterInterface>(conv1_);
+      const shared_ptr<VscConverterInterface>& vsc2 = dynamic_pointer_cast<VscConverterInterface>(conv2_);
+      // to do
+      break;
+      }
+    case ComponentInterface::LCC_CONVERTER:
+      {
+      const shared_ptr<LccConverterInterface>& lcc1 = dynamic_pointer_cast<LccConverterInterface>(conv1_);
+      const shared_ptr<LccConverterInterface>& lcc2 = dynamic_pointer_cast<LccConverterInterface>(conv2_);
+      // to do
+      break;
+      }
+  }
 }
 
 void

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.h
@@ -56,7 +56,9 @@ class HvdcLineInterfaceIIDM : public HvdcLineInterface {
    * @param conv1: converter 1 data interface instance
    * @param conv2: converter 2 data interface instance
    */
-  explicit HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine, boost::shared_ptr<ConverterInterface>& conv1, boost::shared_ptr<ConverterInterface>& conv2);
+  explicit HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine,
+                                 const boost::shared_ptr<ConverterInterface>& conv1,
+                                 const boost::shared_ptr<ConverterInterface>& conv2);
 
   /**
    * @copydoc ComponentInterface::exportStateVariablesUnitComponent()
@@ -116,12 +118,12 @@ class HvdcLineInterfaceIIDM : public HvdcLineInterface {
   /**
    * @copydoc HvdcLineInterface::getConverter1() const
    */
-  boost::shared_ptr<ConverterInterface> getConverter1() const;
+  const boost::shared_ptr<ConverterInterface>& getConverter1() const;
 
   /**
    * @copydoc HvdcLineInterface::getConverter2() const
    */
-  boost::shared_ptr<ConverterInterface> getConverter2() const;
+  const boost::shared_ptr<ConverterInterface>& getConverter2() const;
 
  private:
   IIDM::HvdcLine& hvdcLineIIDM_;  ///< reference to the iidm line instance

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterfaceIIDM.h
@@ -33,6 +33,19 @@ namespace DYN {
 class HvdcLineInterfaceIIDM : public HvdcLineInterface {
  public:
   /**
+   * @brief defines the index of each state variable
+   */
+  typedef enum {
+    VAR_P1 = 0,
+    VAR_P2,
+    VAR_Q1,
+    VAR_Q2,
+    VAR_STATE1,
+    VAR_STATE2
+  } indexVar_t;
+
+ public:
+  /**
    * @brief Destructor
    */
   ~HvdcLineInterfaceIIDM();
@@ -40,8 +53,10 @@ class HvdcLineInterfaceIIDM : public HvdcLineInterface {
   /**
    * @brief Constructor
    * @param hvdcLine: hvdc line iidm instance
+   * @param conv1: converter 1 data interface instance
+   * @param conv2: converter 2 data interface instance
    */
-  explicit HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine);
+  explicit HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine, boost::shared_ptr<ConverterInterface>& conv1, boost::shared_ptr<ConverterInterface>& conv2);
 
   /**
    * @copydoc ComponentInterface::exportStateVariablesUnitComponent()
@@ -98,8 +113,20 @@ class HvdcLineInterfaceIIDM : public HvdcLineInterface {
    */
   int getComponentVarIndex(const std::string& varName) const;
 
+  /**
+   * @copydoc HvdcLineInterface::getConverter1() const
+   */
+  boost::shared_ptr<ConverterInterface> getConverter1() const;
+
+  /**
+   * @copydoc HvdcLineInterface::getConverter2() const
+   */
+  boost::shared_ptr<ConverterInterface> getConverter2() const;
+
  private:
   IIDM::HvdcLine& hvdcLineIIDM_;  ///< reference to the iidm line instance
+  boost::shared_ptr<ConverterInterface> conv1_;  /// conv1
+  boost::shared_ptr<ConverterInterface> conv2_;  /// conv2
 };  ///< Interface class for Hvdc Line model
 
 }  // namespace DYN

--- a/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.cpp
@@ -159,7 +159,7 @@ LccConverterInterfaceIIDM::getPowerFactor() const {
   return lccConverterIIDM_.powerFactor();
 }
 
-IIDM::LccConverterStation&
+const IIDM::LccConverterStation&
 LccConverterInterfaceIIDM::getLccIIDM() const {
   return lccConverterIIDM_;
 }

--- a/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.cpp
@@ -159,4 +159,9 @@ LccConverterInterfaceIIDM::getPowerFactor() const {
   return lccConverterIIDM_.powerFactor();
 }
 
+IIDM::LccConverterStation&
+LccConverterInterfaceIIDM::getLccIIDM() const {
+  return lccConverterIIDM_;
+}
+
 }  // namespace DYN

--- a/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.h
@@ -138,7 +138,7 @@ class LccConverterInterfaceIIDM : public LccConverterInterface, public InjectorI
    * @brief Getter for the reference to the iidm lcc converter istance
    * @return the iidm lcc converter istance
    */
-  IIDM::LccConverterStation& getLccIIDM() const;
+  const IIDM::LccConverterStation& getLccIIDM() const;
 
  private:
   IIDM::LccConverterStation& lccConverterIIDM_;  ///< reference to the iidm lcc converter instance

--- a/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterfaceIIDM.h
@@ -134,6 +134,12 @@ class LccConverterInterfaceIIDM : public LccConverterInterface, public InjectorI
    */
   int getComponentVarIndex(const std::string& varName) const;
 
+  /**
+   * @brief Getter for the reference to the iidm lcc converter istance
+   * @return the iidm lcc converter istance
+   */
+  IIDM::LccConverterStation& getLccIIDM() const;
+
  private:
   IIDM::LccConverterStation& lccConverterIIDM_;  ///< reference to the iidm lcc converter instance
 };

--- a/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.cpp
@@ -182,4 +182,9 @@ VscConverterInterfaceIIDM::getVoltageSetpoint() const {
   return vscConverterIIDM_.voltageSetpoint();
 }
 
+IIDM::VscConverterStation&
+VscConverterInterfaceIIDM::getVscIIDM() const {
+  return vscConverterIIDM_;
+}
+
 }  // namespace DYN

--- a/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.cpp
@@ -182,7 +182,7 @@ VscConverterInterfaceIIDM::getVoltageSetpoint() const {
   return vscConverterIIDM_.voltageSetpoint();
 }
 
-IIDM::VscConverterStation&
+const IIDM::VscConverterStation&
 VscConverterInterfaceIIDM::getVscIIDM() const {
   return vscConverterIIDM_;
 }

--- a/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.h
@@ -144,6 +144,12 @@ class VscConverterInterfaceIIDM : public VscConverterInterface, public InjectorI
    */
   int getComponentVarIndex(const std::string& varName) const;
 
+  /**
+   * @brief Getter for the reference to the iidm vsc converter istance
+   * @return the iidm vsc converter istance
+   */
+  IIDM::VscConverterStation& getVscIIDM() const;
+
  private:
   IIDM::VscConverterStation& vscConverterIIDM_;  ///< reference to the iidm vsc converter instance
 };

--- a/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterfaceIIDM.h
@@ -148,7 +148,7 @@ class VscConverterInterfaceIIDM : public VscConverterInterface, public InjectorI
    * @brief Getter for the reference to the iidm vsc converter istance
    * @return the iidm vsc converter istance
    */
-  IIDM::VscConverterStation& getVscIIDM() const;
+  const IIDM::VscConverterStation& getVscIIDM() const;
 
  private:
   IIDM::VscConverterStation& vscConverterIIDM_;  ///< reference to the iidm vsc converter instance

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelHvdcLink.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelHvdcLink.cpp
@@ -40,6 +40,7 @@
 #include "DYNModelVoltageLevel.h"
 
 using boost::shared_ptr;
+using boost::dynamic_pointer_cast;
 using std::vector;
 using std::map;
 using std::string;
@@ -47,28 +48,26 @@ using std::abs;
 
 namespace DYN {
 
-ModelHvdcLink::ModelHvdcLink(const shared_ptr<VscConverterInterface>& vsc1, const shared_ptr<VscConverterInterface>& vsc2,
-                             const shared_ptr<HvdcLineInterface>& dcLine) :
+ModelHvdcLink::ModelHvdcLink(const shared_ptr<HvdcLineInterface>& dcLine) :
 Impl(dcLine->getID()),
 stateModified_(false) {
   // retrieve data from VscConverterInterface and HvdcLineInterface (IIDM)
-  setAttributes(vsc1, vsc2, dcLine);
+  setAttributes(dcLine);
 
   // calculate active power at the two points of common coupling
-  setConvertersActivePower(vsc1, vsc2);
+  setConvertersActivePower(dcLine);
 
   // calculate reactive power at the two points of common coupling
-  setConvertersReactivePowerVsc(vsc1, vsc2);
-
+  setConvertersReactivePower(dcLine);
 
   ir01_ = 0;
   ii01_ = 0;
-  if (vsc1->getBusInterface()) {
-    double P01 = vsc1->getP() / SNREF;
-    double Q01 = vsc1->getQ() / SNREF;
-    double uNode1 = vsc1->getBusInterface()->getV0();
-    double tetaNode1 = vsc1->getBusInterface()->getAngle0();
-    double unomNode1 = vsc1->getBusInterface()->getVNom();
+  if (dcLine->getConverter1()->getBusInterface()) {
+    double P01 = dcLine->getConverter1()->getP() / SNREF;
+    double Q01 = dcLine->getConverter1()->getQ() / SNREF;
+    double uNode1 = dcLine->getConverter1()->getBusInterface()->getV0();
+    double tetaNode1 = dcLine->getConverter1()->getBusInterface()->getAngle0();
+    double unomNode1 = dcLine->getConverter1()->getBusInterface()->getVNom();
     double ur01 = uNode1 / unomNode1 * cos(tetaNode1 * DEG_TO_RAD);
     double ui01 = uNode1 / unomNode1 * sin(tetaNode1 * DEG_TO_RAD);
     double U201 = ur01 * ur01 + ui01 * ui01;
@@ -80,12 +79,12 @@ stateModified_(false) {
 
   ir02_ = 0;
   ii02_ = 0;
-  if (vsc2->getBusInterface()) {
-    double P02 = vsc2->getP() / SNREF;
-    double Q02 = vsc2->getQ() / SNREF;
-    double uNode2 = vsc2->getBusInterface()->getV0();
-    double tetaNode2 = vsc2->getBusInterface()->getAngle0();
-    double unomNode2 = vsc2->getBusInterface()->getVNom();
+  if (dcLine->getConverter2()->getBusInterface()) {
+    double P02 = dcLine->getConverter2()->getP() / SNREF;
+    double Q02 = dcLine->getConverter2()->getQ() / SNREF;
+    double uNode2 = dcLine->getConverter2()->getBusInterface()->getV0();
+    double tetaNode2 = dcLine->getConverter2()->getBusInterface()->getAngle0();
+    double unomNode2 = dcLine->getConverter2()->getBusInterface()->getVNom();
     double ur02 = uNode2 / unomNode2 * cos(tetaNode2 * DEG_TO_RAD);
     double ui02 = uNode2 / unomNode2 * sin(tetaNode2 * DEG_TO_RAD);
     double U202 = ur02 * ur02 + ui02 * ui02;
@@ -94,35 +93,6 @@ stateModified_(false) {
       ii02_ = (P02 * ui02 - Q02 * ur02) / U202;
     }
   }
-}
-
-ModelHvdcLink::ModelHvdcLink(const shared_ptr<LccConverterInterface>& lcc1, const shared_ptr<LccConverterInterface>& lcc2,
-                             const shared_ptr<HvdcLineInterface>& dcLine) :
-Impl(dcLine->getID()) {
-  // retrieve data from LccConverterInterface and HvdcLineInterface (IIDM)
-  setAttributes(lcc1, lcc2, dcLine);
-
-  // calculate active power at the two points of common coupling
-  setConvertersActivePower(lcc1, lcc2);
-
-  // calculate reactive power at the two points of common coupling
-  setConvertersReactivePowerLcc(lcc1, lcc2);
-
-  double uNode1 = lcc1->getBusInterface()->getV0();
-  double tetaNode1 = lcc1->getBusInterface()->getAngle0();
-  double unomNode1 = lcc1->getBusInterface()->getVNom();
-  double ur01 = uNode1 / unomNode1 * cos(tetaNode1 * DEG_TO_RAD);
-  double ui01 = uNode1 / unomNode1 * sin(tetaNode1 * DEG_TO_RAD);
-  ir01_ = (P01_ * ur01 + Q01_ * ui01) / (ur01 * ur01 + ui01 * ui01);
-  ii01_ = (P01_ * ui01 - Q01_ * ur01) / (ur01 * ur01 + ui01 * ui01);
-
-  double uNode2 = lcc2->getBusInterface()->getV0();
-  double tetaNode2 = lcc2->getBusInterface()->getAngle0();
-  double unomNode2 = lcc2->getBusInterface()->getVNom();
-  double ur02 = uNode2 / unomNode2 * cos(tetaNode2 * DEG_TO_RAD);
-  double ui02 = uNode2 / unomNode2 * sin(tetaNode2 * DEG_TO_RAD);
-  ir02_ = (P02_ * ur02 + Q02_ * ui02) / (ur02 * ur02 + ui02 * ui02);
-  ii02_ = (P02_ * ui02 - Q02_ * ur02) / (ur02 * ur02 + ui02 * ui02);
 }
 
 void
@@ -532,32 +502,72 @@ ModelHvdcLink::addBusNeighbors() {
 }
 
 void
-ModelHvdcLink::setConvertersReactivePowerVsc(const shared_ptr<VscConverterInterface>& vsc1, const shared_ptr<VscConverterInterface>& vsc2) {
-  if (vsc1->hasQ() && vsc2->hasQ()) {
-    // retrieve reactive power at the two points of common coupling from load flow data in IIDM file
-    Q01_ = -vsc1->getQ() / SNREF;
-    Q02_ = -vsc2->getQ() / SNREF;
+ModelHvdcLink::setAttributes(const shared_ptr<HvdcLineInterface>& dcLine) {
+  // retrieve data from ConverterInterface  (IIDM)
+  lossFactor1_ = dcLine->getConverter1()->getLossFactor() / 100.;
+  lossFactor2_ = dcLine->getConverter2()->getLossFactor() / 100.;
+  connectionState1_ = dcLine->getConverter1()->getInitialConnected() ? CLOSED : OPEN;
+  connectionState2_ = dcLine->getConverter2()->getInitialConnected() ? CLOSED : OPEN;
+
+  // retrieve data from HvdcLineInterface (IIDM)
+  vdcNom_ = dcLine->getVNom();
+  pSetPoint_ = dcLine->getActivePowerSetpoint();
+  converterMode_ = dcLine->getConverterMode();
+  rdc_ = dcLine->getResistanceDC();
+}
+
+void
+ModelHvdcLink::setConvertersActivePower(const shared_ptr<HvdcLineInterface>& dcLine) {
+  if (dcLine->getConverter1()->hasP() && dcLine->getConverter2()->hasP()) {
+    // retrieve active power at the two points of common coupling from load flow data in IIDM file
+    P01_ = -dcLine->getConverter1()->getP() / SNREF;
+    P02_ = -dcLine->getConverter2()->getP() / SNREF;
   } else {
-    // calculate reactive power at the two points of common coupling from set points
-    double qSetPoint1 = vsc1->getReactivePowerSetpoint();  // in Mvar (generator convention)
-    double qSetPoint2 = vsc2->getReactivePowerSetpoint();  // in Mvar (generator convention)
-    Q01_ = qSetPoint1 / SNREF;
-    Q02_ = qSetPoint2 / SNREF;
+    // calculate losses on dc line
+    double PdcLoss = rdc_ * (pSetPoint_ / vdcNom_) * (pSetPoint_ / vdcNom_) / SNREF;  // in pu
+
+    // calculate active power at the two points of common coupling (generator convention)
+    double P0dc = pSetPoint_ / SNREF;  // in pu
+    if (converterMode_ == HvdcLineInterface::RECTIFIER_INVERTER) {
+      P01_ = -P0dc;  // RECTIFIER (absorbs power from the grid)
+      P02_ = ((P0dc * (1 - lossFactor1_)) - PdcLoss) * (1. - lossFactor2_);  // INVERTER (injects power to the grid)
+    } else {   // converterMode_ == HvdcLineInterface::INVERTER_RECTIFIER
+      P01_ = ((P0dc * (1 - lossFactor2_)) - PdcLoss) * (1. - lossFactor1_);  // INVERTER (injects power to the grid)
+      P02_ = -P0dc;  // RECTIFIER (absorbs power from the grid)
+    }
   }
 }
 
 void
-ModelHvdcLink::setConvertersReactivePowerLcc(const shared_ptr<LccConverterInterface>& lcc1, const shared_ptr<LccConverterInterface>& lcc2) {
-  if (lcc1->hasQ() && lcc2->hasQ()) {
+ModelHvdcLink::setConvertersReactivePower(const shared_ptr<HvdcLineInterface>& dcLine) {
+  if (dcLine->getConverter1()->hasQ() && dcLine->getConverter2()->hasQ()) {
     // retrieve reactive power at the two points of common coupling from load flow data in IIDM file
-    Q01_ = -lcc1->getQ() / SNREF;
-    Q02_ = -lcc2->getQ() / SNREF;
+    Q01_ = -dcLine->getConverter1()->getQ() / SNREF;
+    Q02_ = -dcLine->getConverter2()->getQ() / SNREF;
   } else {
-    // calculate reactive power at the two points of common coupling
-    double powerFactor1 = lcc1->getPowerFactor();
-    double powerFactor2 = lcc2->getPowerFactor();
-    Q01_ = -abs(powerFactor1 * P01_);
-    Q02_ = -abs(powerFactor2 * P02_);
+    // calculate reactive power at the two points of common coupling from set points
+    switch (dcLine->getConverter1()->getType()) {
+      case ComponentInterface::VSC_CONVERTER:
+        {
+        shared_ptr<VscConverterInterface> vsc1 = dynamic_pointer_cast<VscConverterInterface>(dcLine->getConverter1());
+        shared_ptr<VscConverterInterface> vsc2 = dynamic_pointer_cast<VscConverterInterface>(dcLine->getConverter2());
+        double qSetPoint1 = vsc1->getReactivePowerSetpoint();  // in Mvar (generator convention)
+        double qSetPoint2 = vsc2->getReactivePowerSetpoint();  // in Mvar (generator convention)
+        Q01_ = qSetPoint1 / SNREF;
+        Q02_ = qSetPoint2 / SNREF;
+        break;
+        }
+      case ComponentInterface::LCC_CONVERTER:
+        {
+        shared_ptr<LccConverterInterface> lcc1 = dynamic_pointer_cast<LccConverterInterface>(dcLine->getConverter1());
+        shared_ptr<LccConverterInterface> lcc2 = dynamic_pointer_cast<LccConverterInterface>(dcLine->getConverter2());
+        double powerFactor1 = lcc1->getPowerFactor();
+        double powerFactor2 = lcc2->getPowerFactor();
+        Q01_ = -abs(powerFactor1 * P01_);
+        Q02_ = -abs(powerFactor2 * P02_);
+        break;
+        }
+    }
   }
 }
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.cpp
@@ -590,8 +590,8 @@ ModelNetwork::initializeFromData(const shared_ptr<DataInterface>& data) {
     string idVsc2 = (*iHvdc)->getIdConverter2();
 
     // retrieve the two converters associated with the current hvdc line
-    shared_ptr<ConverterInterface> conv1 = (*iHvdc)->getConverter1();
-    shared_ptr<ConverterInterface> conv2 = (*iHvdc)->getConverter2();
+    const shared_ptr<ConverterInterface>& conv1 = (*iHvdc)->getConverter1();
+    const shared_ptr<ConverterInterface>& conv2 = (*iHvdc)->getConverter2();
 
     // add the hvdc line and convertesr in the component list
     componentsById[ id ] = (*iHvdc);


### PR DESCRIPTION
Note: this development is not complete: do not merge ;)

With this development, HVDC model is created from only one dataInterface instance that knows the IIDM dcline instance and the dataInterface converter instances. No more distinction should be made between lcc and vsc appart from the reactive power in method setConvertersReactivePower. I tested it on a test case and it works fine. Could you give your opinion on this part?

The thing that is not dealt with yet is the import/export from variables. I am a bit blocked here. See more comments and questions in the code bellow.