### PR TITLE
#125 fix clang compilation -Wcovered-switch-default

### DIFF
--- a/dynawo/sources/Common/DYNEnumUtils.cpp
+++ b/dynawo/sources/Common/DYNEnumUtils.cpp
@@ -37,9 +37,8 @@ modeChangeType2Str(const modeChangeType_t& modeChangeType) {
       return "Algebraic mode change";
     case ALGEBRAIC_J_UPDATE_MODE:
       return "Algebraic mode (with J recalculation) change";
-    default:
-      assert(0 && "Mode change type should be one of the enum values");
   }
+  assert(0 && "Mode change type should be one of the enum values");
   return "";
 }
 
@@ -56,9 +55,8 @@ propertyVar2Str(const propertyContinuousVar_t& property) {
       return "OPTIONAL_EXTERNAL";
     case UNDEFINED_PROPERTY:
       return "UNDEFINED";
-    default:
-      assert(0 && "Property should be one of the enum values");
   }
+  assert(0 && "Property should be one of the enum values");
   return "";
 }
 
@@ -77,14 +75,15 @@ typeVar2Str(const typeVar_t& type) {
       return "BOOLEAN";
     case UNDEFINED_TYPE:
       return "UNDEFINED";
-    default:
-      assert(0 && "TypeVar should be one of the enum values");
   }
+  assert(0 && "TypeVar should be one of the enum values");
   return "";
 }
 
 typeVarC_t toCTypeVar(const typeVar_t& type) {
   switch (type) {
+    case UNDEFINED_TYPE:
+      assert(0 && "TypeVar undefined");
     case DISCRETE:
     case CONTINUOUS:
     case FLOW:
@@ -93,11 +92,8 @@ typeVarC_t toCTypeVar(const typeVar_t& type) {
       return VAR_TYPE_INT;
     case BOOLEAN:
       return VAR_TYPE_BOOL;
-    case UNDEFINED_TYPE:
-      assert(0 && "TypeVar undefined");
-    default:
-      assert(0 && "TypeVar should be one of the enum values");
   }
+  assert(0 && "TypeVar should be one of the enum values");
   return VAR_TYPE_DOUBLE;
 }
 
@@ -109,9 +105,8 @@ string paramScope2Str(const parameterScope_t& scope) {
       return "shared parameter";
     case INTERNAL_PARAMETER:
       return "internal parameter";
-    default:
-      assert(0 && "Parameter scope should be one of the enum values");
   }
+  assert(0 && "Parameter scope should be one of the enum values");
   return "";
 }
 

--- a/dynawo/sources/Common/DYNMessage.cpp
+++ b/dynawo/sources/Common/DYNMessage.cpp
@@ -48,8 +48,6 @@ Message::Message(const dictionaryKey& dicoKey, const std::string& key) {
     case LOG_KEY:
       dicoName = "LOG";
       break;
-    default:
-      break;
   }
   initialize(dicoName, key);
 }

--- a/dynawo/sources/Common/DYNTrace.cpp
+++ b/dynawo/sources/Common/DYNTrace.cpp
@@ -370,9 +370,8 @@ Trace::stringFromSeverityLevel(SeverityLevel level) {
       return "WARN";
     case ERROR:
       return "ERROR";
-    default:
-      throw DYNError(Error::GENERAL, InvalidSeverityLevel, static_cast<int> (level));
   }
+  throw DYNError(Error::GENERAL, InvalidSeverityLevel, static_cast<int> (level));
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Common/gtest_dynawo.h
+++ b/dynawo/sources/Common/gtest_dynawo.h
@@ -156,12 +156,25 @@ inline std::string key2Str(const int key) {
  *
  * @param F function/method to launch
  */
+#ifdef __clang__
+#define EXPECT_ASSERT_DYNAWO_BEGIN_                                  \
+  _Pragma("clang diagnostic push")                                   \
+  _Pragma("clang diagnostic ignored \"-Wcovered-switch-default\"")
+#define EXPECT_ASSERT_DYNAWO_END_                                    \
+  _Pragma("clang diagnostic pop")
+#else
+#define EXPECT_ASSERT_DYNAWO_BEGIN_
+#define EXPECT_ASSERT_DYNAWO_END_
+#endif
+
 #define EXPECT_ASSERT_DYNAWO(F)                                      \
+  EXPECT_ASSERT_DYNAWO_BEGIN_                                        \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_                                      \
   if (::testing::FLAGS_gtest_death_test_style = "threadsafe", false) \
     ;                                                                \
   else  /* NOLINT */                                                 \
-    EXPECT_EXIT(F, ::testing::KilledBySignal(SIGABRT), ".*")
+    EXPECT_EXIT(F, ::testing::KilledBySignal(SIGABRT), ".*")         \
+  EXPECT_ASSERT_DYNAWO_END_
 
 /**
  * @brief macro to test if two double are equals

--- a/dynawo/sources/Modeler/Common/DYNSubModel.cpp
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.cpp
@@ -340,35 +340,30 @@ SubModel::getVariableValue(const shared_ptr<Variable>& variable) const {
   const bool negated = variable->getNegated();
   const bool isState = variable->isState();
 
-  double value;
+  double value = std::numeric_limits<double>::quiet_NaN();
   if (!isState) {
     value = calculatedVars_[varNum];
   } else {
     switch (typeVar) {
       case CONTINUOUS:
-      case FLOW: {
+      case FLOW:
         value = yLocal_[varNum];
         break;
-      }
       case DISCRETE:
-      case INTEGER: {  // Z vector contains DISCRETE variables and then INTEGER variables
+      case INTEGER:  // Z vector contains DISCRETE variables and then INTEGER variables
         value = zLocal_[varNum];
         break;
-      }
-      case BOOLEAN: {
+      case BOOLEAN:
         if (toNativeBool(zLocal_[varNum]))
           value = 1;
         else
           value = 0;
         break;
-      }
-      case UNDEFINED_TYPE: {
+      case UNDEFINED_TYPE:
         throw DYNError(Error::MODELER, ModelFuncError, "Unsupported variable type");
-      }
-      default: {
-        throw DYNError(Error::MODELER, SubModelUnknownVariable, name(), modelType(), variable->getName());
-      }
     }
+    if (std::isnan(value))
+      throw DYNError(Error::MODELER, SubModelUnknownVariable, name(), modelType(), variable->getName());
   }
 
   if (negated)
@@ -499,28 +494,25 @@ SubModel::setParameterFromSet(ParameterModeler& parameter, const shared_ptr<para
         case VAR_TYPE_BOOL: {
           const bool value = parametersSet->getParameter(parName)->getBool();
           parameter.setValue<bool>(value, origin);
-          break;
+          return;
         }
         case VAR_TYPE_INT: {
           const int value = parametersSet->getParameter(parName)->getInt();
           parameter.setValue<int>(value, origin);
-          break;
+          return;
         }
         case VAR_TYPE_DOUBLE: {
           const double& value = parametersSet->getParameter(parName)->getDouble();
           parameter.setValue<double>(value, origin);
-          break;
+          return;
         }
         case VAR_TYPE_STRING: {
           const string& value = parametersSet->getParameter(parName)->getString();
           parameter.setValue<string>(value, origin);
-          break;
-        }
-        default:
-        {
-          throw DYNError(Error::MODELER, ParameterNoTypeDetected, parName);
+          return;
         }
       }
+      throw DYNError(Error::MODELER, ParameterNoTypeDetected, parName);
     }
   }
 }
@@ -1051,28 +1043,25 @@ SubModel::printLocalInitParametersValues() const {
       case VAR_TYPE_BOOL: {
         const bool value = parameter.getValue<bool>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_INT: {
         const int value = parameter.getValue<int>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_DOUBLE: {
         const double& value = parameter.getValue<double>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_STRING: {
         const string& value = parameter.getValue<string>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
-      }
-      default:
-      {
-        throw DYNError(Error::MODELER, ParameterNoTypeDetected, *it);
+        continue;
       }
     }
+    throw DYNError(Error::MODELER, ParameterNoTypeDetected, *it);
   }
 
   for (set<string>::const_iterator it = sortedParams.begin(), itEnd = sortedParams.end(); it != itEnd; ++it) {
@@ -1111,28 +1100,25 @@ SubModel::printParameterValues() const {
       case VAR_TYPE_BOOL: {
         const bool value = parameter.getValue<bool>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_INT: {
         const int value = parameter.getValue<int>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_DOUBLE: {
         const double& value = parameter.getValue<double>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_STRING: {
         const string& value = parameter.getValue<string>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
-      }
-      default:
-      {
-        throw DYNError(Error::MODELER, ParameterNoTypeDetected, *it);
+        continue;
       }
     }
+    throw DYNError(Error::MODELER, ParameterNoTypeDetected, *it);
   }
 
   for (set<string>::const_iterator it = sortedInitParams.begin(), itEnd = sortedInitParams.end(); it != itEnd; ++it) {
@@ -1163,28 +1149,25 @@ SubModel::printParameterValues() const {
       case VAR_TYPE_BOOL: {
         const bool value = parameter.getValue<bool>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_INT: {
         const int value = parameter.getValue<int>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_DOUBLE: {
         const double& value = parameter.getValue<double>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_STRING: {
         const string& value = parameter.getValue<string>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, *it, origin2Str(parameter.getOrigin()), value) << Trace::endline;
-        break;
-      }
-      default:
-      {
-        throw DYNError(Error::MODELER, ParameterNoTypeDetected, *it);
+        continue;
       }
     }
+    throw DYNError(Error::MODELER, ParameterNoTypeDetected, *it);
   }
 
   for (set<string>::const_iterator it = sortedParams.begin(), itEnd = sortedParams.end(); it != itEnd; ++it) {

--- a/dynawo/sources/Modeler/DataInterface/DYNComponentInterface.hpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNComponentInterface.hpp
@@ -37,16 +37,12 @@ T ComponentInterface::getStaticParameterValue(const std::string& name) const {
       switch (type) {
         case StaticParameter::INT:
           return static_cast<T>(iter->second.getValue<int>());
-          break;
         case StaticParameter::DOUBLE:
           return static_cast<T>(iter->second.getValue<double>());
-          break;
         case StaticParameter::BOOL:
           return static_cast<T>(iter->second.getValue<bool>());
-          break;
-        default:
-          throw DYNError(Error::MODELER, StaticParameterWrongType, name);
       }
+      throw DYNError(Error::MODELER, StaticParameterWrongType, name);
     }
   } else {
     throw DYNError(Error::MODELER, UnknownStaticParameter, name, getID());

--- a/dynawo/sources/Modeler/DataInterface/DYNConverterInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNConverterInterface.h
@@ -129,19 +129,14 @@ class ConverterInterface : public ComponentInterface {
       case ComponentInterface::SVC:
       case ComponentInterface::HVDC_LINE:
       case ComponentInterface::UNKNOWN:
-      case ComponentInterface::VSC_CONVERTER: {
+      case ComponentInterface::VSC_CONVERTER:
         return VSC_CONVERTER;
-        break;
-      }
-      case ComponentInterface::LCC_CONVERTER: {
+      case ComponentInterface::LCC_CONVERTER:
         return LCC_CONVERTER;
-        break;
-      }
       case ComponentInterface::COMPONENT_TYPE_COUNT:
         throw DYNError(Error::MODELER, ConverterWrongType, getID());
-      default:
-        throw DYNError(Error::MODELER, ConverterWrongType, getID());
     }
+    throw DYNError(Error::MODELER, ConverterWrongType, getID());
   }
 };  ///< common interface class for converters
 

--- a/dynawo/sources/Modeler/DataInterface/DYNCurrentLimits.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNCurrentLimits.h
@@ -34,6 +34,22 @@ typedef enum {
 } CurrentLimitSide;
 
 /**
+ * @brief check if a current limit side is valid
+ * @param side current limit side to check
+ * @return whether current limit side is valid
+ */
+static inline bool isCurrentLimitSideValid(CurrentLimitSide side) {
+  switch (side) {
+    case CURRENT_LIMIT_SIDE_1:
+    case CURRENT_LIMIT_SIDE_2:
+    case CURRENT_LIMIT_SIDE_3:
+      // all correct values
+      return true;
+  }
+  return false;
+}
+
+/**
  * @brief Temporary limit
  */
 struct TemporaryLimit {

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNHvdcLineInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNHvdcLineInterfaceIIDM.cpp
@@ -232,9 +232,8 @@ HvdcLineInterfaceIIDM::getConverterMode() const {
       return HvdcLineInterface::RECTIFIER_INVERTER;
     case IIDM::HvdcLine::mode_InverterRectifier:
       return HvdcLineInterface::INVERTER_RECTIFIER;
-    default:
-      throw DYNError(Error::MODELER, ConvertersModeError, getID());
   }
+  throw DYNError(Error::MODELER, ConvertersModeError, getID());
 }
 
 string

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNStaticVarCompensatorInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNStaticVarCompensatorInterfaceIIDM.cpp
@@ -288,9 +288,8 @@ StaticVarCompensatorInterface::RegulationMode_t StaticVarCompensatorInterfaceIID
       return StaticVarCompensatorInterface::RUNNING_Q;
     case IIDM::StaticVarCompensator::regulation_off:
       return StaticVarCompensatorInterface::OFF;
-    default:
-      return StaticVarCompensatorInterface::OFF;
   }
+  return StaticVarCompensatorInterface::OFF;
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNLineInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNLineInterfaceIIDM.cpp
@@ -314,22 +314,12 @@ LineInterfaceIIDM::getActiveSeason() const {
 
 boost::optional<double>
 LineInterfaceIIDM::getCurrentLimitPermanent(const std::string& season, CurrentLimitSide side) const {
-  if (!currentLimitsPerSeasonExtension_) {
-    return boost::none;
-  }
-  switch (side) {
-    case CURRENT_LIMIT_SIDE_1:
-    case CURRENT_LIMIT_SIDE_2:
-    case CURRENT_LIMIT_SIDE_3:
-      // all correct values
-      break;
-    default:
-      return boost::none;
-  }
-  const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
-  auto found = map.find(season);
-  if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
-    return found->second.currentLimits.at(side)->permanentLimit;
+  if (currentLimitsPerSeasonExtension_ && isCurrentLimitSideValid(side)) {
+    const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
+    auto found = map.find(season);
+    if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
+      return found->second.currentLimits.at(side)->permanentLimit;
+    }
   }
 
   return boost::none;
@@ -337,22 +327,12 @@ LineInterfaceIIDM::getCurrentLimitPermanent(const std::string& season, CurrentLi
 
 boost::optional<unsigned int>
 LineInterfaceIIDM::getCurrentLimitNbTemporary(const std::string& season, CurrentLimitSide side) const {
-  if (!currentLimitsPerSeasonExtension_) {
-    return boost::none;
-  }
-  switch (side) {
-    case CURRENT_LIMIT_SIDE_1:
-    case CURRENT_LIMIT_SIDE_2:
-    case CURRENT_LIMIT_SIDE_3:
-      // all correct values
-      break;
-    default:
-      return boost::none;
-  }
-  const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
-  auto found = map.find(season);
-  if (found != map.end()&& found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
-    return static_cast<unsigned int>(found->second.currentLimits.at(side)->temporaryLimits.size());
+  if (currentLimitsPerSeasonExtension_ && isCurrentLimitSideValid(side)) {
+    const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
+    auto found = map.find(season);
+    if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
+      return static_cast<unsigned int>(found->second.currentLimits.at(side)->temporaryLimits.size());
+    }
   }
 
   return boost::none;
@@ -360,24 +340,14 @@ LineInterfaceIIDM::getCurrentLimitNbTemporary(const std::string& season, Current
 
 boost::optional<std::string>
 LineInterfaceIIDM::getCurrentLimitTemporaryName(const std::string& season, CurrentLimitSide side, unsigned int indexTemporary) const {
-  if (!currentLimitsPerSeasonExtension_) {
-    return boost::none;
-  }
-  switch (side) {
-    case CURRENT_LIMIT_SIDE_1:
-    case CURRENT_LIMIT_SIDE_2:
-    case CURRENT_LIMIT_SIDE_3:
-      // all correct values
-      break;
-    default:
-      return boost::none;
-  }
-  const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
-  auto found = map.find(season);
-  if (found != map.end()&& found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
-    auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
-    if (indexTemporary < size) {
-      return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).name;
+  if (currentLimitsPerSeasonExtension_ && isCurrentLimitSideValid(side)) {
+    const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
+    auto found = map.find(season);
+    if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
+      auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
+      if (indexTemporary < size) {
+        return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).name;
+      }
     }
   }
 
@@ -386,24 +356,14 @@ LineInterfaceIIDM::getCurrentLimitTemporaryName(const std::string& season, Curre
 
 boost::optional<unsigned long>
 LineInterfaceIIDM::getCurrentLimitTemporaryAcceptableDuration(const std::string& season, CurrentLimitSide side, unsigned int indexTemporary) const {
-  if (!currentLimitsPerSeasonExtension_) {
-    return boost::none;
-  }
-  switch (side) {
-    case CURRENT_LIMIT_SIDE_1:
-    case CURRENT_LIMIT_SIDE_2:
-    case CURRENT_LIMIT_SIDE_3:
-      // all correct values
-      break;
-    default:
-      return boost::none;
-  }
-  const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
-  auto found = map.find(season);
-  if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
-    auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
-    if (indexTemporary < size) {
-      return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).acceptableDuration;
+  if (currentLimitsPerSeasonExtension_ && isCurrentLimitSideValid(side)) {
+    const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
+    auto found = map.find(season);
+    if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
+      auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
+      if (indexTemporary < size) {
+        return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).acceptableDuration;
+      }
     }
   }
 
@@ -412,24 +372,14 @@ LineInterfaceIIDM::getCurrentLimitTemporaryAcceptableDuration(const std::string&
 
 boost::optional<double>
 LineInterfaceIIDM::getCurrentLimitTemporaryValue(const std::string& season, CurrentLimitSide side, unsigned int indexTemporary) const {
-  if (!currentLimitsPerSeasonExtension_) {
-    return boost::none;
-  }
-  switch (side) {
-    case CURRENT_LIMIT_SIDE_1:
-    case CURRENT_LIMIT_SIDE_2:
-    case CURRENT_LIMIT_SIDE_3:
-      // all correct values
-      break;
-    default:
-      return boost::none;
-  }
-  const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
-  auto found = map.find(season);
-  if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
-    auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
-    if (indexTemporary < size) {
-      return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).value;
+  if (currentLimitsPerSeasonExtension_ && isCurrentLimitSideValid(side)) {
+    const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
+    auto found = map.find(season);
+    if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
+      auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
+      if (indexTemporary < size) {
+        return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).value;
+      }
     }
   }
 
@@ -438,24 +388,14 @@ LineInterfaceIIDM::getCurrentLimitTemporaryValue(const std::string& season, Curr
 
 boost::optional<bool>
 LineInterfaceIIDM::getCurrentLimitTemporaryFictitious(const std::string& season, CurrentLimitSide side, unsigned int indexTemporary) const {
-  if (!currentLimitsPerSeasonExtension_) {
-    return boost::none;
-  }
-  switch (side) {
-    case CURRENT_LIMIT_SIDE_1:
-    case CURRENT_LIMIT_SIDE_2:
-    case CURRENT_LIMIT_SIDE_3:
-      // all correct values
-      break;
-    default:
-      return boost::none;
-  }
-  const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
-  auto found = map.find(season);
-  if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
-    auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
-    if (indexTemporary < size) {
-      return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).fictitious;
+  if (currentLimitsPerSeasonExtension_ && isCurrentLimitSideValid(side)) {
+    const auto& map = currentLimitsPerSeasonExtension_->getCurrentLimits();
+    auto found = map.find(season);
+    if (found != map.end() && found->second.currentLimits.count(side) > 0 && found->second.currentLimits.at(side)) {
+      auto size = found->second.currentLimits.at(side)->temporaryLimits.size();
+      if (indexTemporary < size) {
+        return found->second.currentLimits.at(side)->temporaryLimits.at(indexTemporary).fictitious;
+      }
     }
   }
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDM.cpp
@@ -276,9 +276,8 @@ StaticVarCompensatorInterface::RegulationMode_t StaticVarCompensatorInterfaceIID
       return StaticVarCompensatorInterface::RUNNING_Q;
     case powsybl::iidm::StaticVarCompensator::RegulationMode::OFF:
       return StaticVarCompensatorInterface::OFF;
-    default:
-      return StaticVarCompensatorInterface::OFF;
   }
+  return StaticVarCompensatorInterface::OFF;
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
@@ -124,27 +124,20 @@ ModelManager::createParametersValueSet(const boost::unordered_map<string, Parame
 
     if (parameter.hasValue()) {
       switch (parameter.getValueType()) {
-        case VAR_TYPE_DOUBLE: {
+        case VAR_TYPE_DOUBLE:
           parametersSet->createParameter(parameterName, parameter.getValue<double>());
-          break;
-        }
-        case VAR_TYPE_INT: {
+          continue;
+        case VAR_TYPE_INT:
           parametersSet->createParameter(parameterName, parameter.getValue<int>());
-          break;
-        }
-        case VAR_TYPE_BOOL: {
+          continue;
+        case VAR_TYPE_BOOL:
           parametersSet->createParameter(parameterName, parameter.getValue<bool>());
-          break;
-        }
-        case VAR_TYPE_STRING: {
+          continue;
+        case VAR_TYPE_STRING:
           parametersSet->createParameter(parameterName, parameter.getValue<string>());
-          break;
-        }
-        default:
-        {
-          throw DYNError(Error::MODELER, ParameterBadType, name());
-        }
+          continue;
       }
+      throw DYNError(Error::MODELER, ParameterBadType, name());
     }
   }
 }

--- a/dynawo/sources/Modeler/util/DYNDumpModel.cpp
+++ b/dynawo/sources/Modeler/util/DYNDumpModel.cpp
@@ -62,28 +62,28 @@ fillParameterDescription(const DYN::ParameterModeler& parameter, const std::stri
   attributes.add("readOnly", parameter.isFullyInternal());
 
   if ((parameter.isUnitary()) && (parameter.hasValue())) {
+    bool badType = true;
     switch (parameter.getValueType()) {
-      case DYN::VAR_TYPE_DOUBLE: {
+      case DYN::VAR_TYPE_DOUBLE:
         attributes.add("defaultValue", parameter.getValue<double>());
+        badType = false;
         break;
-      }
-      case DYN::VAR_TYPE_INT: {
+      case DYN::VAR_TYPE_INT:
         attributes.add("defaultValue", parameter.getValue<int>());
+        badType = false;
         break;
-      }
-      case DYN::VAR_TYPE_BOOL: {
+      case DYN::VAR_TYPE_BOOL:
         attributes.add("defaultValue", parameter.getValue<bool>());
+        badType = false;
         break;
-      }
-      case DYN::VAR_TYPE_STRING: {
+      case DYN::VAR_TYPE_STRING:
         attributes.add("defaultValue", parameter.getValue<std::string>());
+        badType = false;
         break;
-      }
-      default:
-      {
-        cout << "bad parameter for model " << modelName << " : " << parameter.getName() << " has a bad type" << endl;
-        return 1;
-      }
+    }
+    if (badType) {
+      cout << "bad parameter for model " << modelName << " : " << parameter.getName() << " has a bad type" << endl;
+      return 1;
     }
   }
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNDerivative.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNDerivative.cpp
@@ -46,13 +46,12 @@ BusDerivatives::addDerivative(typeDerivative_t type, const int& numVar, const do
   switch (type) {
     case IR_DERIVATIVE:
       irDerivatives_.addValue(numVar, value);
-      break;
+      return;
     case II_DERIVATIVE:
       iiDerivatives_.addValue(numVar, value);
-      break;
-    default:
-      throw DYNError(Error::MODELER, InvalidDerivativeType, type);
+      return;
   }
+  throw DYNError(Error::MODELER, InvalidDerivativeType, type);
 }
 
 const std::map<int, double>&

--- a/dynawo/sources/Simulation/DYNSimulationLauncher.cpp
+++ b/dynawo/sources/Simulation/DYNSimulationLauncher.cpp
@@ -45,7 +45,7 @@ using DYN::SimulationContext;
 // If logging is disabled, Trace::info has no effect so we also print on standard output to have basic information
 template<class T>
 static void print(const T& output, DYN::SeverityLevel level = DYN::INFO) {
-  DYN::TraceStream ss;
+  DYN::TraceStream ss;  // level is INFO by default
   switch (level) {
     case DYN::DEBUG:
       ss = Trace::debug();
@@ -59,9 +59,6 @@ static void print(const T& output, DYN::SeverityLevel level = DYN::INFO) {
     case DYN::ERROR:
       ss = Trace::error();
       break;
-    default:
-      // impossible case by definition of the enum
-      return;
   }
   ss << output << Trace::endline;
   if (!Trace::isLoggingEnabled()) {

--- a/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINAlgRestoration.cpp
+++ b/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINAlgRestoration.cpp
@@ -46,9 +46,8 @@ SolverKINAlgRestoration::stringFromMode(modeKin_t mode) {
       return "algebraic";
     case KIN_DERIVATIVES:
       return "derivatives";
-    default:
-      throw DYNError(Error::GENERAL, InvalidAlgebraicMode, static_cast<int>(mode));
   }
+  throw DYNError(Error::GENERAL, InvalidAlgebraicMode, static_cast<int>(mode));
 }
 
 SolverKINAlgRestoration::SolverKINAlgRestoration() :

--- a/dynawo/sources/Solvers/Common/DYNSolverImpl.cpp
+++ b/dynawo/sources/Solvers/Common/DYNSolverImpl.cpp
@@ -184,28 +184,25 @@ Solver::Impl::printParameterValues() const {
       case VAR_TYPE_BOOL: {
         const bool value = parameter.getValue<bool>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, it->first, origin2Str(PAR), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_INT: {
         const int value = parameter.getValue<int>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, it->first, origin2Str(PAR), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_DOUBLE: {
         const double& value = parameter.getValue<double>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, it->first, origin2Str(PAR), value) << Trace::endline;
-        break;
+        continue;
       }
       case VAR_TYPE_STRING: {
         const string& value = parameter.getValue<string>();
         Trace::debug(Trace::parameters()) << DYNLog(ParamValueInOrigin, it->first, origin2Str(PAR), value) << Trace::endline;
-        break;
-      }
-      default:
-      {
-        throw DYNError(Error::MODELER, ParameterNoTypeDetected, it->first);
+        continue;
       }
     }
+    throw DYNError(Error::MODELER, ParameterNoTypeDetected, it->first);
   }
 }
 
@@ -394,28 +391,25 @@ Solver::Impl::setParameterFromSet(const string& parName, const boost::shared_ptr
         case VAR_TYPE_BOOL: {
           const bool value = parametersSet->getParameter(parName)->getBool();
           setParameterValue(parameter, value);
-          break;
+          return;
         }
         case VAR_TYPE_INT: {
           const int value = parametersSet->getParameter(parName)->getInt();
           setParameterValue(parameter, value);
-          break;
+          return;
         }
         case VAR_TYPE_DOUBLE: {
           const double& value = parametersSet->getParameter(parName)->getDouble();
           setParameterValue(parameter, value);
-          break;
+          return;
         }
         case VAR_TYPE_STRING: {
           const string& value = parametersSet->getParameter(parName)->getString();
           setParameterValue(parameter, value);
-          break;
-        }
-        default:
-        {
-          throw DYNError(Error::GENERAL, ParameterNoTypeDetected, parName);
+          return;
         }
       }
+      throw DYNError(Error::GENERAL, ParameterNoTypeDetected, parName);
     } else if (parameter.isMandatory()) {
       throw DYNError(Error::GENERAL, SolverMissingParam, parameter.getName(), parametersSet->getId(), parametersSet->getFilePath());
     }

--- a/dynawo/sources/Solvers/util/DYNDumpSolver.cpp
+++ b/dynawo/sources/Solvers/util/DYNDumpSolver.cpp
@@ -65,28 +65,28 @@ fillParameterDescription(const DYN::ParameterSolver& parameter, const std::strin
   attributes.add("cardinality", 1);  // default value 1 for solver parameters
 
   if (parameter.hasValue()) {
+    bool badType = true;
     switch (parameter.getValueType()) {
-      case DYN::VAR_TYPE_DOUBLE: {
+      case DYN::VAR_TYPE_DOUBLE:
         attributes.add("defaultValue", parameter.getValue<double>());
+        badType = false;
         break;
-      }
-      case DYN::VAR_TYPE_INT: {
+      case DYN::VAR_TYPE_INT:
         attributes.add("defaultValue", parameter.getValue<int>());
+        badType = false;
         break;
-      }
-      case DYN::VAR_TYPE_BOOL: {
+      case DYN::VAR_TYPE_BOOL:
         attributes.add("defaultValue", parameter.getValue<bool>());
+        badType = false;
         break;
-      }
-      case DYN::VAR_TYPE_STRING: {
+      case DYN::VAR_TYPE_STRING:
         attributes.add("defaultValue", parameter.getValue<std::string>());
+        badType = false;
         break;
-      }
-      default:
-      {
-        cout << "bad parameter for model " << solverName << " : " << parameter.getName() << " has a bad type" << endl;
-        return 1;
-      }
+    }
+    if (badType) {
+      cout << "bad parameter for model " << solverName << " : " << parameter.getName() << " has a bad type" << endl;
+      return 1;
     }
   }
 


### PR DESCRIPTION
Removing -Wno-covered-switch-default causes errors !

`error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]`

See #125 