### PR TITLE
1084 parameters

### DIFF
--- a/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.cpp
+++ b/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.cpp
@@ -298,6 +298,9 @@ ModelVariationArea::setSubModelParameters() {
   nbLoads_ = findParameterDynamic("nbLoads").getValue<int>();
   startTime_ = findParameterDynamic("startTime").getValue<double>();
   stopTime_ = findParameterDynamic("stopTime").getValue<double>();
+
+  deltaP_.clear();
+  deltaQ_.clear();
   for (int k = 0; k < nbLoads_; ++k) {
     std::stringstream deltaPName;
     deltaPName << "deltaP_load_" << k;

--- a/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.cpp
+++ b/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.cpp
@@ -133,13 +133,13 @@ ModelVariationArea::evalF(double t, propertyF_t type) {
     }
   } else if (stateVariationArea_ == ON_GOING) {  // load increase in progress
     for (int i = 0; i < nbLoads_; ++i) {
-      fLocal_[i * 2] = yLocal_[i * 2] - deltaP_ / (stopTime_ - startTime_)*(t - startTime_);
-      fLocal_[i * 2 + 1] = yLocal_[i * 2 + 1] - deltaQ_ / (stopTime_ - startTime_)*(t - startTime_);
+      fLocal_[i * 2] = yLocal_[i * 2] - deltaP_[i] / (stopTime_ - startTime_)*(t - startTime_);
+      fLocal_[i * 2 + 1] = yLocal_[i * 2 + 1] - deltaQ_[i] / (stopTime_ - startTime_)*(t - startTime_);
     }
   } else if (stateVariationArea_ == FINISHED) {  // load increase completed
     for (int i = 0; i < nbLoads_; ++i) {
-      fLocal_[i * 2] = yLocal_[i * 2] - deltaP_;
-      fLocal_[i * 2 + 1] = yLocal_[i * 2 + 1] - deltaQ_;
+      fLocal_[i * 2] = yLocal_[i * 2] - deltaP_[i];
+      fLocal_[i * 2 + 1] = yLocal_[i * 2 + 1] - deltaQ_[i];
     }
   }
 }
@@ -289,8 +289,8 @@ ModelVariationArea::defineParameters(vector<ParameterModeler>& parameters) {
   parameters.push_back(ParameterModeler("nbLoads", VAR_TYPE_INT, EXTERNAL_PARAMETER));
   parameters.push_back(ParameterModeler("startTime", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
   parameters.push_back(ParameterModeler("stopTime", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
-  parameters.push_back(ParameterModeler("deltaP", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
-  parameters.push_back(ParameterModeler("deltaQ", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
+  parameters.push_back(ParameterModeler("deltaP_load", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER, "*", "nbLoads"));
+  parameters.push_back(ParameterModeler("deltaQ_load", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER, "*", "nbLoads"));
 }
 
 void
@@ -298,8 +298,15 @@ ModelVariationArea::setSubModelParameters() {
   nbLoads_ = findParameterDynamic("nbLoads").getValue<int>();
   startTime_ = findParameterDynamic("startTime").getValue<double>();
   stopTime_ = findParameterDynamic("stopTime").getValue<double>();
-  deltaP_ = findParameterDynamic("deltaP").getValue<double>();
-  deltaQ_ = findParameterDynamic("deltaQ").getValue<double>();
+  for (int k = 0; k < nbLoads_; ++k) {
+    std::stringstream deltaPName;
+    deltaPName << "deltaP_load_" << k;
+    deltaP_.push_back(findParameterDynamic(deltaPName.str()).getValue<double>());
+
+    std::stringstream deltaQName;
+    deltaQName << "deltaQ_load_" << k;
+    deltaQ_.push_back(findParameterDynamic(deltaQName.str()).getValue<double>());
+  }
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.h
+++ b/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.h
@@ -268,8 +268,8 @@ class ModelVariationArea : public ModelCPP::Impl {
 
  private:
   // parameters
-  double deltaP_;  ///< variation of active power
-  double deltaQ_;  ///< variation of reactive power
+  std::vector<double> deltaP_;  ///< load variations for active power
+  std::vector<double> deltaQ_;  ///< load variations for reactive power
   double startTime_;  ///< start time
   double stopTime_;  ///< stop time
   int nbLoads_;  ///< number of loads

--- a/dynawo/sources/Models/CPP/ModelVariationArea/test/TestVariationArea.cpp
+++ b/dynawo/sources/Models/CPP/ModelVariationArea/test/TestVariationArea.cpp
@@ -33,7 +33,7 @@
 
 namespace DYN {
 
-boost::shared_ptr<SubModel> initModelVariationArea() {
+boost::shared_ptr<SubModel> initModelVariationArea(double deltaPLoad2, double deltaQLoad2) {
   boost::shared_ptr<SubModel> modelVariationArea = SubModelFactory::createSubModelFromLib("../DYNModelVariationArea" + std::string(sharedLibraryExtension()));
 
   std::vector<ParameterModeler> parameters;
@@ -42,8 +42,10 @@ boost::shared_ptr<SubModel> initModelVariationArea() {
   parametersSet->createParameter("nbLoads", 2);
   parametersSet->createParameter("startTime", 0.);
   parametersSet->createParameter("stopTime", 5.);
-  parametersSet->createParameter("deltaP", .2);
-  parametersSet->createParameter("deltaQ", .1);
+  parametersSet->createParameter("deltaP_load_0", 0.2);
+  parametersSet->createParameter("deltaQ_load_0", 0.05);
+  parametersSet->createParameter("deltaP_load_1", deltaPLoad2);
+  parametersSet->createParameter("deltaQ_load_1", deltaQLoad2);
   modelVariationArea->setPARParameters(parametersSet);
   modelVariationArea->addParameters(parameters, false);
   modelVariationArea->setParametersFromPARFile();
@@ -65,8 +67,10 @@ TEST(ModelsModelVariationArea, ModelVariationAreaDefineMethods) {
   parametersSet->createParameter("nbLoads", 2);
   parametersSet->createParameter("startTime", 0.);
   parametersSet->createParameter("stopTime", 5.);
-  parametersSet->createParameter("deltaP", .2);
-  parametersSet->createParameter("deltaQ", .1);
+  parametersSet->createParameter("deltaP_load_0", .2);
+  parametersSet->createParameter("deltaQ_load_0", .1);
+  parametersSet->createParameter("deltaP_load_1", .5);
+  parametersSet->createParameter("deltaQ_load_1", .05);
   ASSERT_NO_THROW(modelVariationArea->setPARParameters(parametersSet));
 
   modelVariationArea->addParameters(parameters, false);
@@ -163,7 +167,7 @@ TEST(ModelsModelVariationArea, ModelVariationAreaDefineMethods) {
 }
 
 TEST(ModelsModelVariationArea, ModelVariationAreaTypeMethods) {
-  boost::shared_ptr<SubModel> modelVariationArea = initModelVariationArea();
+  boost::shared_ptr<SubModel> modelVariationArea = initModelVariationArea(.1, .01);
   unsigned nbY = 4;
   unsigned nbF = 4;
   std::vector<propertyContinuousVar_t> yTypes(nbY, UNDEFINED_PROPERTY);
@@ -189,7 +193,7 @@ TEST(ModelsModelVariationArea, ModelVariationAreaTypeMethods) {
 }
 
 TEST(ModelsModelVariationArea, ModelVariationAreaInit) {
-  boost::shared_ptr<SubModel> modelVariationArea = initModelVariationArea();
+  boost::shared_ptr<SubModel> modelVariationArea = initModelVariationArea(.1, .01);
   std::vector<double> y(modelVariationArea->sizeY(), 0);
   std::vector<double> yp(modelVariationArea->sizeY(), 0);
   modelVariationArea->setBufferY(&y[0], &yp[0], 0.);
@@ -212,7 +216,7 @@ TEST(ModelsModelVariationArea, ModelVariationAreaInit) {
 }
 
 TEST(ModelsModelVariationArea, ModelVariationAreaContinuousAndDiscreteMethods) {
-  boost::shared_ptr<SubModel> modelVariationArea = initModelVariationArea();
+  boost::shared_ptr<SubModel> modelVariationArea = initModelVariationArea(.1, .01);
   std::vector<double> y(modelVariationArea->sizeY(), 0);
   std::vector<double> yp(modelVariationArea->sizeY(), 0);
   modelVariationArea->setBufferY(&y[0], &yp[0], 0.);
@@ -256,18 +260,18 @@ TEST(ModelsModelVariationArea, ModelVariationAreaContinuousAndDiscreteMethods) {
   modelVariationArea->evalZ(2.);
   modelVariationArea->evalF(2., UNDEFINED_EQ);
   ASSERT_DOUBLE_EQUALS_DYNAWO(f[0], -0.08);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(f[1], -0.04);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(f[2], -0.08);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(f[3], -0.04);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(f[1], -0.02);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(f[2], -0.04);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(f[3], -0.004);
   ASSERT_DOUBLE_EQUALS_DYNAWO(z[0], 1);
 
   modelVariationArea->evalG(6.);
   modelVariationArea->evalZ(6.);
   modelVariationArea->evalF(6., UNDEFINED_EQ);
   ASSERT_DOUBLE_EQUALS_DYNAWO(f[0], -0.2);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(f[1], -0.1);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(f[2], -0.2);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(f[3], -0.1);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(f[1], -0.05);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(f[2], -0.1);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(f[3], -0.01);
   ASSERT_DOUBLE_EQUALS_DYNAWO(z[0], 2);
 
   SparseMatrix smjPrim;


### PR DESCRIPTION
@thiebarrrte fyi we will then after this development require a deltaP and a deltaQ parameter for each load connected to the variation area. The parameter syntax is similar to the one adopted for the OmegaRef model, ie deltaP_load_0 to deltaP_load_nbLoads-1 and the same for deltaQ.

