### PR TITLE
#125 fix clang compilation -Wfloat-equal

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -120,7 +120,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-double-promotion")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-extra-semi")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-float-equal")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-global-constructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-gnu-zero-variadic-macro-arguments")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-mismatched-tags")

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNCurrentLimitInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNCurrentLimitInterfaceIIDM.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "DYNCurrentLimitInterfaceIIDM.h"
+#include "DYNCommon.h"
 
 #include <limits>
 
@@ -37,7 +38,7 @@ CurrentLimitInterfaceIIDM::~CurrentLimitInterfaceIIDM() {
 
 double
 CurrentLimitInterfaceIIDM::getLimit() const {
-  if (limit_ == std::numeric_limits<double>::max())
+  if (doubleEquals(limit_, std::numeric_limits<double>::max()))
     return std::numeric_limits<double>::quiet_NaN();
   return limit_;
 }

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/test/TestCurrentLimitInterface.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/test/TestCurrentLimitInterface.cpp
@@ -24,7 +24,7 @@ TEST(DataInterfaceTest, CurrentLimit) {
   ASSERT_EQ(C.getAcceptableDuration(), 99);
 
   DYN::CurrentLimitInterfaceIIDM D(std::numeric_limits<double>::max(), 9876UL);
-  ASSERT_TRUE(isnan(D.getLimit()));
+  ASSERT_TRUE(std::isnan(D.getLimit()));
   ASSERT_EQ(D.getAcceptableDuration(), 9876);
 
   DYN::CurrentLimitInterfaceIIDM E(-1000, std::numeric_limits<unsigned long>::max());

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
@@ -127,8 +127,8 @@ modelType_("TwoWindingsTransformer") {
     } else {
       vNom2_ = tfo->getRatedU2();  // bus2 is unknown, so for the per unit we decided to use the ratedU2, not correct but better than nothing
     }
-    assert(vNom1_ == vNom1_);  // control that vNom != NAN
-    assert(vNom2_ == vNom2_);  // control that vNom != NAN
+    assert(!std::isnan(vNom1_));  // control that vNom != NAN
+    assert(!std::isnan(vNom2_));  // control that vNom != NAN
   }
 
   if (tfo->getBusInterface1() && tfo->getBusInterface2())


### PR DESCRIPTION
Removing -Wno-float-equal causes errors !

`error: comparing floating point with == or != is unsafe [-Werror,-Wfloat-equal]`

See #125 
