### PR TITLE
#1000 Dealing with bad topology structure

### DIFF
--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.cpp
@@ -260,10 +260,12 @@ DataInterfaceIIDM::importVoltageLevel(IIDM::VoltageLevel& voltageLevelIIDM) {
     for (; itSwitch != voltageLevelIIDM.switches().end(); ++itSwitch) {
       bool open = itSwitch->opened();
       bool retained = itSwitch->retained();
-      if (open || retained) {  // if switch should be retained or is opened, create model of switch
+      if (open || retained) {  // if the switch is close or not retained, don't create a specific switch model
         shared_ptr<SwitchInterface> sw = importSwitch(*itSwitch);
-        components_[sw->getID()] = sw;
-        voltageLevel->addSwitch(sw);
+        if (sw->getBusInterface1() != sw->getBusInterface2()) {  // if the switch is connecting one single bus, don't create a specific switch model
+          components_[sw->getID()] = sw;
+          voltageLevel->addSwitch(sw);
+        }
       }
     }
   } else {
@@ -283,7 +285,7 @@ DataInterfaceIIDM::importVoltageLevel(IIDM::VoltageLevel& voltageLevelIIDM) {
     //===========================
     IIDM::Contains<IIDM::Switch>::iterator itSwitch = voltageLevelIIDM.switches().begin();
     for (; itSwitch != voltageLevelIIDM.switches().end(); ++itSwitch) {
-      shared_ptr<SwitchInterface> sw = importSwitch(*itSwitch);  // in bus breaker topology, keep all switchs
+      shared_ptr<SwitchInterface> sw = importSwitch(*itSwitch);  // in bus breaker topology, keep all switches
       components_[sw->getID()] = sw;
       voltageLevel->addSwitch(sw);
     }

--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterfaceIIDM.cpp
@@ -260,7 +260,7 @@ DataInterfaceIIDM::importVoltageLevel(IIDM::VoltageLevel& voltageLevelIIDM) {
     for (; itSwitch != voltageLevelIIDM.switches().end(); ++itSwitch) {
       bool open = itSwitch->opened();
       bool retained = itSwitch->retained();
-      if (open || retained) {  // if the switch is close or not retained, don't create a specific switch model
+      if (open || retained) {  // if the switch is not open (=closed) or not retained, don't create a specific switch model
         shared_ptr<SwitchInterface> sw = importSwitch(*itSwitch);
         if (sw->getBusInterface1() != sw->getBusInterface2()) {  // if the switch is connecting one single bus, don't create a specific switch model
           components_[sw->getID()] = sw;


### PR DESCRIPTION
There were plenty of ways to implement the test, such as first searching in a new and separate method the interfaces and test before creating the interface object that they are identical.

Finally I have chosen to do a very simple modification using the existing methods because it is the less invasive approach (at this stage, I only do it for node breaker topology) and the simplest to understand. I think there is no impact on performance and no gain to expect from another implementation.