### PR TITLE
#1445 Add a protection against frequency collapse or increase

### DIFF
--- a/documentation/functionalDoc/functionalDoc.tex
+++ b/documentation/functionalDoc/functionalDoc.tex
@@ -363,7 +363,7 @@ The ``OmegaRef'' model calculates the reference speed for each synchronous area.
 \label{Speed reference calculation}
 \end{equation}
 
-This model is connected to all the generators of one synchronous area and takes their speed as inputs to calculate the reference speed that is used into the machine models.
+This model is connected to all the generators of one synchronous area and takes their speed as inputs to calculate the reference speed that is used into the machine models. Notice that a protection exists to stop the simulation if the frequency becomes lower (or higher) than a settable value.
 
 \paragraph{Implicit frequency model - SignalN}
 ~~\\

--- a/dynawo/sources/Common/Dictionaries/DYNError_en_GB.dic
+++ b/dynawo/sources/Common/Dictionaries/DYNError_en_GB.dic
@@ -182,6 +182,8 @@ SwitchMissingBus2           =             SWITCH %1% : bus 2 is missing
 UndefinedNominalV           =             VOLTAGE LEVEL %1% : nominal value is undefined or badly defined (< 0)
 VoltageLevelGraphUndefined  =             VOLTAGE LEVEL %1% : graph is undefined
 VoltageLevelBBSError        =             VOLTAGE LEVEL %1% : error while looking for the closest bus bar section
+FrequencyCollapse           =             frequency collapse (%1% Hz < %2% Hz)
+FrequencyIncrease           =             high frequency (%1% Hz > %2% Hz)
 //--------------- GENERAL -----------------------------------------
 GZReadErrorOnFile           =             unexpected error while reading compressed file %1%
 InvalidSeverityLevel        =             severity level %1% invalid

--- a/dynawo/sources/Modeler/util/test/res/dumpModel.desc.xml
+++ b/dynawo/sources/Modeler/util/test/res/dumpModel.desc.xml
@@ -4,6 +4,8 @@
   <elements>
     <parameters>
       <parameter name="nbGen" valueType="INT" cardinality="1" readOnly="false"/>
+      <parameter name="omegaRefMax" valueType="DOUBLE" cardinality="1" readOnly="false"/>
+      <parameter name="omegaRefMin" valueType="DOUBLE" cardinality="1" readOnly="false"/>
       <parameter name="weight_gen" valueType="DOUBLE" cardinality="*" readOnly="false"/>
     </parameters>
     <variables>

--- a/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.cpp
+++ b/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.cpp
@@ -107,11 +107,6 @@ ModelCPP::Impl::loadVariables(const string& variables) {
 }
 
 void
-ModelCPP::Impl::checkDataCoherence(const double& /*t*/) {
-  // not needed
-}
-
-void
 ModelCPP::Impl::checkParametersCoherence() const {
   // not needed
 }

--- a/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.h
+++ b/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.h
@@ -254,7 +254,7 @@ class ModelCPP::Impl : public ModelCPP {
   /**
    * @copydoc ModelCPP::checkDataCoherence()
    */
-  void checkDataCoherence(const double& t);
+  virtual void checkDataCoherence(const double& t) = 0;
 
   /**
    * @copydoc ModelCPP::checkParametersCoherence() const

--- a/dynawo/sources/Models/CPP/Components/ModelLoadRestorativeWithLimits/DYNModelLoadRestorativeWithLimits.h
+++ b/dynawo/sources/Models/CPP/Components/ModelLoadRestorativeWithLimits/DYNModelLoadRestorativeWithLimits.h
@@ -273,6 +273,11 @@ class ModelLoadRestorativeWithLimits : public ModelCPP::Impl {
   */
   void evalZ(const double & t);
 
+  /**
+   * @copydoc ModelCPP::checkDataCoherence()
+   */
+  void checkDataCoherence(const double& /*t*/) { /* not needed */ }
+
  private:
   State connectionState_;  ///< "internal" load connection status
   State preConnectionState_;  ///< "internal" load connection status at previous timestamp

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
@@ -16,8 +16,8 @@
  *
  * @brief Reference frequency model implementation
  *
- * All generators of the newtork are connected to this model
- * but only the generators with a weight gen > 0 participate to the calcul of the frequency reference
+ * All generators of the network are connected to this model
+ * but only the generators with a weight gen > 0 participate to the calculation of the frequency reference
  *
  */
 #include <sstream>
@@ -28,6 +28,7 @@
 
 #include "DYNModelOmegaRef.h"
 #include "DYNModelOmegaRef.hpp"
+#include "DYNModelConstants.h"
 #include "DYNSparseMatrix.h"
 #include "DYNMacrosMessage.h"
 #include "DYNElement.h"
@@ -94,7 +95,9 @@ Impl("omegaRef"),
 firstState_(true),
 nbGen_(0),
 nbCC_(0),
-nbOmega_(0) {
+nbOmega_(0),
+omegaRefMin_(0.98),
+omegaRefMax_(1.02) {
 }
 
 /**
@@ -459,6 +462,8 @@ void
 ModelOmegaRef::defineParameters(vector<ParameterModeler>& parameters) {
   parameters.push_back(ParameterModeler("nbGen", VAR_TYPE_INT, EXTERNAL_PARAMETER));
   parameters.push_back(ParameterModeler("weight_gen", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER, "*", "nbGen"));
+  parameters.push_back(ParameterModeler("omegaRefMin", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
+  parameters.push_back(ParameterModeler("omegaRefMax", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
 }
 
 void
@@ -482,6 +487,11 @@ ModelOmegaRef::setSubModelParameters() {
   }
 
   omegaRef0_.assign(nbMaxCC, 1.);
+
+  // Get omegaRefMin and omegaRefMax parameters from the par file if they exist
+  bool success;
+  getSubModelParameterValue("omegaRefMin", omegaRefMin_, success);
+  getSubModelParameterValue("omegaRefMax", omegaRefMax_, success);
 }
 
 /**
@@ -551,6 +561,18 @@ ModelOmegaRef::setFequations() {
   }
 
   assert(fEquationIndex_.size() == (unsigned int) sizeF() && "ModelOmegaRef:fEquationIndex_.size() != f_.size()");
+}
+
+void
+ModelOmegaRef::checkDataCoherence(const double& /*t*/) {
+  for (int i = 0; i < nbMaxCC; ++i) {
+    if (doubleEquals(yLocal_[i], omegaRef0_[i]))
+      continue;
+    if (yLocal_[i] < omegaRefMin_)
+      throw DYNError(Error::MODELER, FrequencyCollapse, yLocal_[i] * FNOM, omegaRefMin_ * FNOM);
+    else if (yLocal_[i] > omegaRefMax_)
+      throw DYNError(Error::MODELER, FrequencyIncrease, yLocal_[i] * FNOM, omegaRefMax_ * FNOM);
+  }
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
@@ -568,9 +568,9 @@ ModelOmegaRef::checkDataCoherence(const double& /*t*/) {
   for (int i = 0; i < nbMaxCC; ++i) {
     if (doubleEquals(yLocal_[i], omegaRef0_[i]))
       continue;
-    if (yLocal_[i] < omegaRefMin_)
+    if (yLocal_[i] < omegaRefMin_ && doubleNotEquals(yLocal_[i], omegaRefMin_))
       throw DYNError(Error::MODELER, FrequencyCollapse, yLocal_[i] * FNOM, omegaRefMin_ * FNOM);
-    else if (yLocal_[i] > omegaRefMax_)
+    else if (yLocal_[i] > omegaRefMax_ && doubleNotEquals(yLocal_[i], omegaRefMax_))
       throw DYNError(Error::MODELER, FrequencyIncrease, yLocal_[i] * FNOM, omegaRefMax_ * FNOM);
   }
 }

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.h
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.h
@@ -276,6 +276,11 @@ class ModelOmegaRef : public ModelCPP::Impl {
    */
   void initParams() { /* not needed */ }
 
+  /**
+   * @copydoc ModelCPP::checkDataCoherence()
+   */
+  void checkDataCoherence(const double& t);
+
  private:
   /**
    * @brief Sort every generator by num of subNetwork
@@ -309,6 +314,8 @@ class ModelOmegaRef : public ModelCPP::Impl {
   int nbCC_;  ///< number of connected components
   int nbOmega_;  ///< number of generators with positive weight
   std::vector<int> indexOmega_;  ///< index for each omega inside the local buffer
+  double omegaRefMin_;
+  double omegaRefMax_;
 };
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.h
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.h
@@ -289,7 +289,7 @@ class ModelOmegaRef : public ModelCPP::Impl {
    */
   void sortGenByCC();
   /**
-   * @brief calculate the initial state of the smacc automaton
+   * @brief calculate the initial state of the omegaref model
    *
    */
   void calculateInitialState();
@@ -314,8 +314,8 @@ class ModelOmegaRef : public ModelCPP::Impl {
   int nbCC_;  ///< number of connected components
   int nbOmega_;  ///< number of generators with positive weight
   std::vector<int> indexOmega_;  ///< index for each omega inside the local buffer
-  double omegaRefMin_;
-  double omegaRefMax_;
+  double omegaRefMin_;  ///< minimum acceptable value for omegaref
+  double omegaRefMax_;  ///< maximum acceptable value for omegaref
 };
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/test/TestOmegaRef.cpp
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/test/TestOmegaRef.cpp
@@ -41,6 +41,8 @@ boost::shared_ptr<SubModel> initModelOmegaRef(double weightGen2) {
   parametersSet->createParameter("nbGen", 2);
   parametersSet->createParameter("weight_gen_0", 2.);
   parametersSet->createParameter("weight_gen_1", weightGen2);
+  parametersSet->createParameter("omegaRefMin", 0.5);
+  parametersSet->createParameter("omegaRefMax", 1.5);
   modelOmegaRef->setPARParameters(parametersSet);
   modelOmegaRef->addParameters(parameters, false);
   modelOmegaRef->setParametersFromPARFile();
@@ -56,11 +58,13 @@ TEST(ModelsModelOmegaRef, ModelOmegaRefDefineMethods) {
 
   std::vector<ParameterModeler> parameters;
   modelOmegaRef->defineParameters(parameters);
-  ASSERT_EQ(parameters.size(), 2);
+  ASSERT_EQ(parameters.size(), 4);
 
   boost::shared_ptr<parameters::ParametersSet> parametersSet = boost::shared_ptr<parameters::ParametersSet>(new parameters::ParametersSet("Parameterset"));
   parametersSet->createParameter("nbGen", 1);
   parametersSet->createParameter("weight_gen_0", 2.);
+  parametersSet->createParameter("omegaRefMin", 0.95);
+  parametersSet->createParameter("omegaRefMax", 1.05);
   ASSERT_NO_THROW(modelOmegaRef->setPARParameters(parametersSet));
 
   modelOmegaRef->addParameters(parameters, false);
@@ -338,6 +342,7 @@ TEST(ModelsModelOmegaRef, ModelOmegaRefContinuousAndDiscreteMethods) {
   ASSERT_EQ(smjPrim.nbElem(), 0);
   modeChangeType_t mode = modelOmegaRef->evalMode(1);
   ASSERT_EQ(mode, NO_MODE);
+  ASSERT_THROW_DYNAWO(modelOmegaRef->checkDataCoherence(0), Error::MODELER, KeyError_t::FrequencyIncrease);
 
   z[2] = 0;  // Switching off gen1
   y[12] = 2;
@@ -373,6 +378,12 @@ TEST(ModelsModelOmegaRef, ModelOmegaRefContinuousAndDiscreteMethods) {
   mode = modelOmegaRef->evalMode(2);
   ASSERT_EQ(mode, ALGEBRAIC_J_UPDATE_MODE);
   delete[] zConnected;
+
+  y[0] = 1.2;  // Modifying omegaRef_grp_0
+  ASSERT_NO_THROW(modelOmegaRef->checkDataCoherence(0));
+
+  y[0] = 0.4;  // Modifying omegaRef_grp_0
+  ASSERT_THROW_DYNAWO(modelOmegaRef->checkDataCoherence(0), Error::MODELER, KeyError_t::FrequencyCollapse);
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelSignalN/DYNModelSignalN.h
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelSignalN/DYNModelSignalN.h
@@ -282,6 +282,11 @@ class ModelSignalN : public ModelCPP::Impl {
    */
   void initParams() { /* not needed */ }
 
+  /**
+   * @copydoc ModelCPP::checkDataCoherence()
+   */
+  void checkDataCoherence(const double& /*t*/) { /* not needed */ }
+
  private:
   /**
    * @brief Sort every generator by num of subNetwork

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
@@ -291,6 +291,11 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
    */
   void printModel() const;
 
+  /**
+   * @copydoc ModelCPP::checkDataCoherence()
+   */
+  void checkDataCoherence(const double& /*t*/) { /* not needed */ }
+
  protected:
   /**
   * @copydoc SubModel::dumpUserReadableElementList()

--- a/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.h
+++ b/dynawo/sources/Models/CPP/ModelVariationArea/DYNModelVariationArea.h
@@ -271,6 +271,11 @@ class ModelVariationArea : public ModelCPP::Impl {
    */
   void initParams() { /* not needed */ }
 
+  /**
+   * @copydoc ModelCPP::checkDataCoherence()
+   */
+  void checkDataCoherence(const double& /*t*/) { /* not needed */ }
+
  private:
   // parameters
   std::vector<double> deltaP_;  ///< load variations for active power

--- a/examples/DynaWaltz/IEEE14/IEEE14_CascadingLineTrippings/IEEE14.par
+++ b/examples/DynaWaltz/IEEE14/IEEE14_CascadingLineTrippings/IEEE14.par
@@ -351,6 +351,7 @@
     <par type="DOUBLE" name="weight_gen_2" value="9281.25"/>
     <par type="DOUBLE" name="weight_gen_3" value="398"/>
     <par type="DOUBLE" name="weight_gen_4" value="687"/>
+    <par type="DOUBLE" name="omegaRefMin" value="0.95"/>
   </set>
   <set id="DisconnectLine">
     <par type="DOUBLE" name="event_tEvent" value="50"/>

--- a/nrt/data/IEEE14/IEEE14_WithAutomata/IEEE14_UnderVoltageAutomaton/IEEE14.par
+++ b/nrt/data/IEEE14/IEEE14_WithAutomata/IEEE14_UnderVoltageAutomaton/IEEE14.par
@@ -226,6 +226,7 @@
     <par type="DOUBLE" name="weight_gen_2" value="1650"/>
     <par type="DOUBLE" name="weight_gen_3" value="80"/>
     <par type="DOUBLE" name="weight_gen_4" value="250"/>
+    <par type="DOUBLE" name="omegaRefMin" value="0.9"/>
   </set>
   <set id="8">
     <par type="DOUBLE" name="capacitor_no_reclosing_delay" value="300"/>


### PR DESCRIPTION
In this dev, a few open points/questions remain (that could be solved or modified later on if necessary):
- There is currently no proper method to deal with optional parameters at the submodel level (I had to use the getSubModelParameterValue method initially created for parameter curves) but a lot of the intelligence is duplicated in the submodel and networkComponentImpl classes to handle the non throw aspect. It is kind of a pity for me in terms of maintenance. In addition, there is certainly room for performances improvements in the networkComponentImpl ones (not to search for each parameter in the whole map, etc.)
- As of today, I throw with an error type "Modeler" which is quite common. If we want to catch this in dyn-itf to render a proper status, either we keep it this way and catch more than just frequency incidents (even if we haven't yet seen any other throw of this kind in real life use) or I create a specific Frequency type error. I don't have strong opinions in favor of any option and can do the modification if needed.
- When throwing inside a method called by the simulate method, the error is duplicated in the log file: we first have the throw entry and then the trace added by the catch condition in Simulation. I would suggest deleting this second log but I'm unsure if it is necessary or not for other use cases.

Regarding default values, I have set them to 0.98 for omegaRefMin (= 49 Hz) and 1.02 for omegaRefMax (= 51 Hz). Fine for you @MarianneSaugierRTE ? (knowing that they can be modified by the user if needed through par file) 