### PR TITLE
#1029 WIP: 1029_Integrating_LibXML2

### DIFF
--- a/dynawo/3rdParty/CMakeLists.txt
+++ b/dynawo/3rdParty/CMakeLists.txt
@@ -8,9 +8,6 @@
 #
 # This file is part of Dynawo, an hybrid C++/Modelica open source time domain simulation tool for power systems.
 
-# Minimum required (for ExternalProject_Add)
-cmake_minimum_required(VERSION 3.9.6 FATAL_ERROR)
-
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)" ON)
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel (CMake defaults)")
 option(CXX11_ENABLED "Enable support of C++11 standard" TRUE)
@@ -904,12 +901,21 @@ else()
   set(LIBZIP_HOME ${install_dir})
 endif()
 
-# if ( CXX11_ENABLED )                                                                              # New part for IIDM-2
+#-wip- if ( CXX11_ENABLED )                                                                              # New part for IIDM-2
 
-        # HERE IS THE NEW PART
+# Minimum required for powsybl that sets that rule
+cmake_minimum_required(VERSION 3.12)
 
-# else()                                                                                            # old part : legacy IIDM
+include( "Support-LibXml2")
+#-wip- include( "Support-LibIIDM")  --> uses/sets the same variables LIBIIDM_foo than legacy IIDM
+
+#-wip- else()                                                                                            # old part : legacy IIDM
+
+# Minimum required (for ExternalProject_Add)
+cmake_minimum_required(VERSION 3.9.6)
+
 set(XERCESC_HOME      CACHE PATH "Path where a Xerces-C installation already exists")               # Start install XERCESC
+# Xercesc est aussi mentionné REQUIRED depuis le script CMakeLists.txt principal. A tester avant de le retirer
 
 set(xercesc_version      3.2.2)
 set(xercesc_name         xerces-c-${xercesc_version}.tar.gz)
@@ -1090,4 +1096,5 @@ else()
   ExternalProject_Get_Property(libiidm install_dir)
   set(LIBIIDM_HOME ${install_dir})
 endif()
-                                                                                        # End install IIDM old one and DG changes
+
+#-wip- endif ()                                                                            # End install IIDM old one and DG changes

--- a/dynawo/cmake/SetPatchCommands.cmake
+++ b/dynawo/cmake/SetPatchCommands.cmake
@@ -1,0 +1,60 @@
+# Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of Dynawo, an hybrid C++/Modelica open source time domain simulation tool for power systems.
+
+function( SetPatchCommands projectName)
+
+    set( TmpDirName "$ENV{DYNAWO_HOME}/dynawo/3rdParty")
+    if ( NOT IS_DIRECTORY "${TmpDirName}")
+        message( FATAL_ERROR "Path to patches should be a directory: it is not! : '${TmpDirName}'")
+    endif()
+
+    set( PatchFile "${TmpDirName}/${projectName}/patch/common/${projectName}.patch")
+    if( EXISTS ${PatchFile} )
+        if (UNIX)
+            set( paquet_all_comp_patch
+                patch -p1 --forward --no-backup-if-mismatch -r /dev/null -i ${PatchFile} || echo -n
+                PARENT_SCOPE
+            )
+        else()
+            set( paquet_all_comp_patch
+                git apply -p1 ${PatchFile} --reverse --check 2> nul ||
+                git apply --ignore-whitespace --whitespace=nowarn -p1 ${PatchFile}
+                PARENT_SCOPE
+            )
+        endif()
+    else()
+        set( paquet_all_comp_patch
+            ${CMAKE_COMMAND} -E echo No common patch for ${projectName}.
+            PARENT_SCOPE
+        )
+    endif()
+
+    set( PatchFile "${TmpDirName}/${projectName}/patch/${CMAKE_CXX_COMPILER_ID}/${projectName}.patch")
+    if( EXISTS ${PatchFile} )
+        if (UNIX)
+            set( paquet_compiler_patch
+                patch -p1 --forward --no-backup-if-mismatch -r /dev/null -i ${PatchFile} || echo -n
+                PARENT_SCOPE
+            )
+        else()
+            set( paquet_compiler_patch
+                git apply -p1 ${PatchFile} --reverse --check 2> nul ||
+                git apply --ignore-whitespace --whitespace=nowarn -p1 ${PatchFile}
+                PARENT_SCOPE
+            )
+        endif()
+    else()
+        set( paquet_compiler_patch
+            ${CMAKE_COMMAND} -E echo No compiler patch for ${projectName}.
+            PARENT_SCOPE
+        )
+    endif()
+
+endfunction()

--- a/dynawo/cmake/Support-LibXml2.cmake
+++ b/dynawo/cmake/Support-LibXml2.cmake
@@ -1,0 +1,85 @@
+# Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of Dynawo, an hybrid C++/Modelica open source time domain simulation tool for power systems.
+
+cmake_minimum_required( VERSION 3.12)
+
+if ( NOT CMAKE_SCRIPT_MODE_FILE )
+    project( "Libxml2 support for Dynawo")
+endif ()
+
+include( $ENV{DYNAWO_HOME}/dynawo/cmake/cpu_count.cmake)
+if ( NOT DEFINED CPU_COUNT )
+    message( FATAL_ERROR "cpu_count.cmake: file not found.")
+endif ()
+
+set( paquet_name        "libxml2")
+set( paquet_finder      "LibXml2")
+set( paquet_install_dir "${CMAKE_INSTALL_PREFIX}/libxml2")
+
+string( TOLOWER ${paquet_name} paquet_lowername)
+string( TOUPPER ${paquet_name} paquet_uppername)
+
+unset( CMAKE_MODULE_PATH)
+list( APPEND CMAKE_MODULE_PATH "$ENV{DYNAWO_HOME}/dynawo/cmake")
+if ( IS_DIRECTORY "$ENV{DYNAWO_HOME}/dynawo/3rdParty/${paquet_name}")
+    list( APPEND CMAKE_MODULE_PATH "$ENV{DYNAWO_HOME}/dynawo/3rdParty/${paquet_name}")
+endif ()
+
+set(RequiredVersion 2.9)
+
+set( CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}/libxml2")
+find_package( ${paquet_finder} ${RequiredVersion} QUIET)
+if ( ${paquet_finder}_FOUND )
+
+    add_custom_target( ${paquet_name})
+    set( ${paquet_uppername}_HOME ${paquet_install_dir})
+    message( STATUS "found LibXML2 lib and includes : ${LIBXML2_VERSION_STRING} in ${LIBXML2_HOME}")
+
+else ()
+    include( ExternalProject)
+    ExternalProject_Add(
+                            ${paquet_name}
+        INSTALL_DIR         ${paquet_install_dir}
+
+        GIT_REPOSITORY      https://gitlab.gnome.org/GNOME/libxml2.git
+        GIT_TAG             master
+        GIT_PROGRESS        1
+
+        UPDATE_COMMAND      ""
+
+        TMP_DIR             ${CMAKE_CURRENT_BINARY_DIR}/tmp_dir
+        SOURCE_DIR          ${CMAKE_CURRENT_BINARY_DIR}/source_dir
+        DOWNLOAD_DIR        ${CMAKE_CURRENT_BINARY_DIR}/download_dir
+        STAMP_DIR           ${CMAKE_CURRENT_BINARY_DIR}/stamp_dir
+        BINARY_DIR          ${CMAKE_CURRENT_BINARY_DIR}/binary_dir
+
+        CONFIGURE_COMMAND   <SOURCE_DIR>/autogen.sh
+                            "--without-python"
+                            "--prefix=<INSTALL_DIR>"
+                            "CC=${CMAKE_C_COMPILER}"
+                            "CXX=${CMAKE_CXX_COMPILER}"
+                            "CFLAGS=${CMAKE_C_FLAGS}"
+                            "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+
+        BUILD_COMMAND       make -j ${CPU_COUNT} all
+
+        INSTALL_COMMAND     make install
+    )
+
+    set_target_properties(
+        ${paquet_name}
+        PROPERTIES  INTERFACE_INCLUDE_DIRECTORIES
+        "${CMAKE_INSTALL_PREFIX}/include/libxml2"
+    )
+
+    ExternalProject_Get_Property( ${paquet_name} install_dir)
+    set( ${paquet_uppername}_HOME ${install_dir})
+
+endif ()

--- a/dynawo/cmake/cpu_count.cmake
+++ b/dynawo/cmake/cpu_count.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of Dynawo, an hybrid C++/Modelica open source time domain simulation tool for power systems.
+
+if (NOT DEFINED CPU_COUNT OR CPU_COUNT LESS_EQUAL 0)
+    set( CPU_COUNT $ENV{DYNAWO_NB_PROCESSORS_USED})
+    if (NOT DEFINED CPU_COUNT OR CPU_COUNT LESS_EQUAL 0)
+        include( ProcessorCount)
+        ProcessorCount( CPU_COUNT)
+        if (NOT DEFINED CPU_COUNT OR CPU_COUNT LESS_EQUAL 0)
+            set( CPU_COUNT 1)
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
First try of integrating LibXML2 before changing IIDM version. It still lacks a few things
1 - Documentation and licenses for LibXML2 must be added
2 - Changes may be necessary in envDynawo.sh (specially for deploying)
3 - No patch is applied to the installation: are some needed ?
... and probably more ...

The changes are quoted with '#-wip' mark in CMakeLists.txt. You may commit changes, as they do not affect existing libraries. It only adds (unnecessary) LibXML2 to the project, until next step.