### PR TITLE
#125 fix clang compilation -Wdocumentation

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -115,7 +115,7 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Weverything")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-conditional-uninitialized")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-covered-switch-default")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-documentation")
+  # error: unknown command tag name (@copydoc @n) [-Werror,-Wdocumentation-unknown-command]
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-documentation-unknown-command")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-double-promotion")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")

--- a/dynawo/sources/API/CRV/CRVCurve.h
+++ b/dynawo/sources/API/CRV/CRVCurve.h
@@ -151,16 +151,16 @@ class Curve {
     isParameterCurve_ = isParameterCurve;
   }
   /**
-   * @brief Get the curve type (calculated variable, continous, discrete)
-   * @return the curve type (calculated variable, continous, discrete)
+   * @brief Get the curve type (calculated variable, continuous, discrete)
+   * @return the curve type (calculated variable, continuous, discrete)
    */
   CurveType_t getCurveType() const {
     return curveType_;
   }
 
   /**
-   * @brief Set the curve type (calculated variable, continous, discrete)
-   * @param curveType : curve type (calculated variable, continous, discrete)
+   * @brief Set the curve type (calculated variable, continuous, discrete)
+   * @param curveType : curve type (calculated variable, continuous, discrete)
    */
   void setCurveType(CurveType_t curveType) {
     curveType_ = curveType;
@@ -168,8 +168,8 @@ class Curve {
 
   /**
    * @brief update parameter curve value
-   * @param parameterName
-   * @param parameterValue
+   * @param parameterName name of parameter
+   * @param parameterValue value of parameter
    */
   void updateParameterCurveValue(std::string parameterName, double parameterValue);
 

--- a/dynawo/sources/API/DYD/DYDDynamicModelsCollection.h
+++ b/dynawo/sources/API/DYD/DYDDynamicModelsCollection.h
@@ -103,7 +103,7 @@ class DynamicModelsCollection {
   dynamicModel_const_iterator cendModel() const;
 
   /**
-   * @brief connector iterator ;beginning of connector
+   * @brief connector iterator : beginning of connector
    * @return beginning of connector
    */
   connector_const_iterator cbeginConnector() const;
@@ -219,7 +219,7 @@ class DynamicModelsCollection {
 
   /**
    * @brief find a macroStaticReference thanks to its id
-   * @param id: id of the macroStaticReference to be found
+   * @param id id of the macroStaticReference to be found
    * @return the macroStaticReference associated to the id
    */
   const boost::shared_ptr<MacroStaticReference>& findMacroStaticReference(const std::string& id);

--- a/dynawo/sources/API/DYD/DYDMacroStaticRef.h
+++ b/dynawo/sources/API/DYD/DYDMacroStaticRef.h
@@ -36,7 +36,7 @@ class MacroStaticRef {
    *
    * MacroStaticRef::Impl constructor.
    *
-   * @param[in] id: id of the macroStaticRef
+   * @param[in] id id of the macroStaticRef
    */
   explicit MacroStaticRef(const std::string& id);
 

--- a/dynawo/sources/API/DYD/DYDMacroStaticReference.h
+++ b/dynawo/sources/API/DYD/DYDMacroStaticReference.h
@@ -39,7 +39,7 @@ class MacroStaticReference {
   /**
    * @brief MacroStaticReference constructor
    *
-   * @param[in] id: id of the macroStaticReference
+   * @param[in] id id of the macroStaticReference
    */
   explicit MacroStaticReference(const std::string& id);
 
@@ -53,8 +53,8 @@ class MacroStaticReference {
   /**
    * @brief staticRef adder
    *
-   * @param[in] var: dynamic variable
-   * @param[in] staticVar: static variable
+   * @param[in] var dynamic variable
+   * @param[in] staticVar static variable
    * @throws Error::API exception if the staticRef already exists
    */
   void addStaticRef(const std::string& var, const std::string& staticVar);
@@ -85,7 +85,7 @@ class MacroStaticReference {
 
   /**
    * @brief find a staticRef thanks to its key (var_staticVar)
-   * @param key: key of the staticRef to be found
+   * @param key key of the staticRef to be found
    * @throws Error::API exception if staticRef doesn't exist
    * @return the staticRef associated to the key
    */

--- a/dynawo/sources/API/DYD/DYDModel.h
+++ b/dynawo/sources/API/DYD/DYDModel.h
@@ -82,7 +82,7 @@ class Model {
 
   /**
    * @brief macroStaticRef adder
-   * @param macroStaticRef: macroStaticRef to add to the model
+   * @param macroStaticRef macroStaticRef to add to the model
    * @throws Error::API exception if macroStaticRef already exists
    */
   void addMacroStaticRef(const boost::shared_ptr<MacroStaticRef>& macroStaticRef);
@@ -137,7 +137,7 @@ class Model {
 
   /**
    * @brief find a staticRef thanks to its key (var_staticVar)
-   * @param key: key of the staticRef to be found
+   * @param key key of the staticRef to be found
    * @throws Error::API exception if staticRef doesn't exist
    * @return the staticRef associated to the key
    */
@@ -145,7 +145,7 @@ class Model {
 
   /**
    * @brief find a macroStaticRef thanks to its id
-   * @param id: id of the macroStaticRef to be found
+   * @param id id of the macroStaticRef to be found
    * @throws Error::API exception if macroStaticRef doesn't exist
    * @return the macroStaticRef associated to the id
    */

--- a/dynawo/sources/API/DYD/DYDWhiteBoxModelCommon.h
+++ b/dynawo/sources/API/DYD/DYDWhiteBoxModelCommon.h
@@ -30,7 +30,7 @@ namespace dynamicdata {
  * @param[in] model2 Second model to connect
  * @param[in] var2 Second model var to connect
  * @param[in] id name of the parent model
- * @param[in] map of unitDynamicModel Modelica models contained in the parent model
+ * @param[in] unitDynamicModelsMap Modelica models contained in the parent model
  *
  * @returns connection id
  */
@@ -43,7 +43,7 @@ std::string getConnectionId(const std::string& model1, const std::string& var1, 
  * @param[in] model1 First model to connect
  * @param[in] model2 Second model to connect
  * @param[in] id name of the parent model
- * @param[in] map of unitDynamicModel Modelica models contained in the parent model
+ * @param[in] unitDynamicModelsMap Modelica models contained in the parent model
  *
  * @returns connection id
  */

--- a/dynawo/sources/API/DYD/DYDXmlExporter.h
+++ b/dynawo/sources/API/DYD/DYDXmlExporter.h
@@ -132,7 +132,7 @@ class XmlExporter : public Exporter {
   /**
    * @brief write given macroStaticRef in given formatter
    *
-   * @param[in] macroStaticRef: MacroStaticRef object to write
+   * @param[in] macroStaticRef MacroStaticRef object to write
    * @param[out] formatter Output formatter
    */
   void writeMacroStaticRef(const boost::shared_ptr<MacroStaticRef>& macroStaticRef, xml::sax::formatter::Formatter& formatter) const;
@@ -140,7 +140,7 @@ class XmlExporter : public Exporter {
   /**
    * @brief write given macroStaticReference in given formatter
    *
-   * @param[in] macroStaticReference: MacroStaticReference object to write
+   * @param[in] macroStaticReference MacroStaticReference object to write
    * @param[out] formatter Output formatter
    */
   void writeMacroStaticReference(const boost::shared_ptr<MacroStaticReference>& macroStaticReference, xml::sax::formatter::Formatter& formatter) const;

--- a/dynawo/sources/API/FS/FSFinalStateCollectionFactory.h
+++ b/dynawo/sources/API/FS/FSFinalStateCollectionFactory.h
@@ -31,9 +31,9 @@ namespace finalState {
 class FinalStateCollectionFactory {
  public:
   /**
-   * @brief create a new instance of final stat collection
+   * @brief create a new instance of final state collection
    *
-   * @param id
+   * @param id id of the new instance
    * @return Final state collection
    */
   static boost::shared_ptr<FinalStateCollection> newInstance(const std::string& id);

--- a/dynawo/sources/API/FS/FSModelFactory.h
+++ b/dynawo/sources/API/FS/FSModelFactory.h
@@ -38,7 +38,7 @@ class ModelFactory {
   /**
    * @brief create a new Model instance
    *
-   * @param[in] id: model's id
+   * @param[in] id model's id
    * @return shared pointer to a new @p Model
    */
   static boost::shared_ptr<FinalStateModel> newModel(const std::string& id);

--- a/dynawo/sources/API/FS/FSVariableFactory.h
+++ b/dynawo/sources/API/FS/FSVariableFactory.h
@@ -37,7 +37,7 @@ class VariableFactory {
   /**
    * @brief create a new Variable instance
    *
-   * @param[in] id: variable's id
+   * @param[in] id variable's id
    * @return shared pointer to a new @p Variable
    */
   static boost::shared_ptr<Variable> newVariable(const std::string& id);

--- a/dynawo/sources/API/JOB/JOBAppenderEntry.h
+++ b/dynawo/sources/API/JOB/JOBAppenderEntry.h
@@ -73,19 +73,19 @@ class AppenderEntry {
 
   /**
    * @brief Tag attribute setter
-   * @param tag: Tag filtered by the appender
+   * @param tag Tag filtered by the appender
    */
   void setTag(const std::string& tag);
 
   /**
    * @brief File path attribute setter
-   * @param filePath: Output file path of the appender
+   * @param filePath Output file path of the appender
    */
   void setFilePath(const std::string& filePath);
 
   /**
    * @brief Level filter attribute setter
-   * @param lvlFilter: Minimum severity level exported by the appender
+   * @param lvlFilter Minimum severity level exported by the appender
    */
   void setLvlFilter(const std::string& lvlFilter);
 

--- a/dynawo/sources/API/JOB/JOBConstraintsEntry.h
+++ b/dynawo/sources/API/JOB/JOBConstraintsEntry.h
@@ -32,13 +32,13 @@ class ConstraintsEntry {
  public:
   /**
    * @brief Output file attribute setter
-   * @param outputFile: Output file for constraints
+   * @param outputFile Output file for constraints
    */
   void setOutputFile(const std::string& outputFile);
 
   /**
    * @brief Export Mode attribute setter
-   * @param exportMode: Export mode for constraints
+   * @param exportMode Export mode for constraints
    */
   void setExportMode(const std::string& exportMode);
 

--- a/dynawo/sources/API/JOB/JOBCurvesEntry.h
+++ b/dynawo/sources/API/JOB/JOBCurvesEntry.h
@@ -25,7 +25,7 @@
 namespace job {
 
 /**
- * @brief Curves entry
+ * @class CurvesEntry
  * @brief Curves entries container class
  */
 class CurvesEntry {
@@ -50,19 +50,19 @@ class CurvesEntry {
 
   /**
    * @brief Input file attribute setter
-   * @param inputFile: Input file for curves
+   * @param inputFile Input file for curves
    */
   void setInputFile(const std::string& inputFile);
 
   /**
    * @brief Output file attribute setter
-   * @param outputFile: Output file for curves
+   * @param outputFile Output file for curves
    */
   void setOutputFile(const std::string& outputFile);
 
   /**
    * @brief Export Mode attribute setter
-   * @param exportMode: Export mode for curves
+   * @param exportMode Export mode for curves
    */
   void setExportMode(const std::string& exportMode);
 

--- a/dynawo/sources/API/JOB/JOBFinalStateEntry.h
+++ b/dynawo/sources/API/JOB/JOBFinalStateEntry.h
@@ -25,7 +25,7 @@
 namespace job {
 
 /**
- * @brief FinalState entry
+ * @class FinalStateEntry
  * @brief FinalState entries container class
  */
 class FinalStateEntry {
@@ -61,25 +61,25 @@ class FinalStateEntry {
 
   /**
    * @brief whether to export IIDM output file setter
-   * @param exportIIDMFile: whether to export IIDM output file
+   * @param exportIIDMFile whether to export IIDM output file
    */
   void setExportIIDMFile(const bool exportIIDMFile);
 
   /**
    * @brief whether to export output state setter
-   * @param exportDumpFile: whether to export output state
+   * @param exportDumpFile whether to export output state
    */
   void setExportDumpFile(const bool exportDumpFile);
 
   /**
    * @brief Output file attribute setter
-   * @param outputIIDMFile: Output file for final state
+   * @param outputIIDMFile Output file for final state
    */
   void setOutputIIDMFile(const std::string& outputIIDMFile);
 
   /**
    * @brief Dump file attribute setter
-   * @param dumpFile: Dump file for final state
+   * @param dumpFile Dump file for final state
    */
   void setDumpFile(const std::string& dumpFile);
 

--- a/dynawo/sources/API/JOB/JOBInitValuesEntry.h
+++ b/dynawo/sources/API/JOB/JOBInitValuesEntry.h
@@ -23,7 +23,7 @@
 namespace job {
 
 /**
- * @brief InitValuesEntry
+ * @class InitValuesEntry
  * @brief Init values entries container class
  */
 class InitValuesEntry {

--- a/dynawo/sources/API/JOB/JOBOutputsEntry.h
+++ b/dynawo/sources/API/JOB/JOBOutputsEntry.h
@@ -73,7 +73,7 @@ class OutputsEntry {
 
   /**
    * @brief Init Values entry setter
-   * @param initValuesEntry: initValues entry container for the job
+   * @param initValuesEntry : initValues entry container for the job
    */
   void setInitValuesEntry(const boost::shared_ptr<InitValuesEntry>& initValuesEntry);
 

--- a/dynawo/sources/API/JOB/JOBTimelineEntry.h
+++ b/dynawo/sources/API/JOB/JOBTimelineEntry.h
@@ -37,13 +37,13 @@ class TimelineEntry {
 
   /**
    * @brief Output file attribute setter
-   * @param outputFile: Output file for timeline
+   * @param outputFile Output file for timeline
    */
   void setOutputFile(const std::string& outputFile);
 
   /**
    * @brief Export Mode attribute setter
-   * @param exportMode: Export mode for timeline
+   * @param exportMode Export mode for timeline
    */
   void setExportMode(const std::string& exportMode);
 
@@ -61,7 +61,7 @@ class TimelineEntry {
 
   /**
    * @brief whether to export time setter
-   * @param exportWithTime: whether to export time when exporting timeline
+   * @param exportWithTime whether to export time when exporting timeline
    */
   void setExportWithTime(const bool exportWithTime);
 

--- a/dynawo/sources/API/PAR/PARMacroParSet.h
+++ b/dynawo/sources/API/PAR/PARMacroParSet.h
@@ -31,7 +31,7 @@ class MacroParSet {
  public:
   /**
    * @brief MacroParSet constructor
-   * @param[in] id: id of the macroParSet
+   * @param[in] id id of the macroParSet
    */
   explicit MacroParSet(const std::string& id);
 

--- a/dynawo/sources/API/PAR/PARMacroParameterSet.h
+++ b/dynawo/sources/API/PAR/PARMacroParameterSet.h
@@ -37,7 +37,7 @@ class MacroParameterSet {
  public:
   /**
    * @brief MacroParameterSet constructor
-   * @param[in] id: id of the macroParameterSet
+   * @param[in] id id of the macroParameterSet
    */
   explicit MacroParameterSet(const std::string& id);
 

--- a/dynawo/sources/API/PAR/PARParameter.h
+++ b/dynawo/sources/API/PAR/PARParameter.h
@@ -138,7 +138,7 @@ class Parameter {
   /**
    * @brief Set "used" boolean
    *
-   * @param used: boolean used to set "used" value
+   * @param used boolean used to set "used" value
    */
   void setUsed(bool used);
 

--- a/dynawo/sources/API/PAR/PARParameterFactory.h
+++ b/dynawo/sources/API/PAR/PARParameterFactory.h
@@ -37,8 +37,8 @@ class ParameterFactory {
   /**
    * @brief Create new Parameter instance
    *
-   * @param[in] name: id of the parameter
-   * @param[in] boolValue: value of the parameter
+   * @param[in] name id of the parameter
+   * @param[in] boolValue value of the parameter
    *
    * @returns Shared pointer to a new @p Parameter
    */
@@ -47,8 +47,8 @@ class ParameterFactory {
   /**
    * @brief Create new Parameter instance
    *
-   * @param[in] name: id of the parameter
-   * @param[in] intValue: value of the parameter
+   * @param[in] name id of the parameter
+   * @param[in] intValue value of the parameter
    *
    * @returns Shared pointer to a new @p Parameter
    */
@@ -57,8 +57,8 @@ class ParameterFactory {
   /**
    * @brief Create new Parameter instance
    *
-   * @param[in] name: id of the parameter
-   * @param[in] doubleValue: value of the parameter
+   * @param[in] name id of the parameter
+   * @param[in] doubleValue value of the parameter
    *
    * @returns Shared pointer to a new @p Parameter
    */
@@ -67,8 +67,8 @@ class ParameterFactory {
   /**
    * @brief Create new Parameter instance
    *
-   * @param[in] name: id of the parameter
-   * @param[in] stringValue: value of the parameter
+   * @param[in] name id of the parameter
+   * @param[in] stringValue value of the parameter
    *
    * @returns Shared pointer to a new @p Parameter
    */

--- a/dynawo/sources/API/PAR/PARReference.h
+++ b/dynawo/sources/API/PAR/PARReference.h
@@ -48,7 +48,7 @@ class Reference {
   /**
    * @brief Constructor of reference
    *
-   * @param[in] name: reference name
+   * @param[in] name reference name
    */
   explicit Reference(const std::string& name);
 

--- a/dynawo/sources/API/PAR/PARReferenceFactory.h
+++ b/dynawo/sources/API/PAR/PARReferenceFactory.h
@@ -38,7 +38,7 @@ class ReferenceFactory {
   /**
    * @brief Create new Reference instance
    *
-   * @param[in] name: reference name
+   * @param[in] name reference name
    *
    * @returns Shared pointer to a new @p Reference
    */

--- a/dynawo/sources/Common/DYNFileSystemUtils.h
+++ b/dynawo/sources/Common/DYNFileSystemUtils.h
@@ -163,8 +163,8 @@ std::string absolute(const std::string & name, const std::string & rootName = ".
  * @brief return name if name is absolute, else concatenate name and rootName
  *
  *
- * @param name   the path relative to the root path (may be a file name)
- * @param rootName  the path to the root directory
+ * @param name : the path relative to the root path (may be a file name)
+ * @param rootName : the path to the root directory
  *
  * @return the concatenated file path (if path is not absolute)
  */
@@ -220,7 +220,7 @@ void current_path(const std::string & path);
  * @param[in] path : the path for which to change the extension
  * @param[in] ext : the new extension without dot (ex: "txt")
  *
- * @return : the updated path as a string
+ * @return the updated path as a string
 
  */
 std::string replace_extension(const std::string & path, const std::string & ext);
@@ -229,7 +229,7 @@ std::string replace_extension(const std::string & path, const std::string & ext)
  * @brief Check whether a path points toward a directory
  * @param[in] path : the path to check
  *
- * @return : whether the path points toward a directory
+ * @return whether the path points toward a directory
 
  */
 bool is_directory(const std::string & path);
@@ -244,7 +244,7 @@ void create_directory(const std::string & path);
  * @brief Retrieve the file extension from a file path
  * @param[in] path : the path from which to extract the file extension
  *
- * @return : the file extension (or an empty string when no extension was found)
+ * @return the file extension (or an empty string when no extension was found)
  * Warning : extension ("file.txt.tmp") will return ".tmp"
  */
 std::string extension(const std::string & path);
@@ -252,8 +252,8 @@ std::string extension(const std::string & path);
 /**
  * @brief Check wether given extentions are found in a directory
  * @param[in] directoryToScan : directory to scan
- * @param[in] extensionList: list of extensions to search in the directory
- * @return : wether given extensions are found in directory
+ * @param[in] extensionList : list of extensions to search in the directory
+ * @return whether given extensions are found in directory
  */
 bool extensionFound(const std::string directoryToScan, const std::vector <std::string> & extensionList);
 
@@ -261,7 +261,7 @@ bool extensionFound(const std::string directoryToScan, const std::vector <std::s
  * @brief Check wether file path ends with a given extension
  * @param[in] path : the path to compare with the file extension
  * @param[in] extension : given extension to compare with the path
- * @return : wether they are equals
+ * @return whether they are equals
  * Warning : extensionEquals ("file.TXT.TMP", ".txt.tmp") will return false
  */
 bool extensionEquals(const std::string path, const std::string extension);
@@ -278,7 +278,7 @@ std::list<std::string> list_directory(const std::string & path);
  * @brief Retrieve the file name from a file path
  * @param[in] path : the path from which to extract the file name
  *
- * @return : the file name (or an empty string when it fails)
+ * @return the file name (or an empty string when it fails)
 
  */
 std::string file_name(const std::string & path);
@@ -287,7 +287,7 @@ std::string file_name(const std::string & path);
  * @brief Remove the file name from a file path
  * @param[in] path : the path from which to remove the file name
  *
- * @return : the file path without the file name
+ * @return the file path without the file name
  */
 std::string remove_file_name(const std::string & path);
 
@@ -295,7 +295,7 @@ std::string remove_file_name(const std::string & path);
  * @brief Delete all contents in a directory
  *
  *
- * @param[in] directory the directory where all contents are deleted
+ * @param[in] directory : the directory where all contents are deleted
  */
 void remove_all_in_directory(const std::string & directory);
 
@@ -324,7 +324,7 @@ std::string lastParentDirectory(const std::string childPath);
  * @brief Check whether a given path is absolute or relative
  * @param[in] path : the path to check
  *
- * @return : whether the path is absolute
+ * @return whether the path is absolute
  */
 bool isAbsolutePath(const std::string path);
 

--- a/dynawo/sources/Common/DYNParameter.h
+++ b/dynawo/sources/Common/DYNParameter.h
@@ -96,7 +96,7 @@ class ParameterCommon {
 
   /**
    * @brief index setter
-   * @param index: the index to set
+   * @param index the index to set
    */
   void setIndex(const unsigned int& index);
 

--- a/dynawo/sources/Common/DYNTrace.h
+++ b/dynawo/sources/Common/DYNTrace.h
@@ -180,7 +180,7 @@ class Trace {
 
     /**
      * @brief Tag attribute setter
-     * @param tag: Tag filtered by the appender
+     * @param tag Tag filtered by the appender
      */
     void setTag(std::string tag) {
       tag_ = tag;
@@ -188,7 +188,7 @@ class Trace {
 
     /**
      * @brief File path attribute setter
-     * @param filePath: Output file path of the appender
+     * @param filePath Output file path of the appender
      */
     void setFilePath(std::string filePath) {
       filePath_ = filePath;
@@ -196,7 +196,7 @@ class Trace {
 
     /**
      * @brief Level filter attribute setter
-     * @param lvlFilter: Minimum severity level exported by the appender
+     * @param lvlFilter Minimum severity level exported by the appender
      */
     void setLvlFilter(SeverityLevel lvlFilter) {
       lvlFilter_ = lvlFilter;
@@ -261,7 +261,7 @@ class Trace {
     bool showTimeStamp_;  ///< @b true if the timestamp of the log should be printed
     std::string timeStampFormat_;  ///< format of the timestamp information , "" if no time to print
     bool append_;  ///< Append to existing file instead of erasing
-    bool persistant_;  ///< Do not remove this appender when reseting
+    bool persistant_;  ///< Do not remove this appender when resetting
   };
 
   /**
@@ -288,7 +288,7 @@ class Trace {
 
   /**
    * @brief Add custom appenders to trace system
-   * @param[in] appenders: Appenders to add
+   * @param[in] appenders : Appenders to add
    */
   static void addAppenders(const std::vector<TraceAppender>& appenders);
 
@@ -403,7 +403,7 @@ class Trace {
   /**
    * @brief Print end of line in trace.
    *
-   * @param os: Trace to add end of line.
+   * @param os : Trace to add end of line.
    * @return The TraceStream with the end of line added.
    */
   static TraceStream& endline(TraceStream& os);  ///< End of line function for stream-like logging
@@ -424,7 +424,7 @@ class Trace {
    *
    * This test the level of the standard output log
    *
-   * @param slv Severity level
+   * @param slv : Severity level
    * @returns whether the standard log accepts the log level
    */
   static bool standardLogExists(SeverityLevel slv) {
@@ -472,7 +472,7 @@ class Trace {
    *
    * Implementation of static function
    *
-   * @param[in] appenders: Appenders to add
+   * @param[in] appenders : Appenders to add
    */
   void addAppenders_(const std::vector<TraceAppender>& appenders);
 

--- a/dynawo/sources/Common/TestUtil.h
+++ b/dynawo/sources/Common/TestUtil.h
@@ -26,8 +26,8 @@
 /**
  * @brief operator to compare 2 files
  *
- * @param[in] file1: file 1 to compare
- * @param[in] file2: file 2 to compare
+ * @param[in] file1 first file to compare
+ * @param[in] file2 second file to compare
  * @return @b true if file1 == file2 @b false else
  */
 inline bool compareFiles(const std::string& file1, const std::string& file2) {

--- a/dynawo/sources/Modeler/Common/DYNCommonModeler.h
+++ b/dynawo/sources/Modeler/Common/DYNCommonModeler.h
@@ -32,7 +32,7 @@ namespace DYN {
    *
    * @param name : name of the element
    * @param type : type of the element
-   * @param elements: vector where the new element should be store
+   * @param elements : vector where the new element should be store
    * @param mapElement : map associating name of element and element where the new element should be store
    */
   void addElement(const std::string& name, const Element::typeElement& type, std::vector<Element> &elements, std::map<std::string, int>& mapElement);
@@ -45,8 +45,8 @@ namespace DYN {
    * @param type : type of the sub element
    * @param parentName : name of the parent model
    * @param parentType : type of the parent model
-   * @param elements: vector where the new sub element should be store
-   * @param mapElement: map associating name of element and element where the new sub element should be store
+   * @param elements : vector where the new sub element should be store
+   * @param mapElement : map associating name of element and element where the new sub element should be store
    */
   void addSubElement(const std::string& name, const std::string& elementName, const Element::typeElement& type,
       const std::string parentName, const std::string& parentType,

--- a/dynawo/sources/Modeler/Common/DYNCompiler.h
+++ b/dynawo/sources/Modeler/Common/DYNCompiler.h
@@ -61,17 +61,17 @@ class Compiler {
  public:
   /**
    * @brief Compiler constructor.
-   * @param dyd : dynamic data instance  where data of models to compile are stored
-   * @param useStandardPrecompiledModels: whether to use standard precompiled models
-   * @param precompiledModelsDirs: precompiled models directory
-   * @param precompiledModelsExtension: precompiled modesls extension
-   * @param useStandardModelicaModels: whether to use standard modelica models
+   * @param dyd dynamic data instance  where data of models to compile are stored
+   * @param useStandardPrecompiledModels whether to use standard precompiled models
+   * @param precompiledModelsDirs precompiled models directory
+   * @param precompiledModelsExtension precompiled modesls extension
+   * @param useStandardModelicaModels whether to use standard modelica models
    * @param modelicaModelsDirs modelica models directories
-   * @param modelicaModelsExtension: modelica models extension
-   * @param pathsToIgnore : paths that shouldn't be explored
-   * @param additionalHeaderFiles: list of headers that should be included in the dynamic model files
-   * @param rmModels: remove .mo model
-   * @param outputDir: output directory
+   * @param modelicaModelsExtension modelica models extension
+   * @param pathsToIgnore paths that shouldn't be explored
+   * @param additionalHeaderFiles list of headers that should be included in the dynamic model files
+   * @param rmModels remove .mo model
+   * @param outputDir output directory
    */
   Compiler(const boost::shared_ptr<DynamicData>& dyd,
           const bool useStandardPrecompiledModels,

--- a/dynawo/sources/Modeler/Common/DYNConnectInterface.h
+++ b/dynawo/sources/Modeler/Common/DYNConnectInterface.h
@@ -35,7 +35,7 @@ class ConnectInterface {  ///< Generic class for connecting two dynamic models
 
   /**
    * @brief set first model
-   * @param model
+   * @param model first model
    */
   inline void setConnectedModel1(const std::string& model) {
     connectedModel1_ = model;
@@ -51,7 +51,7 @@ class ConnectInterface {  ///< Generic class for connecting two dynamic models
 
   /**
    * @brief set second model
-   * @param model
+   * @param model second model
    */
   inline void setConnectedModel2(const std::string& model) {
     connectedModel2_ = model;

--- a/dynawo/sources/Modeler/Common/DYNDynamicData.h
+++ b/dynawo/sources/Modeler/Common/DYNDynamicData.h
@@ -76,7 +76,7 @@ class DynamicData {
 
   /**
    * @brief set network parameters
-   * @param parameters
+   * @param parameters parameters set
    */
   inline void setNetworkParameters(const boost::shared_ptr<parameters::ParametersSet>& parameters) {
     networkParameters_ = parameters;
@@ -132,7 +132,7 @@ class DynamicData {
 
   /**
    * @brief set static data
-   * @param data
+   * @param data static data
    */
   inline void setDataInterface(const boost::shared_ptr<DataInterface>& data) {
     dataInterface_ = data;

--- a/dynawo/sources/Modeler/Common/DYNElement.h
+++ b/dynawo/sources/Modeler/Common/DYNElement.h
@@ -57,9 +57,9 @@ class Element {
 
   /**
    * @brief constructor
-   * @param name
-   * @param id
-   * @param type
+   * @param name element's name
+   * @param id element's id
+   * @param type element's type
    */
   Element(const std::string& name, const std::string& id, typeElement type)
   : type_(type)

--- a/dynawo/sources/Modeler/Common/DYNModelDescription.h
+++ b/dynawo/sources/Modeler/Common/DYNModelDescription.h
@@ -46,7 +46,7 @@ class ModelDescription {
 
   /**
    * @brief default constructor.
-   * @param model
+   * @param model another model
    */
   explicit ModelDescription(const boost::shared_ptr<dynamicdata::Model>& model) :
   model_(model),
@@ -59,7 +59,7 @@ class ModelDescription {
 
   /**
    * @brief add static reference interface
-   * @param staticRefInterface
+   * @param staticRefInterface static reference interface
    */
   inline void addStaticRefInterface(const boost::shared_ptr<StaticRefInterface>& staticRefInterface) {
     staticRefInterfaces_.push_back(staticRefInterface);
@@ -99,7 +99,7 @@ class ModelDescription {
 
   /**
    * @brief set compiled model ID
-   * @param compiledModelId
+   * @param compiledModelId compiled model ID
    */
   inline void setCompiledModelId(const std::string& compiledModelId) {
     compiledModelId_ = compiledModelId;

--- a/dynawo/sources/Modeler/Common/DYNModeler.h
+++ b/dynawo/sources/Modeler/Common/DYNModeler.h
@@ -132,10 +132,10 @@ class Modeler {
 
   /**
    * @brief replace STATIC and NODE macros in a macro connection
-   * @param subModel1: first connected model
-   * @param var1: first connected variable
-   * @param subModel2: second connected model
-   * @param var2: second connected variable
+   * @param subModel1 first connected model
+   * @param var1 first connected variable
+   * @param subModel2 second connected model
+   * @param var2 second connected variable
    */
   void replaceStaticAndNodeMacroInVariableName(const boost::shared_ptr<SubModel>& subModel1, std::string& var1,
       const boost::shared_ptr<SubModel>& subModel2, std::string& var2) const;
@@ -148,12 +148,12 @@ class Modeler {
   void initParamDescription(const boost::shared_ptr<ModelDescription>& modelDescription);
 
   /**
-   * @brief replace \@NODE\@, \@NODE1\@, \@NODE2\@ with the id of the bus the compoment is connected to
-   * @param subModel1: first connected model
-   * @param var1: first connected variable
-   * @param subModel2: second connected model
-   * @param var2: second connected variable
-   * @param labelNode: \@NODE\@ or \@NODE1\@ or \@NODE2\@
+   * @brief replace \@NODE\@, \@NODE1\@, \@NODE2\@ with the id of the bus the component is connected to
+   * @param subModel1 first connected model
+   * @param var1 first connected variable
+   * @param subModel2 second connected model
+   * @param var2 second connected variable
+   * @param labelNode \@NODE\@ or \@NODE1\@ or \@NODE2\@
    */
   void replaceNodeWithBus(const boost::shared_ptr<SubModel>& subModel1, std::string& var1,
       const boost::shared_ptr<SubModel>& subModel2, std::string& var2, const std::string& labelNode) const;

--- a/dynawo/sources/Modeler/Common/DYNParameterModeler.h
+++ b/dynawo/sources/Modeler/Common/DYNParameterModeler.h
@@ -67,7 +67,7 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief checks whether a parameter value may be set
-   * @param origin: tested origin for the parameter
+   * @param origin tested origin for the parameter
    * @throws when it is forbidden to write data for the current parameter and origin
    * @throws when the parameter is not unitary
    */
@@ -75,7 +75,7 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief checks whether a parameter value may be set for a given origin
-   * @param origin: tested origin for the parameter
+   * @param origin tested origin for the parameter
    * @return whether write rights are granted
    */
   inline bool originWriteAllowed(const parameterOrigin_t& origin) const {
@@ -84,14 +84,14 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief parameter's value setter
-   * @param value: parameter's value
-   * @param origin: parameter's origin
+   * @param value parameter's value
+   * @param origin parameter's origin
    */
   template<typename T> void setValue(const T& value, const parameterOrigin_t& origin);
 
   /**
    * @brief Setter for parameter's cardinality
-   * @param cardinality: parameter's cardinality
+   * @param cardinality parameter's cardinality
    */
   inline void setCardinality(const std::string& cardinality) {
     cardinality_ = cardinality;
@@ -99,7 +99,7 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief Setter for cardinality informator
-   * @param cardinalityInformator: parameter's cardinality informator
+   * @param cardinalityInformator parameter's cardinality informator
    */
   void setCardinalityInformator(const std::string& cardinalityInformator);
 
@@ -111,7 +111,7 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief Update the priority origin of the parameter
-   * @param origin: origin used to update the priority origin
+   * @param origin origin used to update the priority origin
    */
   void updateOrigin(const parameterOrigin_t& origin);
 
@@ -125,7 +125,7 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief Set the priority origin of the parameter
-   * @param origin: origin used to update the priority origin
+   * @param origin origin used to update the priority origin
    */
   inline void setOrigin(const parameterOrigin_t& origin) {
     origin_ = origin;
@@ -141,14 +141,14 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief indicates whether a parameter has a value associated with a given origin
-   * @param origin: tested origin for the parameter
+   * @param origin tested origin for the parameter
    * @return true if the parameter has a value associated with the given origin, false otherwise
    */
   bool hasOrigin(const parameterOrigin_t& origin) const;
 
   /**
    * @brief indicates whether a parameter has a value associated with a given origin or a less important origin
-   * @param origin: tested origin for the parameter
+   * @param origin tested origin for the parameter
    * @return true if the parameter has a value associated with the given origin or a less important origin, false otherwise
    */
   inline bool hasAtLeastOrigin(const parameterOrigin_t& origin) const {
@@ -199,7 +199,7 @@ class ParameterModeler : public ParameterCommon {
 
   /**
    * @brief set whether the parameter is the result of a non-unitary parameter instanciation
-   * @param nonUnitaryParameterInstance: whether the parameter is the result of a non-unitary parameter instanciation
+   * @param nonUnitaryParameterInstance whether the parameter is the result of a non-unitary parameter instanciation
    */
   inline void setIsNonUnitaryParameterInstance(const bool nonUnitaryParameterInstance) {
     nonUnitaryParameterInstance_ = nonUnitaryParameterInstance;

--- a/dynawo/sources/Modeler/Common/DYNStaticRefInterface.h
+++ b/dynawo/sources/Modeler/Common/DYNStaticRefInterface.h
@@ -35,7 +35,7 @@ class StaticRefInterface {
 
   /**
    * @brief set model id
-   * @param modelID
+   * @param modelID model's id
    */
   void setModelID(const std::string& modelID) {
     modelID_ = modelID;
@@ -43,7 +43,7 @@ class StaticRefInterface {
 
   /**
    * @brief set model variable
-   * @param modelVar
+   * @param modelVar model's variable
    */
   void setModelVar(const std::string& modelVar) {
     modelVar_ = modelVar;
@@ -51,7 +51,7 @@ class StaticRefInterface {
 
   /**
    * @brief set static variable
-   * @param staticVar
+   * @param staticVar model's static variable
    */
   void setStaticVar(const std::string& staticVar) {
     staticVar_ = staticVar;

--- a/dynawo/sources/Modeler/Common/DYNSubModel.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.h
@@ -502,7 +502,6 @@ class SubModel {
   /**
    * @brief Coherence check on data (asserts, min/max values, sanity checks)
    *
-   *
    * @param t : time for which to conduct the data coherence check
    */
   void checkDataCoherenceSub(const double t);
@@ -700,7 +699,7 @@ class SubModel {
    * @brief check whether the parameter is available within the sub-model
    *
    * @param nameParameter name of the parameter
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    * @return @b true if the parameter exists inside the model
    */
   bool hasParameter(const std::string& nameParameter, const bool isInitParam);
@@ -843,9 +842,9 @@ class SubModel {
   /**
    * @brief instantiate all non-unitary parameters
    *
-   * @param isInitParam: whether to do it for initial (or dynamic) parameters
-   * @param nonUnitaryParameters: non unitary parameter of this model
-   * @param addedParameter: parameter added after processing non unitary parameters
+   * @param isInitParam whether to do it for initial (or dynamic) parameters
+   * @param nonUnitaryParameters non unitary parameter of this model
+   * @param addedParameter parameter added after processing non unitary parameters
    */
   void instantiateNonUnitaryParameters(const bool isInitParam,
       const std::map<std::string, ParameterModeler>& nonUnitaryParameters,
@@ -854,8 +853,8 @@ class SubModel {
   /**
    * @brief set a parameter value from a parameters set (API PAR) (only for unitary cardinality)
    *
-   * @param parameterName: name of the parameter to be set
-   * @param isInitParam: whether to do it for initial (or dynamic) parameters
+   * @param parameterName name of the parameter to be set
+   * @param isInitParam whether to do it for initial (or dynamic) parameters
    */
   inline void setParameterFromPARFile(const std::string& parameterName, const bool isInitParam) {
     if (readPARParameters_->hasReference(parameterName))
@@ -867,9 +866,9 @@ class SubModel {
   /**
    * @brief set a parameter value from a parameters set(only for unitary cardinality)
    *
-   * @param parameter: parameter to be set
-   * @param parametersSet: the set to scan for a value
-   * @param origin: the origin of the set data (MO, PAR, INIT, ...)
+   * @param parameter parameter to be set
+   * @param parametersSet the set to scan for a value
+   * @param origin the origin of the set data (MO, PAR, INIT, ...)
    */
   void setParameterFromSet(ParameterModeler& parameter, const boost::shared_ptr<parameters::ParametersSet>& parametersSet, const parameterOrigin_t& origin);
 
@@ -880,15 +879,15 @@ class SubModel {
 
   /**
    * @brief set all parameters values from a parameters set (API PAR)
-   * @param isInitParam: whether the parameter is an initParam or a dynamic parameter
+   * @param isInitParam whether the parameter is an initParam or a dynamic parameter
    */
   void setParametersFromPARFile(const bool isInitParam);
 
   /**
    * @brief search for a parameter with a given name
    *
-   * @param name: name of the desired parameter
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param name name of the desired parameter
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    * @return desired parameter
    */
   const ParameterModeler& findParameter(const std::string& name, const bool isInitParam) const;
@@ -896,7 +895,7 @@ class SubModel {
   /**
    * @brief search for an initial parameter with a given name
    *
-   * @param name: name of the desired parameter
+   * @param name name of the desired parameter
    * @return desired initial parameter
    */
   inline const ParameterModeler& findParameterInit(const std::string& name) const {
@@ -906,7 +905,7 @@ class SubModel {
   /**
    * @brief search for a dynamic parameter with a given name
    *
-   * @param name: name of the desired parameter
+   * @param name name of the desired parameter
    * @return desired dynamic parameter
    */
   inline const ParameterModeler& findParameterDynamic(const std::string& name) const {
@@ -916,17 +915,17 @@ class SubModel {
   /**
    * @brief set a given parameter value
    *
-   * @param name: name of the desired parameter
-   * @param origin: the origin from which the value comes from
-   * @param value : the value to set
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param name name of the desired parameter
+   * @param origin the origin from which the value comes from
+   * @param value the value to set
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    */
   template <typename T> void setParameterValue(const std::string& name, const parameterOrigin_t& origin, const T& value, const bool isInitParam);
 
 
   /**
    * @brief Getter for parameters
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    * @return submodel parameters
    */
   inline const boost::unordered_map<std::string, ParameterModeler>& getParameters(const bool isInitParam) const {
@@ -950,23 +949,23 @@ class SubModel {
   /**
    * @brief Add parameters
    *
-   * @param parameters: vector of parameters to add
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param parameters vector of parameters to add
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    */
   void addParameters(const std::vector<ParameterModeler>& parameters, const bool isInitParam);
 
   /**
    * @brief Add a parameter
    *
-   * @param parameter: Parameter to add
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param parameter Parameter to add
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    */
   void addParameter(const ParameterModeler& parameter, const bool isInitParam);
 
   /**
    * @brief Reset the parameters
    *
-   * @param isInitParam: whether to reset the initial (or dynamic) parameters
+   * @param isInitParam whether to reset the initial (or dynamic) parameters
    */
   void resetParameters(const bool isInitParam);
 
@@ -986,7 +985,7 @@ class SubModel {
   /**
    * @brief Define all parameters for the init or dynamic model
    *
-   * @param isInitParam: whether to define the initial (or dynamic) parameters
+   * @param isInitParam whether to define the initial (or dynamic) parameters
    */
   void defineParameters(const bool isInitParam);
 
@@ -1334,7 +1333,7 @@ class SubModel {
   /**
    * @brief setter for the parameters set read from PAR file
    *
-   * @param params: parameters set read from PAR file
+   * @param params parameters set read from PAR file
    */
   void setPARParameters(const boost::shared_ptr<parameters::ParametersSet>& params);
 
@@ -1410,8 +1409,8 @@ class SubModel {
   /**
    * @brief search for a parameter with a given name
    *
-   * @param name: name of the desired parameter
-   * @param isInitParam: whether to retrieve the initial (or dynamic) parameters
+   * @param name name of the desired parameter
+   * @param isInitParam whether to retrieve the initial (or dynamic) parameters
    * @return desired parameter as a reference
    */
   ParameterModeler& findParameterReference(const std::string& name, const bool isInitParam);
@@ -1450,7 +1449,7 @@ class SubModel {
   /**
    * @brief set a parameter value from a parameters set (API PAR) (only for unitary cardinality)
    *
-   * @param parameter: parameter to be set
+   * @param parameter parameter to be set
    */
   inline void setParameterFromPARFile(ParameterModeler& parameter) {
     if (!readPARParameters_)

--- a/dynawo/sources/Modeler/Common/DYNSubModelFactory.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModelFactory.h
@@ -162,7 +162,7 @@ class SubModelDelete {
   /**
    * @brief Constructor
    *
-   * @param factory: model factory to delete
+   * @param factory model factory to delete
    */
   explicit SubModelDelete(SubModelFactory* factory);
 
@@ -174,7 +174,7 @@ class SubModelDelete {
   /**
    * @brief Function to use this class as a Functor
    *
-   * @param subModel: pointer to the subModel to delete
+   * @param subModel pointer to the subModel to delete
    * map
    */
   void operator()(SubModel* subModel);

--- a/dynawo/sources/Modeler/DataInterface/DYNConverterInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNConverterInterface.h
@@ -41,19 +41,19 @@ class ConverterInterface : public ComponentInterface {
 
   /**
    * @brief Setter for the converter bus interface
-   * @param busInterface: interface of the bus where the converter is connected
+   * @param busInterface interface of the bus where the converter is connected
    */
   virtual void setBusInterface(const boost::shared_ptr<BusInterface>& busInterface) = 0;
 
   /**
    * @brief Setter for the converter voltage interface
-   * @param voltageLevelInterface: interface of the voltageLevel where the converter is connected
+   * @param voltageLevelInterface interface of the voltageLevel where the converter is connected
    */
   virtual void setVoltageLevelInterface(const boost::shared_ptr<VoltageLevelInterface>& voltageLevelInterface) = 0;
 
   /**
    * @brief Getter for the converter bus interface
-   * @return busInterface: interface of the bus where the converter is connected
+   * @return busInterface interface of the bus where the converter is connected
    */
   virtual boost::shared_ptr<BusInterface> getBusInterface() const = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterface.h
@@ -81,10 +81,10 @@ class DataInterface {
 
   /**
    * @brief Associate a component variable to a model variable
-   * @param componentVar: component's var
-   * @param staticId: static id of the model
-   * @param modelId : model's id
-   * @param modelVar: model's var associated to the component's var
+   * @param componentVar component's var
+   * @param staticId static id of the model
+   * @param modelId model's id
+   * @param modelVar model's var associated to the component's var
    */
   virtual void setReference(const std::string& componentVar, const std::string& staticId, const std::string& modelId, const std::string& modelVar) = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/DYNNetworkInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNNetworkInterface.h
@@ -67,7 +67,7 @@ class NetworkInterface {
 
   /**
    * @brief Add a new instance of hvdc line interface to the network interface
-   * @param hvdc: instance of hvdc line interface to add
+   * @param hvdc instance of hvdc line interface to add
    */
   virtual void addHvdcLine(const boost::shared_ptr<HvdcLineInterface>& hvdc) = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/DYNPhaseTapChangerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNPhaseTapChangerInterface.h
@@ -56,7 +56,7 @@ class PhaseTapChangerInterface {
 
   /**
    * @brief Setter for the current tap position
-   * @param position: the current tap position
+   * @param position the current tap position
    */
   virtual void setCurrentPosition(const int& position) = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/DYNRatioTapChangerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNRatioTapChangerInterface.h
@@ -56,7 +56,7 @@ class RatioTapChangerInterface {
 
   /**
    * @brief Setter for the current tap position
-   * @param position: the current tap position
+   * @param position the current tap position
    */
   virtual void setCurrentPosition(const int& position) = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/DYNVoltageLevelInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNVoltageLevelInterface.h
@@ -140,13 +140,13 @@ class VoltageLevelInterface {
 
    /**
    * @brief Add a new instance of vsc converter interface to the voltageLevel interface
-   * @param vsc: instance of vsc converter interface to add
+   * @param vsc instance of vsc converter interface to add
    */
   virtual void addVscConverter(const boost::shared_ptr<VscConverterInterface>& vsc) = 0;
 
   /**
    * @brief Add a new instance of lcc converter interface to the voltageLevel interface
-   * @param lcc: instance of lcc converter interface to add
+   * @param lcc instance of lcc converter interface to add
    */
   virtual void addLccConverter(const boost::shared_ptr<LccConverterInterface>& lcc) = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNDataInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNDataInterfaceIIDM.h
@@ -246,7 +246,7 @@ class DataInterfaceIIDM : public DataInterface {
  private:
   /**
    * @brief find a bus interface thanks to its id
-   * @param id: id of the bus interface to find
+   * @param id id of the bus interface to find
    *
    * @return instance of bus interface found
    */
@@ -254,7 +254,7 @@ class DataInterfaceIIDM : public DataInterface {
 
   /**
    * @brief find a voltage level interface thanks to its id
-   * @param id: id of the voltage level interface to find
+   * @param id id of the voltage level interface to find
    *
    * @return instance of voltage level interface found
    */
@@ -379,7 +379,7 @@ class DataInterfaceIIDM : public DataInterface {
   /**
    * @brief import and create a vsc converter interface thanks to the IIDM instance
    *
-   * @param vscIIDM: IIDM instance to use to create vsc converter interface
+   * @param vscIIDM IIDM instance to use to create vsc converter interface
    * @return the instance of vscConverterInterface created
    */
   boost::shared_ptr<VscConverterInterface> importVscConverter(IIDM::VscConverterStation& vscIIDM);
@@ -387,7 +387,7 @@ class DataInterfaceIIDM : public DataInterface {
   /**
    * @brief import and create a lcc converter interface thanks to the IIDM instance
    *
-   * @param lccIIDM: IIDM instance to use to create lcc converter interface
+   * @param lccIIDM IIDM instance to use to create lcc converter interface
    * @return the instance of lccConverterInterface created
    */
   boost::shared_ptr<LccConverterInterface> importLccConverter(IIDM::LccConverterStation& lccIIDM);

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNGeneratorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNGeneratorInterfaceIIDM.h
@@ -56,7 +56,7 @@ class GeneratorInterfaceIIDM : public GeneratorInterface, public InjectorInterfa
 
   /**
    * @brief Constructor
-   * @param generator: generator's iidm instance
+   * @param generator generator's iidm instance
    */
   explicit GeneratorInterfaceIIDM(IIDM::Generator& generator);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNHvdcLineInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNHvdcLineInterfaceIIDM.h
@@ -52,9 +52,9 @@ class HvdcLineInterfaceIIDM : public HvdcLineInterface {
 
   /**
    * @brief Constructor
-   * @param hvdcLine: hvdc line iidm instance
-   * @param conv1: converter 1 data interface instance
-   * @param conv2: converter 2 data interface instance
+   * @param hvdcLine hvdc line iidm instance
+   * @param conv1 converter 1 data interface instance
+   * @param conv2 converter 2 data interface instance
    */
   explicit HvdcLineInterfaceIIDM(IIDM::HvdcLine& hvdcLine,
                                  const boost::shared_ptr<ConverterInterface>& conv1,

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNLccConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNLccConverterInterfaceIIDM.h
@@ -45,7 +45,7 @@ class LccConverterInterfaceIIDM : public LccConverterInterface, public InjectorI
 
   /**
    * @brief Constructor
-   * @param lcc: lcc converter iidm instance
+   * @param lcc lcc converter iidm instance
    */
   explicit LccConverterInterfaceIIDM(IIDM::LccConverterStation& lcc);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNNetworkInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNNetworkInterfaceIIDM.h
@@ -42,7 +42,7 @@ class NetworkInterfaceIIDM : public NetworkInterface {
 
   /**
    * @brief Constructor
-   * @param network: the network's iidm instance
+   * @param network the network's iidm instance
    */
   explicit NetworkInterfaceIIDM(IIDM::Network& network);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNShuntCompensatorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNShuntCompensatorInterfaceIIDM.h
@@ -55,7 +55,7 @@ class ShuntCompensatorInterfaceIIDM : public ShuntCompensatorInterface, public I
 
   /**
    * @brief Constructor
-   * @param shunt: shunt compensator's iidm instance
+   * @param shunt shunt compensator's iidm instance
    */
   explicit ShuntCompensatorInterfaceIIDM(IIDM::ShuntCompensator& shunt);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNStaticVarCompensatorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNStaticVarCompensatorInterfaceIIDM.h
@@ -61,7 +61,7 @@ class StaticVarCompensatorInterfaceIIDM : public StaticVarCompensatorInterface, 
 
   /**
    * @brief Constructor
-   * @param svc: static var compensator's iidm instance
+   * @param svc static var compensator's iidm instance
    */
   explicit StaticVarCompensatorInterfaceIIDM(IIDM::StaticVarCompensator& svc);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNStepInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNStepInterfaceIIDM.h
@@ -44,13 +44,13 @@ class StepInterfaceIIDM : public StepInterface {
 
   /**
    * @brief Constructor
-   * @param step: phase tap changer step's iidm instance
+   * @param step phase tap changer step's iidm instance
    */
   explicit StepInterfaceIIDM(const IIDM::PhaseTapChangerStep& step);
 
   /**
    * @brief Constructor
-   * @param step :ratio tap changer step's iidm instance
+   * @param step ratio tap changer step's iidm instance
    */
   explicit StepInterfaceIIDM(const IIDM::RatioTapChangerStep& step);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNSwitchInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNSwitchInterfaceIIDM.h
@@ -49,7 +49,7 @@ class SwitchInterfaceIIDM : public SwitchInterface {
 
   /**
    * @brief Constructor
-   * @param sw: the switch's iidm instance
+   * @param sw the switch's iidm instance
    */
   explicit SwitchInterfaceIIDM(IIDM::Switch& sw);
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNVscConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNVscConverterInterfaceIIDM.h
@@ -45,7 +45,7 @@ class VscConverterInterfaceIIDM : public VscConverterInterface, public InjectorI
 
   /**
    * @brief Constructor
-   * @param vsc: vsc converter iidm instance
+   * @param vsc vsc converter iidm instance
    */
   explicit VscConverterInterfaceIIDM(IIDM::VscConverterStation& vsc);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.h
@@ -261,7 +261,7 @@ class DataInterfaceIIDM : public DataInterface {
 
   /**
    * @brief find a voltage level interface thanks to its id
-   * @param id: id of the voltage level interface to find
+   * @param id id of the voltage level interface to find
    *
    * @return instance of voltage level interface found
    */
@@ -365,7 +365,7 @@ class DataInterfaceIIDM : public DataInterface {
   /**
    * @brief import and create a vsc converter interface thanks to the IIDM instance
    *
-   * @param vscIIDM: IIDM instance to use to create vsc converter interface
+   * @param vscIIDM IIDM instance to use to create vsc converter interface
    * @return the instance of vscConverterInterface created
    */
   boost::shared_ptr<VscConverterInterfaceIIDM> importVscConverter(powsybl::iidm::VscConverterStation& vscIIDM);
@@ -373,7 +373,7 @@ class DataInterfaceIIDM : public DataInterface {
   /**
    * @brief import and create a lcc converter interface thanks to the IIDM instance
    *
-   * @param lccIIDM: IIDM instance to use to create lcc converter interface
+   * @param lccIIDM IIDM instance to use to create lcc converter interface
    * @return the instance of lccConverterInterface created
    */
   boost::shared_ptr<LccConverterInterfaceIIDM> importLccConverter(powsybl::iidm::LccConverterStation& lccIIDM);

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorInterfaceIIDM.h
@@ -58,7 +58,7 @@ class GeneratorInterfaceIIDM : public GeneratorInterface, public InjectorInterfa
 
   /**
    * @brief Constructor
-   * @param generator: generator's iidm instance
+   * @param generator generator's iidm instance
    */
   explicit GeneratorInterfaceIIDM(powsybl::iidm::Generator& generator);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNHvdcLineInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNHvdcLineInterfaceIIDM.h
@@ -62,9 +62,9 @@ class HvdcLineInterfaceIIDM : public HvdcLineInterface, public boost::noncopyabl
 
   /**
    * @brief Constructor
-   * @param hvdcLine: hvdc line iidm instance
-   * @param conv1: converter 1 data interface instance
-   * @param conv2: converter 2 data interface instance
+   * @param hvdcLine hvdc line iidm instance
+   * @param conv1 converter 1 data interface instance
+   * @param conv2 converter 2 data interface instance
    */
   explicit HvdcLineInterfaceIIDM(powsybl::iidm::HvdcLine& hvdcLine,
                                  const boost::shared_ptr<ConverterInterface>& conv1,

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNLccConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNLccConverterInterfaceIIDM.h
@@ -46,7 +46,7 @@ class LccConverterInterfaceIIDM : public LccConverterInterface, public InjectorI
 
   /**
    * @brief Constructor
-   * @param lcc: lcc converter iidm instance
+   * @param lcc lcc converter iidm instance
    */
   explicit LccConverterInterfaceIIDM(powsybl::iidm::LccConverterStation& lcc);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNNetworkInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNNetworkInterfaceIIDM.h
@@ -41,7 +41,7 @@ class NetworkInterfaceIIDM : public NetworkInterface {
 
   /**
    * @brief Constructor
-   * @param network: the network's iidm instance
+   * @param network the network's iidm instance
    */
   explicit NetworkInterfaceIIDM(powsybl::iidm::Network& network);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNShuntCompensatorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNShuntCompensatorInterfaceIIDM.h
@@ -52,7 +52,7 @@ class ShuntCompensatorInterfaceIIDM : public ShuntCompensatorInterface, public I
 
   /**
    * @brief Constructor
-   * @param shunt: shunt compensator's iidm instance
+   * @param shunt shunt compensator's iidm instance
    */
   explicit ShuntCompensatorInterfaceIIDM(powsybl::iidm::ShuntCompensator& shunt);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDM.h
@@ -56,7 +56,7 @@ class StaticVarCompensatorInterfaceIIDM : public StaticVarCompensatorInterface, 
 
   /**
    * @brief Constructor
-   * @param svc: static var compensator's iidm instance
+   * @param svc static var compensator's iidm instance
    */
   explicit StaticVarCompensatorInterfaceIIDM(powsybl::iidm::StaticVarCompensator& svc);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDMExtension.h
@@ -38,7 +38,7 @@ class StaticVarCompensatorInterfaceIIDMExtension {
 
   /**
    * @brief Interface to export the stand by mode of the svc
-   * @param standByMode: svc in standby or no
+   * @param standByMode svc in standby or no
    */
   virtual void exportStandByMode(bool standByMode) = 0;
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStepInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStepInterfaceIIDM.h
@@ -38,13 +38,13 @@ class StepInterfaceIIDM : public StepInterface {
 
   /**
    * @brief Constructor
-   * @param step: phase tap changer step's iidm instance
+   * @param step phase tap changer step's iidm instance
    */
   explicit StepInterfaceIIDM(const powsybl::iidm::PhaseTapChangerStep& step);
 
   /**
    * @brief Constructor
-   * @param step :ratio tap changer step's iidm instance
+   * @param step ratio tap changer step's iidm instance
    */
   explicit StepInterfaceIIDM(const powsybl::iidm::RatioTapChangerStep& step);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNSwitchInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNSwitchInterfaceIIDM.h
@@ -43,7 +43,7 @@ class SwitchInterfaceIIDM : public SwitchInterface {
 
   /**
    * @brief Constructor
-   * @param sw: the switch's iidm instance
+   * @param sw the switch's iidm instance
    */
   explicit SwitchInterfaceIIDM(powsybl::iidm::Switch& sw);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVscConverterInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVscConverterInterfaceIIDM.h
@@ -44,7 +44,7 @@ class VscConverterInterfaceIIDM : public VscConverterInterface, public InjectorI
 
   /**
    * @brief Constructor
-   * @param vsc: vsc converter iidm instance
+   * @param vsc vsc converter iidm instance
    */
   explicit VscConverterInterfaceIIDM(powsybl::iidm::VscConverterStation& vsc);
 

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
@@ -47,6 +47,7 @@
 #include "DYNModelManagerOwnTypes.h"  ///< redefinition of local own types : should be before simulation_data.h
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wextra-semi-stmt"
 #endif  // __clang__
 #include "simulation_data.h"

--- a/dynawo/sources/Modeler/ModelManager/test/Test.cpp
+++ b/dynawo/sources/Modeler/ModelManager/test/Test.cpp
@@ -117,11 +117,6 @@ class MyModelica: public ModelModelica {
    */
   void initRpar() {}
 
-  /**
-   * @brief calculates the residual functions of the model
-   *
-   * @param f local buffer to fill
-   */
   virtual void setFomc(double* /*f*/, propertyF_t /*type*/) {
     ++nbCallF_;
   }
@@ -130,11 +125,6 @@ class MyModelica: public ModelModelica {
     return nbCallF_;
   }
 
-  /**
-   * @brief  calculates the roots of the model
-   *
-   * @param g local buffer to fill
-   */
   void setGomc(state_g* /*g*/) {
     ++nbCallG_;
   }
@@ -143,12 +133,6 @@ class MyModelica: public ModelModelica {
     return nbCallG_;
   }
 
-  /**
-   * @brief check whether a mode has been triggered
-   *
-   * @param t the time for which to check
-   * @return @b true if a mode has been trigered, @b false otherwise (for use by ModelManager)
-   */
   modeChangeType_t evalMode(const double /*t*/) const {
     return DIFFERENTIAL_MODE;
   }
@@ -165,10 +149,6 @@ class MyModelica: public ModelModelica {
     return nbCallZ_;
   }
 
-  /**
-   * @brief set the silent flag for discrete variables
-   * @param silentZTable flag table
-   */
   void collectSilentZ(BitMask* /*silentZTable*/) { }
 
   /**
@@ -189,11 +169,6 @@ class MyModelica: public ModelModelica {
     return nbCallY0_;
   }
 
-  /**
-   * @brief set the values of the parameters of the model
-   *
-   * @param params set of parameters where to read the values of the model's parameters
-   */
   void setParameters(boost::shared_ptr<parameters::ParametersSet> /*params*/) {}
 
   /**
@@ -220,11 +195,6 @@ class MyModelica: public ModelModelica {
   }
 
 
-  /**
-   * @brief defines the checkSum of the model (in order to check whether it was modified)
-   *
-   * @param checkSum value of the checkSum
-   */
   void checkSum(std::string & /*checkSum*/) {}
 
 #ifdef _ADEPT_
@@ -235,12 +205,12 @@ class MyModelica: public ModelModelica {
    * @param yp values of the derivatives of the continuous variable
    * @param F computes values of the residual functions
    */
-  virtual void evalFAdept(const std::vector<adept::adouble> &y, const std::vector<adept::adouble> &yp, std::vector<adept::adouble> &res) {
+  virtual void evalFAdept(const std::vector<adept::adouble> &y, const std::vector<adept::adouble> &yp, std::vector<adept::adouble> &F) {
     ASSERT_EQ(y.size(), 2);
     ASSERT_EQ(yp.size(), 2);
-    ASSERT_EQ(res.size(), 2);
-    res[0] = 2*y[0]+yp[1];
-    res[1] = 0.5*y[1]-yp[0];
+    ASSERT_EQ(F.size(), 2);
+    F[0] = 2*y[0]+yp[1];
+    F[1] = 0.5*y[1]-yp[0];
   }
 #endif
 
@@ -276,11 +246,6 @@ class MyModelica: public ModelModelica {
     gEquationIndex[0] = "MyGEq";
   }
 
-  /**
-   * @brief defines the model type of the model
-   *
-   * @param modelType model type to set
-   */
   void setModelType(std::string /*modelType*/) {}
 
   /**
@@ -292,27 +257,12 @@ class MyModelica: public ModelModelica {
     return parent_;
   }
 
-  /**
-   * @brief set the current model manager used
-   *
-   * @param model current model manager used
-   */
   void setModelManager(ModelManager* /*model*/) {}
 
-  /**
-   * @brief defines the property of each continuous variables
-   *
-   * @param yType local buffer to fill
-   */
   void evalStaticYType_omc(propertyContinuousVar_t* /*yType*/) {
     ++nbCallStaticYType_;
   }
 
-  /**
-   * @brief defines the property of each continuous variable with dynamic type
-   *
-   * @param yType local buffer to fill
-   */
   void evalDynamicYType_omc(propertyContinuousVar_t* /*yType*/) {
     ++nbCallDynamicYType_;
   }
@@ -325,20 +275,10 @@ class MyModelica: public ModelModelica {
     return nbCallDynamicYType_;
   }
 
-  /**
-   * @brief defines the property of each residual function
-   *
-   * @param fType local buffer to fill
-   */
   void evalStaticFType_omc(propertyF_t* /*fType*/) {
     ++nbCallStaticFType_;
   }
 
-  /**
-   * @brief defines the property of each residual function with dynamic type
-   *
-   * @param fType local buffer to fill
-   */
   void evalDynamicFType_omc(propertyF_t* /*fType*/) {
     ++nbCallDynamicFType_;
   }
@@ -351,12 +291,6 @@ class MyModelica: public ModelModelica {
     return nbCallDynamicFType_;
   }
 
-  /**
-   * @brief define the elements of the model
-   *
-   * @param elements vector of each elements contains in the model
-   * @param mapElement map associating an element and the index of the elements contains in it
-   */
   void defineElements(std::vector<Element> &/*elements*/, std::map<std::string, int>& /*mapElement*/) {}
 
   /**
@@ -372,11 +306,6 @@ class MyModelica: public ModelModelica {
     return parametersSet;
   }
 
-  /**
-   * @brief compute the value of calculated variables
-   *
-   * @param calculatedVars calculated variables vector
-   */
   void evalCalculatedVars(std::vector<double>& /*calculatedVars*/) {
     ++nbCallCalcVars_;
   }
@@ -384,39 +313,18 @@ class MyModelica: public ModelModelica {
   unsigned getNbCallCalcVars() const {
     return nbCallCalcVars_;
   }
-  /**
-   * @brief evaluate the value of a calculated variable
-   *
-   * @param iCalculatedVar index of the calculated variable
-   * @param y values of the variables used to calculate the variable
-   * @param yp values of the derivatives used to calculate the variable
-   *
-   * @return value of the calculated variable
-   */
+
   double evalCalculatedVarI(unsigned /*iCalculatedVar*/) const {
     return 10.;
   }
 
 #ifdef _ADEPT_
-  /**
-   * @brief evaluate the value of a calculated variable with ADEPT library
-   *
-   * @param iCalculatedVar index of the calculated variable
-   * @return value of the calculated variable
-   */
   adept::adouble evalCalculatedVarIAdept(unsigned /*iCalculatedVar*/, unsigned /*indexOffset*/,
       const std::vector<adept::adouble> &y, const std::vector<adept::adouble> &/*yp*/) const {
     return 2*y[0];
   }
 #endif
 
-  /**
-   * @brief get the index of variables used to define the jacobian associated to a calculated variable
-   *
-   * @param iCalculatedVar index of the calculated variable
-   *
-   * @return index of variables used to define the jacobian
-   */
   void getIndexesOfVariablesUsedForCalculatedVarI(unsigned /*iCalculatedVar*/, std::vector<int>& indexes) const {
     indexes.push_back(0);
     indexes.push_back(1);
@@ -469,11 +377,11 @@ class MyModelicaInit: public MyModelica {
    * @param yp values of the derivatives of the continuous variable
    * @param F computes values of the residual functions
    */
-  void evalFAdept(const std::vector<adept::adouble> &y, const std::vector<adept::adouble> &yp, std::vector<adept::adouble> &res) {
+  void evalFAdept(const std::vector<adept::adouble> &y, const std::vector<adept::adouble> &yp, std::vector<adept::adouble> &F) {
     ASSERT_EQ(y.size(), 1);
     ASSERT_EQ(yp.size(), 1);
-    ASSERT_EQ(res.size(), 1);
-    res[0] = y[0] - 8;
+    ASSERT_EQ(F.size(), 1);
+    F[0] = y[0] - 8;
   }
 #endif
 

--- a/dynawo/sources/Models/CPP/Common/DYNModelCPP.h
+++ b/dynawo/sources/Models/CPP/Common/DYNModelCPP.h
@@ -54,7 +54,7 @@ class ModelCPP : public SubModel {
 
   /**
    * @brief initialize all the data for a sub model
-   * @param t0: initial time of the simulation
+   * @param t0 initial time of the simulation
    */
   virtual void init(const double t0) = 0;
 

--- a/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.h
+++ b/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.h
@@ -36,7 +36,7 @@ class ModelCPP::Impl : public ModelCPP {
   Impl();
   /**
    * @brief constructor
-   * @param modelType
+   * @param modelType model's type
    */
   explicit Impl(std::string modelType);
 

--- a/dynawo/sources/Models/CPP/Components/ModelLoadRestorativeWithLimits/DYNModelLoadRestorativeWithLimits.h
+++ b/dynawo/sources/Models/CPP/Components/ModelLoadRestorativeWithLimits/DYNModelLoadRestorativeWithLimits.h
@@ -95,7 +95,7 @@ class ModelLoadRestorativeWithLimits : public ModelCPP::Impl {
   } zInd;
   /**
   * @brief define parameters
-  * @param parameters: vector to fill with the generic parameters
+  * @param parameters vector to fill with the generic parameters
   */
   void defineParameters(std::vector<ParameterModeler>& parameters);
   /**

--- a/dynawo/sources/Models/CPP/Controls/Shunts/ModelCentralizedShuntsSectionControl/DYNModelCentralizedShuntsSectionControl.h
+++ b/dynawo/sources/Models/CPP/Controls/Shunts/ModelCentralizedShuntsSectionControl/DYNModelCentralizedShuntsSectionControl.h
@@ -83,7 +83,7 @@ class ModelCentralizedShuntsSectionControl : public ModelCPP::Impl {
   } CalculatedVars_t;
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   void defineParameters(std::vector<ParameterModeler> &parameters);
   /**

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
@@ -183,28 +183,11 @@ ModelOmegaRef::evalF(double /*t*/, propertyF_t type) {
   }
 }
 
-/**
- * @brief Reference frequency G(t,y,y') function evaluation
- *
- * Get the root's value
- *
- * @param t Simulation instant
- */
 void
 ModelOmegaRef::evalG(const double /*t*/) {
-  // No root fucntion for this model
+  // No root function for this model
 }
 
-/**
- * @brief Reference frequency transposed jacobian evaluation
- *
- * Get the sparse transposed jacobian \f$ Jt=@F/@y + cj*@F/@y' \f$
- *
- * @param t Simulation instant
- * @param cj Jacobian prime coefficient
- * @param jt
- * @param rowOffset
- */
 void
 ModelOmegaRef::evalJt(const double /*t*/, const double /*cj*/, SparseMatrix& jt, const int rowOffset) {
   // Equations:
@@ -249,16 +232,6 @@ ModelOmegaRef::evalJt(const double /*t*/, const double /*cj*/, SparseMatrix& jt,
   }
 }
 
-/**
- * @brief  Reference frequency transposed jacobian evaluation
- *
- * Get the sparse transposed jacobian \f$ Jt=@F/@y' \f$
- *
- * @param t Simulation instant
- * @param cj Jacobian prime coefficient
- * @param jt
- * @param rowOffset
- */
 void
 ModelOmegaRef::evalJtPrim(const double /*t*/, const double /*cj*/, SparseMatrix& jt, const int /*rowOffset*/) {
   // Equations:
@@ -279,14 +252,6 @@ ModelOmegaRef::evalJtPrim(const double /*t*/, const double /*cj*/, SparseMatrix&
     jt.changeCol();
 }
 
-/**
- * @brief Reference frequency discrete variables evaluation
- *
- * Get the discrete variables' value depending on current simulation instant and
- * current state variables values.
- *
- * @param t Simulation instant
- */
 void
 ModelOmegaRef::evalZ(const double /*t*/) {
   std::copy(zLocal_, zLocal_ + nbGen_, numCCNode_.begin());
@@ -300,15 +265,6 @@ ModelOmegaRef::collectSilentZ(BitMask* silentZTable) {
   }
 }
 
-/**
- * @brief Reference frequency modes' evaluation
- *
- * Set the modes' value depending on current simulation instant and
- * current state variables values. For this model, the mode changes when the number
- * of subNetwork changes
- *
- * @param t Simulation instant
- */
 modeChangeType_t
 ModelOmegaRef::evalMode(const double /*t*/) {
   // mode change = number of subNetwork change or grp status change

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNDerivative.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNDerivative.h
@@ -45,8 +45,8 @@ class Derivatives {
   void reset();
   /**
    * @brief add value
-   * @param numVar : number of variable
-   * @param value: value
+   * @param numVar number of variable
+   * @param value value
    */
   void addValue(const int& numVar, const double& value);
 
@@ -85,9 +85,9 @@ class BusDerivatives {
   /**
    * @brief add derivative
    *
-   * @param type: derivative type
-   * @param numVar: number of variable
-   * @param value: number of value
+   * @param type derivative type
+   * @param numVar number of variable
+   * @param value number of value
    */
   void addDerivative(typeDerivative_t type, const int& numVar, const double& value);
   /**

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.h
@@ -42,8 +42,8 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
  public:
   /**
    * @brief default constructor
-   * @param bus: bus data interface to use for the model
-   * @param isNodeBreaker: true if the voltage level is in NODE BREAKER
+   * @param bus bus data interface to use for the model
+   * @param isNodeBreaker true if the voltage level is in NODE BREAKER
    */
   explicit ModelBus(const boost::shared_ptr<BusInterface>& bus, bool isNodeBreaker);
 
@@ -117,31 +117,31 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -273,7 +273,7 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);
@@ -327,14 +327,14 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
 
   /**
    * @brief  scan a subnetwork in order to find all neighboring buses
-   * @param subNetwork
-   * @param numComponent
+   * @param subNetwork subnetwork to scan
+   * @param numComponent number of components
    */
   void exploreNeighbors(const int& numComponent, const boost::shared_ptr<SubNetwork>& subNetwork);  // scan a subnetwork to find all neighbouring buses
 
   /**
    * @brief set refIslands
-   * @param refIsland
+   * @param refIsland refIslands
    */
   inline void setRefIslands(int refIsland) {
     refIslands_ = refIsland;
@@ -647,14 +647,14 @@ class SubNetwork {  ///< sub-network gathering buses connected by AC components
 
   /**
    * @brief constructor
-   * @param num
+   * @param num num
    */
   explicit SubNetwork(const int& num)
   :num_(num) { }
 
   /**
    * @brief set num
-   * @param num
+   * @param num num
    */
   inline void setNum(int num) {
     num_ = num;
@@ -670,7 +670,7 @@ class SubNetwork {  ///< sub-network gathering buses connected by AC components
 
   /**
    * @brief  add a bus to the sub-network
-   * @param bus
+   * @param bus bus
    */
   inline void addBus(const boost::shared_ptr<ModelBus>& bus) {
     assert(bus && "Undefined bus");
@@ -687,7 +687,7 @@ class SubNetwork {  ///< sub-network gathering buses connected by AC components
 
   /**
    * @brief get bus
-   * @param num
+   * @param num num
    * @return bus
    */
   inline boost::shared_ptr<ModelBus> bus(int num) const {
@@ -727,7 +727,7 @@ class ModelBusContainer {
 
   /**
    * @brief add bus
-   * @param model
+   * @param model model
    */
   void add(const boost::shared_ptr<ModelBus>& model);
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelCurrentLimits.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelCurrentLimits.h
@@ -79,26 +79,26 @@ class ModelCurrentLimits {  ///< Generic Current Limits model
    * @param desactivate @b true if the current limits is off
    * @param modelType type of the model
    *
-   * @return
+   * @return the state of the current limits
    */
   state_t evalZ(const std::string& componentName, const double& t, state_g * g, ModelNetwork* network,
                 const double& desactivate, const std::string& modelType);  // compute the local Z function
 
   /**
    * @brief add a new current limit (p.u. base UNom, base SNRef)
-   * @param limit
-   * @param acceptableDuration
+   * @param limit new current limit
+   * @param acceptableDuration acceptable duration
    */
   void addLimit(const double& limit, const int& acceptableDuration);
 
   /**
    * @brief set side
-   * @param side
+   * @param side side
    */
   void setSide(const side_t side);
   /**
    * @brief set the max time operation
-   * @param maxTimeOperation
+   * @param maxTimeOperation max time operation
    */
   void setMaxTimeOperation(const double& maxTimeOperation);
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelDanglingLine.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelDanglingLine.h
@@ -90,7 +90,7 @@ class ModelDanglingLine : public NetworkComponent::Impl {
 
   /**
    * @brief set connection state
-   * @param state
+   * @param state connection state
    */
   void setConnectionState(State state) {
     connectionState_ = state;
@@ -98,7 +98,7 @@ class ModelDanglingLine : public NetworkComponent::Impl {
 
   /**
    * @brief set current limit status
-   * @param desactivate
+   * @param desactivate currentLimitsDesactivate
    */
   void setCurrentLimitsDesactivate(const double& desactivate) {
     currentLimitsDesactivate_ = desactivate;
@@ -130,31 +130,31 @@ class ModelDanglingLine : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -264,7 +264,7 @@ class ModelDanglingLine : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);
@@ -328,41 +328,41 @@ class ModelDanglingLine : public NetworkComponent::Impl {
   double ui_Fict() const;
   /**
    * @brief get ir_Load value
-   * @param ur
-   * @param ui
-   * @return value
-   */
-  double ir_Load(const double& ur, const double& ui) const;
-  /**
-   * @brief get ir_Load value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
    * @return value
    */
-  double ii_Load(const double& ur, const double& ui) const;
+  double ir_Load(const double& ur, const double& ui) const;
   /**
    * @brief get ii_Load value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
    * @return value
    */
+  double ii_Load(const double& ur, const double& ui) const;
+  /**
+   * @brief get irLoad_dUr value
+   * @param ur real part of the voltage
+   * @param ui imaginary part of the voltage
+   * @return value
+   */
   double irLoad_dUr(const double& ur, const double& ui) const;
   /**
-   * @brief get  value
+   * @brief get irLoad_dUi value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
    * @return value
    */
   double irLoad_dUi(const double& ur, const double& ui) const;
   /**
-   * @brief get value
+   * @brief get iiLoad_dUr value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
    * @return value
    */
   double iiLoad_dUr(const double& ur, const double& ui) const;
   /**
-   * @brief get  value
+   * @brief get iiLoad_dUi value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
    * @return value
@@ -373,8 +373,8 @@ class ModelDanglingLine : public NetworkComponent::Impl {
    * @brief get ir1 value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
-   * @param urFict
-   * @param uiFict
+   * @param urFict urFict
+   * @param uiFict uiFict
    * @return value
    */
   double ir1(const double& ur, const double& ui, const double& urFict, const double& uiFict) const;
@@ -382,8 +382,8 @@ class ModelDanglingLine : public NetworkComponent::Impl {
    * @brief get ii1 value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
-   * @param urFict
-   * @param uiFict
+   * @param urFict urFict
+   * @param uiFict uiFict
    * @return value
    */
   double ii1(const double& ur, const double& ui, const double& urFict, const double& uiFict) const;
@@ -391,8 +391,8 @@ class ModelDanglingLine : public NetworkComponent::Impl {
    * @brief get ir2 value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
-   * @param urFict
-   * @param uiFict
+   * @param urFict urFict
+   * @param uiFict uiFict
    * @return value
    */
   double ir2(const double& ur, const double& ui, const double& urFict, const double& uiFict) const;
@@ -400,8 +400,8 @@ class ModelDanglingLine : public NetworkComponent::Impl {
    * @brief get ii2 value
    * @param ur real part of the voltage
    * @param ui imaginary part of the voltage
-   * @param urFict
-   * @param uiFict
+   * @param urFict urFict
+   * @param uiFict uiFict
    * @return value
    */
   double ii2(const double& ur, const double& ui, const double& urFict, const double& uiFict) const;

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelGenerator.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelGenerator.h
@@ -56,7 +56,7 @@ class ModelGenerator : public NetworkComponent::Impl {
 
   /**
    * @brief set connection status of the generator
-   * @param state
+   * @param state connection status
    */
   void setConnected(State state) {
     connectionState_ = state;
@@ -103,31 +103,31 @@ class ModelGenerator : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -228,7 +228,7 @@ class ModelGenerator : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelHvdcLink.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelHvdcLink.h
@@ -179,7 +179,7 @@ class ModelHvdcLink : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);
@@ -207,31 +207,31 @@ class ModelHvdcLink : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element> &elements, std::map<std::string, int>& mapElement);
@@ -280,7 +280,7 @@ class ModelHvdcLink : public NetworkComponent::Impl {
 
   /**
    * @brief set connection status
-   * @param state
+   * @param state connection status
    */
   void setConnected1(State state) {
     connectionState1_ = state;
@@ -288,7 +288,7 @@ class ModelHvdcLink : public NetworkComponent::Impl {
 
   /**
    * @brief set connection status
-   * @param state
+   * @param state connection status
    */
   void setConnected2(State state) {
     connectionState2_ = state;

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLine.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLine.h
@@ -78,7 +78,7 @@ class ModelLine : public NetworkComponent::Impl {
 
   /**
    * @brief set the connected state (fully connected, one end open, ...) of the line
-   * @param state
+   * @param state connected state
    */
   void setConnectionState(State state) {
     connectionState_ = state;
@@ -86,7 +86,7 @@ class ModelLine : public NetworkComponent::Impl {
 
   /**
    * @brief set CurrentLimits Desactivate
-   * @param desactivate
+   * @param desactivate CurrentLimits Desactivate
    */
   void setCurrentLimitsDesactivate(const double& desactivate) {
     currentLimitsDesactivate_ = desactivate;
@@ -150,31 +150,31 @@ class ModelLine : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element> &elements, std::map<std::string, int>& mapElement);
@@ -293,7 +293,7 @@ class ModelLine : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);  // check whether a discrete event happened

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLoad.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLoad.h
@@ -58,7 +58,7 @@ class ModelLoad : public NetworkComponent::Impl {
 
   /**
    * @brief set the load connection status
-   * @param state
+   * @param state load connection status
    */
   void setConnected(State state) {
     connectionState_ = state;
@@ -100,31 +100,31 @@ class ModelLoad : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -232,7 +232,7 @@ class ModelLoad : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
@@ -86,7 +86,7 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
  public:
   /**
    * @brief initialize the network model
-   * @param t0: initial time of the simulation
+   * @param t0 initial time of the simulation
    */
   void init(const double t0);
 
@@ -192,8 +192,8 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
 
   /**
    * @brief define elements
-   * @param elements
-   * @param mapElement
+   * @param elements vector of elements
+   * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
 
@@ -204,7 +204,7 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
@@ -216,7 +216,7 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
 
   /**
    * @brief define parameters
-   * @param parameters
+   * @param parameters parameters
    */
   void defineParameters(std::vector<ParameterModeler>& parameters);
 
@@ -233,7 +233,7 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
 
   /**
    * @brief init from data
-   * @param data
+   * @param data data
    */
   void initializeFromData(const boost::shared_ptr<DataInterface>& data);
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelPhaseTapChanger.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelPhaseTapChanger.h
@@ -46,8 +46,8 @@ class ModelPhaseTapChanger : public ModelTapChanger {
    * @brief  evaluate the zero crossing functions
    *
    * @param t : time to use during the evaluation
-   * @param iValue: current monitored by the tap changer
-   * @param nodeOff: unused
+   * @param iValue : current monitored by the tap changer
+   * @param nodeOff : unused
    * @param g : value of the zero crossing function
    * @param disable : is the tap changer disabled ?
    * @param locked : is the tap changer locked ?
@@ -59,8 +59,8 @@ class ModelPhaseTapChanger : public ModelTapChanger {
   /**
    * @brief  evaluate discrete values
    *
-   * @param t time to use during the evaluation
-   * @param g: root values
+   * @param t : time to use during the evaluation
+   * @param g : root values
    * @param network : network of the transformer
    * @param disable : is the tap changer disabled ?
    * @param P1SupP2 : is the active power evaluated at side 1 is superior to the active power evaluated at side 2  ?

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelRatioTapChanger.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelRatioTapChanger.h
@@ -46,8 +46,8 @@ class ModelRatioTapChanger : public ModelTapChanger {
    * @brief  evaluate the zero crossing functions
    *
    * @param t : time to use during the evaluation
-   * @param uValue: voltage monitored by the tap changer
-   * @param nodeOff: unused
+   * @param uValue : voltage monitored by the tap changer
+   * @param nodeOff : unused
    * @param g : value of the zero crossing function
    * @param disable : is the tap changer disabled ?
    * @param locked : is the tap changer locked ?
@@ -59,8 +59,8 @@ class ModelRatioTapChanger : public ModelTapChanger {
   /**
    * @brief  evaluate discrete values
    *
-   * @param t time to use during the evaluation
-   * @param g: root values
+   * @param t : time to use during the evaluation
+   * @param g : root values
    * @param network : network of the transformer
    * @param disable : is the tap changer disabled ?
    * @param nodeOff : is the node monitored by the tap changer off ?

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelShuntCompensator.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelShuntCompensator.h
@@ -71,7 +71,7 @@ class ModelShuntCompensator : public NetworkComponent::Impl {
 
   /**
    * @brief set connection status
-   * @param state
+   * @param state connection status
    */
   void setConnected(State state) {
     connectionState_ = state;
@@ -119,31 +119,31 @@ class ModelShuntCompensator : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -245,7 +245,7 @@ class ModelShuntCompensator : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelStaticVarCompensator.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelStaticVarCompensator.h
@@ -64,7 +64,7 @@ class ModelStaticVarCompensator : public NetworkComponent::Impl {
 
   /**
    * @brief set connection status
-   * @param state
+   * @param state connection status
    */
   void setConnected(State state) {
     connectionState_ = state;
@@ -97,31 +97,31 @@ class ModelStaticVarCompensator : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -234,7 +234,7 @@ class ModelStaticVarCompensator : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.h
@@ -62,7 +62,7 @@ class ModelSwitch : public boost::enable_shared_from_this<ModelSwitch>, public N
 
   /**
    * @brief set the switch connection state
-   * @param state
+   * @param state connection state
    */
   void setConnectionState(State state) {
     connectionState_ = state;
@@ -98,7 +98,7 @@ class ModelSwitch : public boost::enable_shared_from_this<ModelSwitch>, public N
 
   /**
    * @brief inLoop or not
-   * @param inLoop
+   * @param inLoop inLoop
    */
   void inLoop(bool inLoop) {
     inLoop_ = inLoop;
@@ -162,31 +162,31 @@ class ModelSwitch : public boost::enable_shared_from_this<ModelSwitch>, public N
   void evalDerivativesPrim() { /* not needed */ }
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement);
@@ -294,7 +294,7 @@ class ModelSwitch : public boost::enable_shared_from_this<ModelSwitch>, public N
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTapChanger.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTapChanger.h
@@ -63,7 +63,7 @@ class ModelTapChanger {
 
   /**
    * @brief return the step associated to the index
-   * @param index
+   * @param index index
    * @return step associated to the index
    */
   inline const TapChangerStep& getStep(int index) const {
@@ -76,7 +76,7 @@ class ModelTapChanger {
 
   /**
    * @brief  add a new TapChangerStep to the steps vector
-   * @param step
+   * @param step tap changer step
    */
   inline void addStep(const TapChangerStep& step) {
     steps_.push_back(step);
@@ -98,7 +98,7 @@ class ModelTapChanger {
 
   /**
    * @brief  set the current step to a new index
-   * @param index
+   * @param index step index
    */
   inline void setCurrentStepIndex(int index) { currentStepIndex_ = index; }
 
@@ -123,7 +123,7 @@ class ModelTapChanger {
 
   /**
    * @brief  set the highest step index
-   * @param index
+   * @param index step index
    */
   inline void setHighStepIndex(int index) { highStepIndex_ = index; }
 
@@ -135,7 +135,7 @@ class ModelTapChanger {
 
   /**
    * @brief set if the tap changer is regulating
-   * @param regulating
+   * @param regulating regulating
    */
   inline void setRegulating(bool regulating) { regulating_ = regulating; }
 
@@ -147,7 +147,7 @@ class ModelTapChanger {
 
   /**
    * @brief   set the time to wait before changing of step for the first time
-   * @param time
+   * @param time time
    */
   inline void setTFirst(double time) { tFirst_ = time; }
 
@@ -161,7 +161,7 @@ class ModelTapChanger {
   /**
    * @brief  set the time to wait before changing of step if it's not the first
    * time
-   * @param time
+   * @param time time
    */
   inline void setTNext(double time) { tNext_ = time; }
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelThreeWindingsTransformer.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelThreeWindingsTransformer.h
@@ -34,7 +34,7 @@ class ModelThreeWindingsTransformer : public NetworkComponent::Impl {
  public:
   /**
    * @brief default constructor
-   * @param tfo: three windings transformer data interface used to build the model
+   * @param tfo three windings transformer data interface used to build the model
    */
   explicit ModelThreeWindingsTransformer(const boost::shared_ptr<ThreeWTransformerInterface>& tfo);
 
@@ -84,25 +84,25 @@ class ModelThreeWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.h
@@ -101,7 +101,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief set the connection state (open, closed on one side, ...)
-   * @param state
+   * @param state connection state
    */
   void setConnectionState(State state) {
     connectionState_ = state;
@@ -109,7 +109,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief set the tap-changer model used along with the transformer
-   * @param model
+   * @param model tap-changer model
    */
   void setModelTapChanger(boost::shared_ptr<ModelTapChanger> model) {
     modelTapChanger_ = model;
@@ -135,7 +135,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief set monitoring bus
-   * @param modelBus
+   * @param modelBus monitored bus model
    */
   void setBusMonitored(const boost::shared_ptr<ModelBus>& modelBus) {
     modelBusMonitored_ = modelBus;
@@ -175,7 +175,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief set whether the current limit automaton is deactivated
-   * @param desactivate
+   * @param desactivate whether the current limit automaton is deactivated
    */
   void setCurrentLimitsDesactivate(const double& desactivate) {
     currentLimitsDesactivate_ = desactivate;
@@ -191,7 +191,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief set whether to rely on an internal (or external) tap-changer model
-   * @param disable
+   * @param disable whether to rely on an internal (or external) tap-changer model
    */
   void setDisableInternalTapChanger(const double& disable) {
     disableInternalTapChanger_ = disable;
@@ -207,7 +207,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief  set whether the tap-changer is locked (and cannot change taps)
-   * @param  locked
+   * @param  locked whether the tap-changer is locked
    */
   void setTapChangerLocked(const double& locked) {
     tapChangerLocked_ = locked;
@@ -254,32 +254,32 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables variables
    */
   static void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief instantiate variables
-   * @param variables
+   * @param variables variables
    */
   void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief define parameters
-   * @param parameters: vector to fill with the generic parameters
+   * @param parameters vector to fill with the generic parameters
    */
   static void defineParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   void defineNonGenericParameters(std::vector<ParameterModeler>& parameters);
 
   /**
    * @brief define elements
-   * @param elements
-   * @param mapElement
+   * @param elements vector of elements
+   * @param mapElement map of elements
    */
   void defineElements(std::vector<Element> &elements, std::map<std::string, int>& mapElement);
 
@@ -355,7 +355,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief init
-   * @param yNum
+   * @param yNum yNum
    */
   void init(int& yNum);
 
@@ -381,7 +381,7 @@ class ModelTwoWindingsTransformer : public NetworkComponent::Impl {
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   NetworkComponent::StateChange_t evalState(const double& time);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelVoltageLevel.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelVoltageLevel.h
@@ -42,7 +42,7 @@ class ModelVoltageLevel : public NetworkComponent::Impl {
  public:
   /**
    * @brief default constructor
-   * @param[in] voltageLevel: voltage level data interface to use for the model
+   * @param[in] voltageLevel voltage level data interface to use for the model
    */
   explicit ModelVoltageLevel(const boost::shared_ptr<VoltageLevelInterface>& voltageLevel);
 
@@ -111,15 +111,15 @@ class ModelVoltageLevel : public NetworkComponent::Impl {
 
   /**
    * @brief find the closest bus bar section of a bus in a voltage level
-   * @param node: the index of the bus for which to look for the closest bus bar section
-   * @param shortestPath: list of switch names that separate the bus bar section from the initial bus
+   * @param node the index of the bus for which to look for the closest bus bar section
+   * @param shortestPath list of switch names that separate the bus bar section from the initial bus
    * @return the closest bus bar section index
    */
   unsigned int findClosestBBS(const unsigned int node, std::vector<std::string>& shortestPath);
 
   /**
    * @brief return true if the closest bus bar section is switched off
-   * @param bus: the bus from which to look for the closest bus bar section
+   * @param bus the bus from which to look for the closest bus bar section
    * @return true is the closest bus bar section is switched off, false otherwise
    */
   bool isClosestBBSSwitchedOff(const boost::shared_ptr<ModelBus>& bus);
@@ -138,7 +138,7 @@ class ModelVoltageLevel : public NetworkComponent::Impl {
   /**
    * @brief evaluate jacobian \f$( J = @F/@x + cj * @F/@x')\f$
    * @param jt sparse matrix to fill
-   * @param cj
+   * @param cj jacobian prime coefficient
    * @param rowOffset row offset to use to find the first row to fill
    */
   void evalJt(SparseMatrix& jt, const double& cj, const int& rowOffset);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponent.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponent.h
@@ -70,19 +70,19 @@ class NetworkComponent {  ///< Base class for network component models
 
   /**
    * @brief define variables
-   * @param variables
+   * @param variables vector of variables
    */
   virtual void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& variables) = 0;
 
   /**
    * @brief define non generic parameters
-   * @param parameters: vector to fill with the non generic parameters
+   * @param parameters vector to fill with the non generic parameters
    */
   virtual void defineNonGenericParameters(std::vector<ParameterModeler>& parameters) = 0;
 
   /**
    * @brief define elements
-   * @param elements
+   * @param elements vector of elements
    * @param mapElement map of elements
    */
   virtual void defineElements(std::vector<Element>& elements, std::map<std::string, int>& mapElement) = 0;
@@ -215,7 +215,7 @@ class NetworkComponent {  ///< Base class for network component models
 
   /**
    * @brief init
-   * @param yNum
+   * @param yNum yNum
    */
   virtual void init(int& yNum) = 0;
 
@@ -262,22 +262,22 @@ class NetworkComponent {  ///< Base class for network component models
 
   /**
    * @brief network submodels parameters setter
-   * @param params: vector of parameters used to set network submodels parameters
+   * @param params vector of parameters used to set network submodels parameters
    */
   virtual void setSubModelParameters(const boost::unordered_map<std::string, ParameterModeler>& params) = 0;
 
   /**
    * @brief get a parameter with a given name from a vector of parameters
-   * @param name: name of the desired parameter
-   * @param params: vector of parameters
+   * @param name name of the desired parameter
+   * @param params vector of parameters
    * @return parameter with the given name
    */
   virtual ParameterModeler findParameter(const std::string& name, const boost::unordered_map<std::string, ParameterModeler>& params) const = 0;
 
   /**
    * @brief true if a parameter with a given name is present in a vector of parameters
-   * @param name: name of the desired parameter
-   * @param params: vector of parameters
+   * @param name name of the desired parameter
+   * @param params vector of parameters
    * @return true if the parameter with the given name has been found, false otherwise
    */
   virtual bool hasParameter(const std::string& name, const boost::unordered_map<std::string, ParameterModeler>& params) const = 0;
@@ -296,14 +296,14 @@ class NetworkComponent {  ///< Base class for network component models
 
   /**
    * @brief evaluate state
-   * @param time
+   * @param time time
    * @return state change type
    */
   virtual StateChange_t evalState(const double& time) = 0;
 
   /**
    * @brief set network
-   * @param model
+   * @param model model
    */
   virtual void setNetwork(ModelNetwork* model) = 0;
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponentImpl.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponentImpl.h
@@ -299,16 +299,16 @@ class NetworkComponent::Impl : public NetworkComponent {
 
   /**
    * @brief true if a parameter with a given name is present in a vector of parameters
-   * @param name: name of the desired parameter
-   * @param params: vector of parameters
+   * @param name name of the desired parameter
+   * @param params vector of parameters
    * @return true if the parameter with the given name has been found, false otherwise
    */
   bool hasParameter(const std::string& name, const boost::unordered_map<std::string, ParameterModeler>& params) const;
 
   /**
    * @brief get a parameter with a given name from a vector of parameters. Will throw a ParameterNotDefined exception if not found.
-   * @param name: name of the desired parameter
-   * @param params: vector of parameters
+   * @param name name of the desired parameter
+   * @param params vector of parameters
    * @return parameter with the given name
    */
   ParameterModeler findParameter(const std::string& name, const boost::unordered_map<std::string, ParameterModeler>& params) const;

--- a/dynawo/sources/Solvers/Common/DYNParameterSolver.h
+++ b/dynawo/sources/Solvers/Common/DYNParameterSolver.h
@@ -71,7 +71,7 @@ class ParameterSolver : public ParameterCommon {
 
   /**
    * @brief parameter's value setter
-   * @param value: parameter's value
+   * @param value parameter's value
    */
   template<typename T> void setValue(const T& value);
 

--- a/dynawo/sources/Solvers/Common/DYNSolver.h
+++ b/dynawo/sources/Solvers/Common/DYNSolver.h
@@ -85,7 +85,7 @@ class Solver {
   /**
    * @brief set the solver's parameters
    *
-   * @param params : parameter set used to set the solver's parameters
+   * @param params parameter set used to set the solver's parameters
    */
   virtual void setParameters(const boost::shared_ptr<parameters::ParametersSet> &params) = 0;
 
@@ -130,14 +130,14 @@ class Solver {
    *
    * If a parameter is not used, add a debug trace
    *
-   * @param params : parameter set to check
+   * @param params parameter set to check
    */
   virtual void checkUnusedParameters(boost::shared_ptr<parameters::ParametersSet> params) = 0;
 
   /**
    * @brief search for a parameter with a given name
    *
-   * @param name: name of the desired parameter
+   * @param name name of the desired parameter
    * @return desired parameter
    */
   virtual ParameterSolver& findParameter(const std::string &name) = 0;
@@ -145,15 +145,15 @@ class Solver {
   /**
    * @brief set a parameter value from a parameters set
    *
-   * @param parName: the name of the parameter to be set
-   * @param parametersSet: the set to scan for a value
+   * @param parName the name of the parameter to be set
+   * @param parametersSet the set to scan for a value
    */
   virtual void setParameterFromSet(const std::string &parName, const boost::shared_ptr<parameters::ParametersSet> parametersSet) = 0;
 
   /**
    * @brief set all parameters values from a parameters set (API PAR)
    *
-   * @param params : parameter set to check
+   * @param params parameter set to check
   */
   virtual void setParametersFromPARFile(const boost::shared_ptr<parameters::ParametersSet> &params) = 0;
 

--- a/dynawo/sources/Solvers/Common/DYNSolverFactory.h
+++ b/dynawo/sources/Solvers/Common/DYNSolverFactory.h
@@ -154,7 +154,7 @@ class SolverDelete {
   /**
    * @brief Constructor
    *
-   * @param factory: solver factory to delete
+   * @param factory solver factory to delete
    */
   explicit SolverDelete(SolverFactory* factory);
 
@@ -166,7 +166,7 @@ class SolverDelete {
   /**
    * @brief Function to use this class as a Functor
    *
-   * @param solver: pointer to the solver to delete
+   * @param solver pointer to the solver to delete
    * map
    */
   void operator()(Solver* solver);

--- a/dynawo/sources/Solvers/Common/DYNSolverImpl.h
+++ b/dynawo/sources/Solvers/Common/DYNSolverImpl.h
@@ -240,15 +240,15 @@ class Solver::Impl : public Solver, private boost::noncopyable {
   /**
    * @brief set a given parameter value
    *
-   * @param parameter: the desired parameter
-   * @param value : the value to set
+   * @param parameter the desired parameter
+   * @param value the value to set
    */
   template <typename T> void setParameterValue(ParameterSolver &parameter, const T &value);
 
   /**
    * @brief initialize all internal structure of the solver
-   * @param t0 : initial time of the simulation
-   * @param model : model to simulate, gives the size of all internal structure
+   * @param t0 initial time of the simulation
+   * @param model model to simulate, gives the size of all internal structure
    */
   void init(const double& t0, const boost::shared_ptr<Model> &model);
 


### PR DESCRIPTION
Removing -Wno-documentation causes errors !

```
error: empty paragraph passed to '@param' command [-Werror,-Wdocumentation]
error: parameter 'XXX:' not found in the function declaration [-Werror,-Wdocumentation]
error: duplicated command '@brief' [-Werror,-Wdocumentation]
openmodelica_func.h: error: empty paragraph passed to '\param' command [-Werror,-Wdocumentation]
openmodelica_func.h: error: unrecognized parameter passing direction, valid directions are '[in]', '[out]' and '[in,out]' [-Werror,-Wdocumentation]
```
See #125 
