### PR TITLE
#1100 Correct traces on standard output

### DIFF
--- a/dynawo/sources/Common/DYNTrace.cpp
+++ b/dynawo/sources/Common/DYNTrace.cpp
@@ -67,6 +67,12 @@ typedef sinks::synchronous_sink< sinks::text_file_backend > file_sink;  ///< def
 static vector< boost::shared_ptr<file_sink> > sinks;  ///<  vector of file sink
 static vector< boost::shared_ptr<text_sink> > originalSinks;  ///< vector of text sink
 
+#if _DEBUG_
+const SeverityLevel Trace::defaultLevel_ = DEBUG;
+#else
+const SeverityLevel Trace::defaultLevel_ = INFO;
+#endif
+
 /**
  * @brief Operator<< overload for severity level on ostreams
  *

--- a/dynawo/sources/Common/DYNTrace.h
+++ b/dynawo/sources/Common/DYNTrace.h
@@ -318,11 +318,28 @@ class Trace {
   /**
    * @brief test if a log exists
    *
+   * This tests only the file logs
+   *
    * @param tag : Tag added to the log, can be used as a filter in logging sinks.
    * @param slv : Severity level.
    * @return true if this log with this level exists
    */
   static bool logExists(const std::string& tag, SeverityLevel slv);
+
+  /**
+   * @brief Test if a standard log exists
+   *
+   * This test the level of the standard output log
+   *
+   * @param slv Severity level
+   * @returns whether the standard log accepts the log level
+   */
+  static bool standardLogExists(SeverityLevel slv) {
+    return slv >= defaultLevel_;
+  }
+
+ private:
+  static const SeverityLevel defaultLevel_;  ///< Default log level for standard output
 
  private:
   /**

--- a/dynawo/sources/Common/DYNTraceStream.cpp
+++ b/dynawo/sources/Common/DYNTraceStream.cpp
@@ -27,14 +27,13 @@ TraceStream::TraceStream() :
 buffer_(boost::shared_ptr<std::stringstream>(new std::stringstream)),
 slv_(INFO),
 tag_("") {
-  buffer_ = boost::shared_ptr<std::stringstream>(new std::stringstream);
 }
 
 TraceStream::TraceStream(SeverityLevel slv, const std::string& tag) :
 buffer_(),
 slv_(slv),
 tag_(tag) {
-  if (Trace::logExists(tag, slv)) {
+  if (Trace::standardLogExists(slv) || Trace::logExists(tag, slv)) {
     buffer_ = boost::shared_ptr<std::stringstream>(new std::stringstream);
   }
 }


### PR DESCRIPTION
All info logs will be built in the stream to be displayed,
at least, on standard output