### PR TITLE
#125 fix clang compilation -Wfloat-conversion

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -120,7 +120,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-double-promotion")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-extra-semi")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-float-conversion")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-float-equal")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-global-constructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-gnu-zero-variadic-macro-arguments")

--- a/dynawo/sources/Common/DYNCommon.cpp
+++ b/dynawo/sources/Common/DYNCommon.cpp
@@ -94,16 +94,16 @@ int sign(const double& value) {
 
 
 static double MAXIMUM_PRECISION = 1e-6;  ///< maximum precision
-static double MAXIMUM_PRECISION_AS_NB_DECIMAL = 6;  ///< maximum precision
+static int MAXIMUM_PRECISION_AS_NB_DECIMAL = 6;  ///< maximum precision
 double getCurrentPrecision() {
   return MAXIMUM_PRECISION;
 }
 void setCurrentPrecision(double precision) {
-  MAXIMUM_PRECISION = precision;
-  MAXIMUM_PRECISION_AS_NB_DECIMAL =  -std::log10(MAXIMUM_PRECISION);
+  MAXIMUM_PRECISION = std::abs(precision);
+  MAXIMUM_PRECISION_AS_NB_DECIMAL = static_cast<int>(-std::log10(MAXIMUM_PRECISION));
   MAXIMUM_VALUE_FIXED = std::pow(10, MAXIMUM_PRECISION_AS_NB_DECIMAL);
 }
-unsigned getPrecisionAsNbDecimal() {
+int getPrecisionAsNbDecimal() {
   return MAXIMUM_PRECISION_AS_NB_DECIMAL;
 }
 

--- a/dynawo/sources/Common/DYNCommon.h
+++ b/dynawo/sources/Common/DYNCommon.h
@@ -94,7 +94,7 @@ namespace DYN {
    * @brief return the current precision in the form of the number of decimals
    * @return the current precision in the form of the number of decimals
    */
-  unsigned getPrecisionAsNbDecimal();
+  int getPrecisionAsNbDecimal();
 
   /**
    * @brief convert native bool to Real (aka Dynawo boolean)

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
@@ -270,7 +270,7 @@ ModelMulti::init(const double t0) {
   for (int i = 0; i < sizeZ(); ++i) {
     if (doubleNotEquals(zLocal_[i], zSave_[i])) {
       indicesDiff.push_back(i);
-      valuesModified.push_back(zLocal_[i]);
+      valuesModified.push_back(static_cast<int>(zLocal_[i]));
     }
   }
 

--- a/dynawo/sources/Modeler/DataInterface/DYNComponentInterface.hpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNComponentInterface.hpp
@@ -36,13 +36,13 @@ T ComponentInterface::getStaticParameterValue(const std::string& name) const {
     } else {
       switch (type) {
         case StaticParameter::INT:
-          return iter->second.getValue<int>();
+          return static_cast<T>(iter->second.getValue<int>());
           break;
         case StaticParameter::DOUBLE:
-          return iter->second.getValue<double>();
+          return static_cast<T>(iter->second.getValue<double>());
           break;
         case StaticParameter::BOOL:
-          return iter->second.getValue<bool>();
+          return static_cast<T>(iter->second.getValue<bool>());
           break;
         default:
           throw DYNError(Error::MODELER, StaticParameterWrongType, name);
@@ -67,13 +67,13 @@ T ComponentInterface::getValue(const int index) const {
   } else {
     switch (stateVariables_[index].getType()) {
       case StateVariable::INT:
-        return stateVariables_[index].getValue<int>();
+        return static_cast<T>(stateVariables_[index].getValue<int>());
         break;
       case StateVariable::DOUBLE:
-        return stateVariables_[index].getValue<double>();
+        return static_cast<T>(stateVariables_[index].getValue<double>());
         break;
       case StateVariable::BOOL:
-        return stateVariables_[index].getValue<bool>();
+        return static_cast<T>(stateVariables_[index].getValue<bool>());
         break;
     }
   }

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNVoltageLevelInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNVoltageLevelInterfaceIIDM.cpp
@@ -280,7 +280,7 @@ VoltageLevelInterfaceIIDM::exportSwitchesState() {
   // following component (de)connection (only Modelica models)
   map<shared_ptr<SwitchInterface>, double >::const_iterator iter = switchState_.begin();
   for (; iter != switchState_.end(); ++iter) {
-    int state = iter->second;
+    int state = static_cast<int>(iter->second);
     if (state == OPEN)
       iter->first->open();
     else

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVoltageLevelInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVoltageLevelInterfaceIIDM.cpp
@@ -352,7 +352,7 @@ VoltageLevelInterfaceIIDM::exportSwitchesState() {
   // following component (de)connection (only Modelica models)
   for (boost::unordered_map<shared_ptr<SwitchInterface>, double >::const_iterator iter = switchState_.begin(),
       iterEnd = switchState_.end(); iter != iterEnd; ++iter) {
-    int state = iter->second;
+    int state = static_cast<int>(iter->second);
     if (state == OPEN)
       iter->first->open();
     else

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.h
@@ -502,7 +502,7 @@ class ModelBus : public NetworkComponent::Impl {  ///< Generic AC network bus
   inline int numSubNetwork() const {
     assert(z_ != NULL);
     assert(doubleNotEquals(z_[numSubNetworkNum_], -1.));
-    return z_[numSubNetworkNum_];
+    return static_cast<int>(z_[numSubNetworkNum_]);
   }
 
   /**

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
@@ -172,7 +172,7 @@ modelType_("TwoWindingsTransformer") {
       double bTap = b * (1. + bTapChanger + steps[i]->getB() / 100.);
       modelPhaseChanger_->addStep(TapChangerStep(rho, phaseShift, rTap, xTap, gTap, bTap));
     }
-    modelPhaseChanger_->setHighStepIndex(phaseTapChanger->getNbTap() - 1. + lowIndex);
+    modelPhaseChanger_->setHighStepIndex(phaseTapChanger->getNbTap() + lowIndex - 1);
     modelPhaseChanger_->setCurrentStepIndex(phaseTapChanger->getCurrentPosition());
 
     // At the moment, only current regulation is supported.
@@ -196,7 +196,7 @@ modelType_("TwoWindingsTransformer") {
         double bTap = b * (1. + steps[i]->getB() / 100.);
         modelRatioChanger_->addStep(TapChangerStep(rho, 0, rTap, xTap, gTap, bTap));
       }
-      modelRatioChanger_->setHighStepIndex(ratioTapChanger->getNbTap() - 1. + lowIndex);
+      modelRatioChanger_->setHighStepIndex(ratioTapChanger->getNbTap() + lowIndex - 1);
       modelRatioChanger_->setCurrentStepIndex(ratioTapChanger->getCurrentPosition());
 
       bool regulating = ratioTapChanger->getRegulating();

--- a/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINCommon.cpp
+++ b/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINCommon.cpp
@@ -137,7 +137,7 @@ SolverKINCommon::initCommon(const std::string& linearSolverName, double fnormtol
   // -------------------
   // Passing CSR_MAT indicates that we solve A'x = B - linear system using the matrix transpose -
   // and not Ax = B (see sunlinsol_klu.c:149)
-  const int nnz = 0.0001 * numF_ * numF_;  // This value will be adjusted later on in the process
+  const int nnz = static_cast<int>(0.0001 * numF_ * numF_);  // This value will be adjusted later on in the process
   sundialsMatrix_ = SUNSparseMatrix(numF_, numF_, nnz, CSR_MAT);
   if (sundialsMatrix_ == NULL)
     throw DYNError(Error::SUNDIALS_ERROR, SolverFuncErrorKINSOL, "SUNSparseMatrix");


### PR DESCRIPTION
Removing -Wno-float-conversion causes errors !

```
error: implicit conversion turns floating-point number into integer: 'double' to 'unsigned int' [-Werror,-Wfloat-conversion]
error: implicit conversion turns floating-point number into integer: 'double' to 'std::vector<int, std::allocator<int> >::value_type' (aka 'int') [-Werror,-Wfloat-conversion]
...
```

See #125 
