### PR TITLE
#1063 Library improvements for Modelica use

### DIFF
--- a/dynawo/sources/Models/Modelica/Dynawo/Connectors/ACPower.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Connectors/ACPower.mo
@@ -16,5 +16,5 @@ connector ACPower "Connector for AC power (described using complex V and i varia
   public
     Types.Voltage V "Complex AC voltage";
     flow Types.Current i "Complex AC current (positive when entering the device)";
-  annotation(preferredView = "text", Icon(graphics = {Rectangle(extent = {{-100, 98}, {100, -102}}, lineColor = {0, 0, 255}, fillColor = {0, 0, 255}, fillPattern = FillPattern.Solid)}));
+  annotation(preferredView = "text", Icon(graphics = {Rectangle(lineColor = {0, 0, 255}, fillColor = {85, 170, 255}, fillPattern = FillPattern.Solid, extent = {{-100, 98}, {100, -102}})}, coordinateSystem(initialScale = 0.1)));
 end ACPower;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/BaseClasses.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/BaseClasses.mo
@@ -45,6 +45,7 @@ package BaseClasses
   partial model BaseGeneratorSimplifiedPFBehavior "Base model for generator active power / frequency modulation"
     import Dynawo.NonElectrical.Logs.Timeline;
     import Dynawo.NonElectrical.Logs.TimelineKeys;
+    extends BaseGeneratorSimplified;
     type PStatus = enumeration(Standard "Active power is modulated by the frequency deviation", LimitPMin "Active power is fixed to its minimum value", LimitPMax "Active power is fixed to its maximum value");
     Connectors.ImPin omegaRefPu "Network angular reference frequency in p.u (base OmegaNom)";
     parameter Types.ActivePower PMin "Minimum active power in MW";

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/GeneratorPQ.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/GeneratorPQ.mo
@@ -21,7 +21,6 @@ model GeneratorPQ "Generator with power / frequency modulation and fixed reactiv
   import Dynawo.NonElectrical.Logs.Timeline;
   import Dynawo.NonElectrical.Logs.TimelineKeys;
 
-  extends BaseClasses.BaseGeneratorSimplified;
   extends BaseClasses.BaseGeneratorSimplifiedPFBehavior;
   extends AdditionalIcons.Machine;
 

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/GeneratorPV.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/GeneratorPV.mo
@@ -22,7 +22,6 @@ model GeneratorPV "Generator with power / frequency modulation and voltage / rea
   import Dynawo.NonElectrical.Logs.Timeline;
   import Dynawo.NonElectrical.Logs.TimelineKeys;
 
-  extends BaseClasses.BaseGeneratorSimplified;
   extends BaseClasses.BaseGeneratorSimplifiedPFBehavior;
   extends AdditionalIcons.Machine;
 

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/BaseClasses.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/BaseClasses.mo
@@ -47,11 +47,11 @@ package BaseClasses
 
   equation
 
-    when QGenPu <= QMinPu and (pre(QGenPu) <> QMinPu or UPu > URefPu.value) then
+    when QGenPu <= QMinPu and (pre(qStatus) <> QStatus.AbsorptionMax or UPu > URefPu.value) then
       qStatus = QStatus.AbsorptionMax;
-    elsewhen QGenPu >= QMaxPu and (pre(QGenPu) <> QMaxPu or UPu < URefPu.value) then
+    elsewhen QGenPu >= QMaxPu and (pre(qStatus) <> QStatus.GenerationMax or UPu < URefPu.value) then
       qStatus = QStatus.GenerationMax;
-    elsewhen (QGenPu > QMinPu or (pre(QGenPu) == QMinPu and UPu <= URefPu.value)) and (QGenPu < QMaxPu or (pre(QGenPu) == QMaxPu and UPu >= URefPu.value)) then
+    elsewhen (QGenPu > QMinPu or (pre(qStatus) == QStatus.AbsorptionMax and UPu <= URefPu.value)) and (QGenPu < QMaxPu or (pre(qStatus) == QStatus.GenerationMax and UPu >= URefPu.value)) then
       qStatus = QStatus.Standard;
     end when;
 

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPV.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPV.mo
@@ -15,6 +15,7 @@ within Dynawo.Electrical.Machines.SignalN;
 model GeneratorPV "Model for generator PV based on SignalN for the frequency handling"
 
   extends BaseClasses.BaseGeneratorSignalN;
+  extends AdditionalIcons.Machine;
 
   equation
 

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVProp.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVProp.mo
@@ -15,6 +15,7 @@ within Dynawo.Electrical.Machines.SignalN;
 model GeneratorPVProp "Model for generator PV based on SignalN for the frequency handling and with a proportional voltage regulation"
 
   extends BaseClasses.BaseGeneratorSignalN;
+  extends AdditionalIcons.Machine;
 
   parameter Types.PerUnit KVoltage "Parameter of the proportional voltage regulation";
 

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/BaseClasses.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/BaseClasses.mo
@@ -18,9 +18,9 @@ package BaseClasses
 record TransformerParameters "Classical transformer parameters"
 
   parameter Types.PerUnit RPu "Resistance of the generator transformer in p.u (base U2Nom, SnRef)";
-  parameter Types.PerUnit BPu "Susceptance of the generator transformer in p.u (base U2Nom, SnRef)";
   parameter Types.PerUnit XPu "Reactance of the generator transformer in p.u (base U2Nom, SnRef)";
   parameter Types.PerUnit GPu "Conductance of the generator transformer in p.u (base U2Nom, SnRef)";
+  parameter Types.PerUnit BPu "Susceptance of the generator transformer in p.u (base U2Nom, SnRef)";
 
   final parameter Types.ComplexImpedancePu ZPu = Complex(RPu, XPu) "Impedance in p.u (base U2Nom, SnRef)";
   final parameter Types.ComplexAdmittancePu YPu = Complex(GPu, BPu) "Admittance in p.u (base U2Nom, SnRef)";


### PR DESCRIPTION
* Cosmetic improvements:

Modify the background color for terminal.
Add missing icons
Modifications on the order of parameters in Base Transformers to have the same one as in Line

* Functional improvements:

Correction of an issue in Machines BaseClasses: the variables and parameters used in a partial model should be declared into this partial model and not another (except if the second one extends the first one)
Correction on the use of pre in Machines Signal N BaseClasses: pre() can only be applied on discrete values


