### PR TITLE
#1574 Correct autocompletion

### DIFF
--- a/util/envDynawo.sh
+++ b/util/envDynawo.sh
@@ -646,7 +646,7 @@ git diff-index --check --cached HEAD -- ':(exclude)*/reference/*' ':(exclude)*.p
   fi
 
   if [ -e "$DYNAWO_HOME/.git" ]; then
-    if [ -z "$(git config --get core.commentchar 2> /dev/null)" ] || [ $(git config --get core.commentchar 2> /dev/null) = "#" ]; then
+    if [ -z "$(git --git-dir $DYNAWO_HOME/.git config --get core.commentchar 2> /dev/null)" ] || [ $(git --git-dir $DYNAWO_HOME/.git config --get core.commentchar 2> /dev/null) = "#" ]; then
       git config core.commentchar % || error_exit "You need to change git config commentchar from # to %."
     fi
   fi


### PR DESCRIPTION
When autocompletion is performed, set_commit_hook is called,
leading to issue if we are not in the main repo