### PR TITLE
#1851 Improve performance for data check coherence

### DIFF
--- a/dynawo/sources/Modeler/Common/DYNConnectorCalculatedVariable.cpp
+++ b/dynawo/sources/Modeler/Common/DYNConnectorCalculatedVariable.cpp
@@ -60,11 +60,6 @@ ConnectorCalculatedVariable::init(const double /*t0*/) {
 }
 
 void
-ConnectorCalculatedVariable::checkDataCoherence(const double /*t*/) {
-  // no check
-}
-
-void
 ConnectorCalculatedVariable::checkParametersCoherence() const {
   // no check
 }

--- a/dynawo/sources/Modeler/Common/DYNConnectorCalculatedVariable.h
+++ b/dynawo/sources/Modeler/Common/DYNConnectorCalculatedVariable.h
@@ -205,11 +205,6 @@ class ConnectorCalculatedVariable : public SubModel {
   void defineParametersInit(std::vector<ParameterModeler>& parameters);
 
   /**
-   * @copydoc SubModel::checkDataCoherence (const double t)
-   */
-  void checkDataCoherence(const double t);
-
-  /**
    * @copydoc SubModel::checkParametersCoherence () const
    */
   void checkParametersCoherence() const;

--- a/dynawo/sources/Modeler/Common/DYNSubModel.cpp
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.cpp
@@ -925,6 +925,9 @@ SubModel::checkDataCoherenceSub(const double t) {
   if (isInitProcess_ && withLoadedParameters_ && withLoadedVariables_) {
     return;
   }
+  if (!hasDataCheckCoherence()) {
+    return;
+  }
   setCurrentTime(t);
   checkDataCoherence(t);
 }
@@ -1338,6 +1341,11 @@ SubModel::printInitValuesVariables(std::ofstream& fstream) {
   for (unsigned int i = 0, iEnd = zAliasesNames.size(); i < iEnd; ++i)
     fstream << std::setw(50) << std::left << zAliasesNames[i].first << std::right << ": "<<
     ((zAliasesNames[i].second.second)?"negated ":"") << "alias of " << zAliasesNames[i].second.first << "\n";
+}
+
+void
+SubModel::checkDataCoherence(const double) {
+  // Does nothing, by compliance with default implementation of hasDataCheckCoherence
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Modeler/Common/DYNSubModel.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.h
@@ -197,7 +197,7 @@ class SubModel {
    *
    * @param t time for which to conduct the data coherence check
    */
-  virtual void checkDataCoherence(const double t) = 0;  ///< sanity checks on data
+  virtual void checkDataCoherence(const double t);
 
   /**
    * @brief set formula for modelica models' equation
@@ -1404,6 +1404,14 @@ class SubModel {
    * @param fstream the file to stream parameters to
    */
   virtual void printInitValuesParameters(std::ofstream& fstream);
+
+  /**
+   * @brief Determines if the sub model has a data check coherence operation (non empty function)
+   * @returns true if the sub model has a data check coherence operation, false if not
+   */
+  virtual bool hasDataCheckCoherence() const {
+    return false;
+  }
 
  private:
   /**

--- a/dynawo/sources/Modeler/Common/test/Test.cpp
+++ b/dynawo/sources/Modeler/Common/test/Test.cpp
@@ -117,10 +117,6 @@ class SubModelMockBase : public SubModel {
 
   virtual modeChangeType_t evalMode(const double) = 0;
 
-  void checkDataCoherence(const double) {
-    // Dummy class used for testing
-  }
-
   void checkParametersCoherence() const {
     // Dummy class used for testing
   }

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
@@ -236,6 +236,11 @@ ModelManager::evalF(double t, propertyF_t type) {
   modelModelica()->setFomc(fLocal_, type);
 }
 
+bool
+ModelManager::hasDataCheckCoherence() const {
+  return modelModelica()->hasCheckDataCoherence();
+}
+
 void
 ModelManager::checkDataCoherence(const double t) {
 #if defined(_DEBUG_) || defined(PRINT_TIMERS)

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManager.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManager.h
@@ -349,6 +349,11 @@ class ModelManager : public SubModel, private boost::noncopyable {
    */
   void addDelay(int exprNumber, const double* time, const double* exprValue, double delayMax);
 
+  /**
+   * @copydoc SubModel::hasDataCheckCoherence() const
+   */
+  bool hasDataCheckCoherence() const;
+
  private:
 #ifdef _ADEPT_
 

--- a/dynawo/sources/Modeler/ModelManager/DYNModelModelica.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelModelica.h
@@ -278,6 +278,15 @@ class ModelModelica {
    * @param indexes vector to fill with the indexes
    */
   virtual void getIndexesOfVariablesUsedForCalculatedVarI(unsigned iCalculatedVar, std::vector<int>& indexes) const = 0;
+
+  /**
+   * @brief Determines if the sub model has a data check coherence operation (non empty function)
+   * @returns true if the sub model has a data check coherence operation, false if not
+   */
+  inline bool hasCheckDataCoherence() const { return hasCheckDataCoherence_; }
+
+ protected:
+  bool hasCheckDataCoherence_;  ///< Determines if the modelica model has a data check coherence operation
 };
 }  // namespace DYN
 

--- a/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/headerPatternDefine.py
+++ b/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/headerPatternDefine.py
@@ -47,7 +47,10 @@ class HeaderPatternDefine:
   class Model__fill_model_name___Dyn : public ModelModelica
   {
     public:
-    Model__fill_model_name___Dyn() {dataStructIsInitialized_ = false;}
+    Model__fill_model_name___Dyn() {
+        dataStructIsInitialized_ = false;
+        hasCheckDataCoherence_ = __fill_has_check_data_coherence__;
+    }
     ~Model__fill_model_name___Dyn() {if (dataStructIsInitialized_) deInitializeDataStruc();}
 
 
@@ -133,7 +136,10 @@ namespace DYN {
   class Model__fill_model_name___Init : public ModelModelica
   {
     public:
-    Model__fill_model_name___Init() {dataStructIsInitialized_ = false;}
+    Model__fill_model_name___Init() {
+        dataStructIsInitialized_ = false;
+        hasCheckDataCoherence_ = __fill_has_check_data_coherence__;
+    }
     ~Model__fill_model_name___Init() {if (dataStructIsInitialized_) deInitializeDataStruc();}
 
 

--- a/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/modelWriter.py
+++ b/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/modelWriter.py
@@ -869,9 +869,13 @@ class ModelWriter(ModelWriterBase):
     # @param self : object pointer
     # @return
     def insert_model_name(self):
+        has_check_data_coherence_str = "false" if (not self.builder.get_list_for_warnings()) else "true"
         for n, line in enumerate(self.file_content_h):
             if "__fill_model_name__" in line:
                 line_tmp = line.replace("__fill_model_name__", self.mod_name)
+                self.file_content_h [n] = line_tmp
+            if "__fill_has_check_data_coherence__" in line:
+                line_tmp = line.replace("__fill_has_check_data_coherence__", has_check_data_coherence_str)
                 self.file_content_h [n] = line_tmp
 
     ##

--- a/dynawo/sources/ModelicaCompiler/test/ModelicaModel/reference/GeneratorPQ_Dyn.h
+++ b/dynawo/sources/ModelicaCompiler/test/ModelicaModel/reference/GeneratorPQ_Dyn.h
@@ -19,7 +19,10 @@ namespace DYN {
   class ModelGeneratorPQ_Dyn : public ModelModelica
   {
     public:
-    ModelGeneratorPQ_Dyn() {dataStructIsInitialized_ = false;}
+    ModelGeneratorPQ_Dyn() {
+        dataStructIsInitialized_ = false;
+        hasCheckDataCoherence_ = false;
+    }
     ~ModelGeneratorPQ_Dyn() {if (dataStructIsInitialized_) deInitializeDataStruc();}
 
 

--- a/dynawo/sources/ModelicaCompiler/test/ModelicaModel/reference/GeneratorPQ_Init.h
+++ b/dynawo/sources/ModelicaCompiler/test/ModelicaModel/reference/GeneratorPQ_Init.h
@@ -18,7 +18,10 @@ namespace DYN {
   class ModelGeneratorPQ_Init : public ModelModelica
   {
     public:
-    ModelGeneratorPQ_Init() {dataStructIsInitialized_ = false;}
+    ModelGeneratorPQ_Init() {
+        dataStructIsInitialized_ = false;
+        hasCheckDataCoherence_ = false;
+    }
     ~ModelGeneratorPQ_Init() {if (dataStructIsInitialized_) deInitializeDataStruc();}
 
 

--- a/dynawo/sources/Models/CPP/Common/DYNModelCPP.h
+++ b/dynawo/sources/Models/CPP/Common/DYNModelCPP.h
@@ -284,11 +284,6 @@ class ModelCPP : public SubModel {
   virtual void defineParametersInit(std::vector<ParameterModeler>& parameters) = 0;
 
   /**
-   * @copydoc SubModel::checkDataCoherence(const double t)
-   */
-  virtual void checkDataCoherence(const double t) = 0;
-
-  /**
    * @copydoc SubModel::checkParametersCoherence() const
    */
   virtual void checkParametersCoherence() const = 0;

--- a/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.h
+++ b/dynawo/sources/Models/CPP/Common/DYNModelCPPImpl.h
@@ -256,11 +256,6 @@ class ModelCPP::Impl : public ModelCPP {
   void loadParameters(const std::string &parameters);
 
   /**
-   * @copydoc ModelCPP::checkDataCoherence()
-   */
-  virtual void checkDataCoherence(const double t) = 0;
-
-  /**
    * @copydoc ModelCPP::checkParametersCoherence() const
    */
   void checkParametersCoherence() const;

--- a/dynawo/sources/Models/CPP/Components/ModelLoadRestorativeWithLimits/DYNModelLoadRestorativeWithLimits.h
+++ b/dynawo/sources/Models/CPP/Components/ModelLoadRestorativeWithLimits/DYNModelLoadRestorativeWithLimits.h
@@ -271,11 +271,6 @@ class ModelLoadRestorativeWithLimits : public ModelCPP::Impl {
   */
   void evalZ(const double t);
 
-  /**
-   * @brief Coherence check on data (asserts, min/max values, sanity checks)
-   */
-  void checkDataCoherence(const double /*t*/) { /* not needed */ }
-
  private:
   unsigned int UfRawYNum_;  ///< local Y index for UfRaw
   unsigned int UfYNum_;  ///< local Y index for Uf

--- a/dynawo/sources/Models/CPP/Controls/Shunts/ModelCentralizedShuntsSectionControl/DYNModelCentralizedShuntsSectionControl.h
+++ b/dynawo/sources/Models/CPP/Controls/Shunts/ModelCentralizedShuntsSectionControl/DYNModelCentralizedShuntsSectionControl.h
@@ -195,10 +195,6 @@ class ModelCentralizedShuntsSectionControl : public ModelCPP::Impl {
    */
   void initializeStaticData() { /* not needed */ }
   /**
-   * @brief Coherence check on data (asserts, min/max values, sanity checks)
-   */
-  void checkDataCoherence(const double /*t*/) { /* not needed */ }
-  /**
    * @brief calculate calculated variables
    */
   void evalCalculatedVars() { /* not need */ }

--- a/dynawo/sources/Models/CPP/Events/ModelVariationArea/DYNModelVariationArea.h
+++ b/dynawo/sources/Models/CPP/Events/ModelVariationArea/DYNModelVariationArea.h
@@ -270,11 +270,6 @@ class ModelVariationArea : public ModelCPP::Impl {
    */
   void initParams() { /* not needed */ }
 
-  /**
-   * @brief Coherence check on data (asserts, min/max values, sanity checks)
-   */
-  void checkDataCoherence(const double /*t*/) { /* not needed */ }
-
  private:
   // parameters
   std::vector<double> deltaP_;  ///< load variations for active power

--- a/dynawo/sources/Models/CPP/Events/ModelVoltageSetPointChange/DYNModelVoltageSetPointChange.h
+++ b/dynawo/sources/Models/CPP/Events/ModelVoltageSetPointChange/DYNModelVoltageSetPointChange.h
@@ -272,11 +272,6 @@ class ModelVoltageSetPointChange : public ModelCPP::Impl {
    */
   void initParams() { /* not needed */ }
 
-  /**
-   * @brief Coherence check on data (asserts, min/max values, sanity checks)
-   */
-  void checkDataCoherence(const double /*t*/) { /* not needed */ }
-
  private:
   double startTime_;  ///< start time
   double stopTime_;  ///< stop time

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.h
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.h
@@ -281,6 +281,11 @@ class ModelOmegaRef : public ModelCPP::Impl {
    */
   void checkDataCoherence(const double t);
 
+  /**
+   * @copydoc SubModel::hasDataCheckCoherence() const
+   */
+  bool hasCheckDataCoherence() const { return true; }
+
  private:
   /**
    * @brief Sort every generator by num of subNetwork

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
@@ -291,11 +291,6 @@ class ModelNetwork : public ModelCPP::Impl, private boost::noncopyable {
    */
   void printModel() const;
 
-  /**
-   * @brief Coherence check on data (asserts, min/max values, sanity checks)
-   */
-  void checkDataCoherence(const double /*t*/) { /* not needed */ }
-
  protected:
   /**
   * @copydoc SubModel::dumpUserReadableElementList()


### PR DESCRIPTION
A lot of checkDataCoherence functions are empty function, generating a lot of pointless calls. So we check a boolean to determine if the function is not empty