### PR TITLE
#125 fix clang compilation -Wglobal-constructors

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -120,7 +120,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-double-promotion")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-extra-semi")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-global-constructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-mismatched-tags")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-noreturn")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-prototypes")

--- a/dynawo/sources/API/CRT/CRTXmlHandler.cpp
+++ b/dynawo/sources/API/CRT/CRTXmlHandler.cpp
@@ -43,18 +43,22 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-xml::sax::parser::namespace_uri crt_ns("http://www.rte-france.com/dynawo");  ///< namespace used to read crt xml file
-
 namespace criteria {
+
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
 
 XmlHandler::XmlHandler() :
 criteriaCollection_(CriteriaCollectionFactory::newInstance()),
-busCriteriaHandler_(parser::ElementName(crt_ns, "busCriteria")) ,
-loadCriteriaHandler_(parser::ElementName(crt_ns, "loadCriteria")),
-genCriteriaHandler_(parser::ElementName(crt_ns, "generatorCriteria")) {
-  onElement(crt_ns("criteria/busCriteria"), busCriteriaHandler_);
-  onElement(crt_ns("criteria/loadCriteria"), loadCriteriaHandler_);
-  onElement(crt_ns("criteria/generatorCriteria"), genCriteriaHandler_);
+busCriteriaHandler_(parser::ElementName(namespace_uri(), "busCriteria")) ,
+loadCriteriaHandler_(parser::ElementName(namespace_uri(), "loadCriteria")),
+genCriteriaHandler_(parser::ElementName(namespace_uri(), "generatorCriteria")) {
+  onElement(namespace_uri()("criteria/busCriteria"), busCriteriaHandler_);
+  onElement(namespace_uri()("criteria/loadCriteria"), loadCriteriaHandler_);
+  onElement(namespace_uri()("criteria/generatorCriteria"), genCriteriaHandler_);
   busCriteriaHandler_.onEnd(lambda::bind(&XmlHandler::addBusCriteria, lambda::ref(*this)));
   loadCriteriaHandler_.onEnd(lambda::bind(&XmlHandler::addLoadCriteria, lambda::ref(*this)));
   genCriteriaHandler_.onEnd(lambda::bind(&XmlHandler::addGenCriteria, lambda::ref(*this)));
@@ -84,13 +88,13 @@ XmlHandler::addGenCriteria() {
 }
 
 CriteriaHandler::CriteriaHandler(elementName_type const& root_element) :
-criteriaParamsHandler_(parser::ElementName(crt_ns, "parameters")),
-cmpHandler_(parser::ElementName(crt_ns, "component")),
-countryHandler_(parser::ElementName(crt_ns, "country")) {
+criteriaParamsHandler_(parser::ElementName(namespace_uri(), "parameters")),
+cmpHandler_(parser::ElementName(namespace_uri(), "component")),
+countryHandler_(parser::ElementName(namespace_uri(), "country")) {
   onStartElement(root_element, lambda::bind(&CriteriaHandler::create, lambda::ref(*this), lambda_args::arg2));
-  onElement(root_element + crt_ns("parameters"), criteriaParamsHandler_);
-  onElement(root_element + crt_ns("component"), cmpHandler_);
-  onElement(root_element + crt_ns("country"), countryHandler_);
+  onElement(root_element + namespace_uri()("parameters"), criteriaParamsHandler_);
+  onElement(root_element + namespace_uri()("component"), cmpHandler_);
+  onElement(root_element + namespace_uri()("country"), countryHandler_);
   criteriaParamsHandler_.onEnd(lambda::bind(&CriteriaHandler::addCriteriaParams, lambda::ref(*this)));
   cmpHandler_.onEnd(lambda::bind(&CriteriaHandler::addComponent, lambda::ref(*this)));
   countryHandler_.onEnd(lambda::bind(&CriteriaHandler::addCountry, lambda::ref(*this)));

--- a/dynawo/sources/API/CRT/test/TestXmlImporter.cpp
+++ b/dynawo/sources/API/CRT/test/TestXmlImporter.cpp
@@ -27,10 +27,9 @@
 
 using DYN::doubleEquals;
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace criteria {
-testing::Environment* const env = initXmlEnvironment();
 
 //-----------------------------------------------------
 // TEST XmlImporter

--- a/dynawo/sources/API/CRV/CRVXmlHandler.cpp
+++ b/dynawo/sources/API/CRV/CRVXmlHandler.cpp
@@ -41,14 +41,18 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-xml::sax::parser::namespace_uri crv_ns("http://www.rte-france.com/dynawo");  ///< namespace used to read crv xml file
-
 namespace curves {
+
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
 
 XmlHandler::XmlHandler() :
 curvesCollection_(CurvesCollectionFactory::newInstance("")),
-curveHandler_(parser::ElementName(crv_ns, "curve")) {
-  onElement(crv_ns("curvesInput/curve"), curveHandler_);
+curveHandler_(parser::ElementName(namespace_uri(), "curve")) {
+  onElement(namespace_uri()("curvesInput/curve"), curveHandler_);
   curveHandler_.onEnd(lambda::bind(&XmlHandler::addCurve, lambda::ref(*this)));
 }
 

--- a/dynawo/sources/API/CRV/test/TestXmlImporter.cpp
+++ b/dynawo/sources/API/CRV/test/TestXmlImporter.cpp
@@ -21,10 +21,9 @@
 
 #include "CRVXmlImporter.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace curves {
-testing::Environment* const env = initXmlEnvironment();
 
 //-----------------------------------------------------
 // TEST XmlImporter

--- a/dynawo/sources/API/DYD/DYDXmlHandler.cpp
+++ b/dynawo/sources/API/DYD/DYDXmlHandler.cpp
@@ -60,28 +60,32 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-xml::sax::parser::namespace_uri dyd_ns("http://www.rte-france.com/dynawo"); ///< namespace used to read dyd xml file
-
 namespace dynamicdata {
+
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
 
 XmlHandler::XmlHandler() :
 dynamicModelsCollection_(DynamicModelsCollectionFactory::newCollection()),
-modelicaModelHandler_(parser::ElementName(dyd_ns, "modelicaModel")),
-modelTemplateHandler_(parser::ElementName(dyd_ns, "modelTemplate")),
-blackBoxModelHandler_(parser::ElementName(dyd_ns, "blackBoxModel")),
-modelTemplateExpansionHandler_(parser::ElementName(dyd_ns, "modelTemplateExpansion")),
-connectHandler_(parser::ElementName(dyd_ns, "connect")),
-macroConnectHandler_(parser::ElementName(dyd_ns, "macroConnect")),
-macroConnectorHandler_(parser::ElementName(dyd_ns, "macroConnector")),
-macroStaticReferenceHandler_(parser::ElementName(dyd_ns, "macroStaticReference")) {
-  onElement(dyd_ns("dynamicModelsArchitecture/modelicaModel"), modelicaModelHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/modelTemplate"), modelTemplateHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/blackBoxModel"), blackBoxModelHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/modelTemplateExpansion"), modelTemplateExpansionHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/connect"), connectHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/macroConnect"), macroConnectHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/macroConnector"), macroConnectorHandler_);
-  onElement(dyd_ns("dynamicModelsArchitecture/macroStaticReference"), macroStaticReferenceHandler_);
+modelicaModelHandler_(parser::ElementName(namespace_uri(), "modelicaModel")),
+modelTemplateHandler_(parser::ElementName(namespace_uri(), "modelTemplate")),
+blackBoxModelHandler_(parser::ElementName(namespace_uri(), "blackBoxModel")),
+modelTemplateExpansionHandler_(parser::ElementName(namespace_uri(), "modelTemplateExpansion")),
+connectHandler_(parser::ElementName(namespace_uri(), "connect")),
+macroConnectHandler_(parser::ElementName(namespace_uri(), "macroConnect")),
+macroConnectorHandler_(parser::ElementName(namespace_uri(), "macroConnector")),
+macroStaticReferenceHandler_(parser::ElementName(namespace_uri(), "macroStaticReference")) {
+  onElement(namespace_uri()("dynamicModelsArchitecture/modelicaModel"), modelicaModelHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/modelTemplate"), modelTemplateHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/blackBoxModel"), blackBoxModelHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/modelTemplateExpansion"), modelTemplateExpansionHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/connect"), connectHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/macroConnect"), macroConnectHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/macroConnector"), macroConnectorHandler_);
+  onElement(namespace_uri()("dynamicModelsArchitecture/macroStaticReference"), macroStaticReferenceHandler_);
 
   modelicaModelHandler_.onEnd(lambda::bind(&XmlHandler::addModelicaModel, lambda::ref(*this)));
   modelTemplateHandler_.onEnd(lambda::bind(&XmlHandler::addModelTemplate, lambda::ref(*this)));
@@ -142,20 +146,20 @@ XmlHandler::addMacroStaticReference() {
 }
 
 ModelicaModelHandler::ModelicaModelHandler(elementName_type const& root_element) :
-connectHandler_(parser::ElementName(dyd_ns, "connect")),
-initConnectHandler_(parser::ElementName(dyd_ns, "initConnect")),
-macroConnectHandler_(parser::ElementName(dyd_ns, "macroConnect")),
-staticRefHandler_(parser::ElementName(dyd_ns, "staticRef")),
-macroStaticRefHandler_(parser::ElementName(dyd_ns, "macroStaticRef")),
-unitDynamicModelHandler_(parser::ElementName(dyd_ns, "unitDynamicModel")) {
+connectHandler_(parser::ElementName(namespace_uri(), "connect")),
+initConnectHandler_(parser::ElementName(namespace_uri(), "initConnect")),
+macroConnectHandler_(parser::ElementName(namespace_uri(), "macroConnect")),
+staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")),
+macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")),
+unitDynamicModelHandler_(parser::ElementName(namespace_uri(), "unitDynamicModel")) {
   onStartElement(root_element, lambda::bind(&ModelicaModelHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + dyd_ns("connect"), connectHandler_);
-  onElement(root_element + dyd_ns("initConnect"), initConnectHandler_);
-  onElement(root_element + dyd_ns("macroConnect"), macroConnectHandler_);
-  onElement(root_element + dyd_ns("staticRef"), staticRefHandler_);
-  onElement(root_element + dyd_ns("macroStaticRef"), macroStaticRefHandler_);
-  onElement(root_element + dyd_ns("unitDynamicModel"), unitDynamicModelHandler_);
+  onElement(root_element + namespace_uri()("connect"), connectHandler_);
+  onElement(root_element + namespace_uri()("initConnect"), initConnectHandler_);
+  onElement(root_element + namespace_uri()("macroConnect"), macroConnectHandler_);
+  onElement(root_element + namespace_uri()("staticRef"), staticRefHandler_);
+  onElement(root_element + namespace_uri()("macroStaticRef"), macroStaticRefHandler_);
+  onElement(root_element + namespace_uri()("unitDynamicModel"), unitDynamicModelHandler_);
 
   connectHandler_.onEnd(lambda::bind(&ModelicaModelHandler::addConnect, lambda::ref(*this)));
   initConnectHandler_.onEnd(lambda::bind(&ModelicaModelHandler::addInitConnect, lambda::ref(*this)));
@@ -218,21 +222,21 @@ ModelicaModelHandler::addUnitDynamicModel() {
 }
 
 ModelTemplateHandler::ModelTemplateHandler(elementName_type const& root_element) :
-connectHandler_(parser::ElementName(dyd_ns, "connect")),
-initConnectHandler_(parser::ElementName(dyd_ns, "initConnect")),
-macroConnectHandler_(parser::ElementName(dyd_ns, "macroConnect")),
-staticRefHandler_(parser::ElementName(dyd_ns, "staticRef")),
-macroStaticRefHandler_(parser::ElementName(dyd_ns, "macroStaticRef")),
-unitDynamicModelHandler_(parser::ElementName(dyd_ns, "unitDynamicModel")) {
+connectHandler_(parser::ElementName(namespace_uri(), "connect")),
+initConnectHandler_(parser::ElementName(namespace_uri(), "initConnect")),
+macroConnectHandler_(parser::ElementName(namespace_uri(), "macroConnect")),
+staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")),
+macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")),
+unitDynamicModelHandler_(parser::ElementName(namespace_uri(), "unitDynamicModel")) {
   onStartElement(root_element, lambda::bind(&ModelTemplateHandler::create, lambda::ref(*this), lambda_args::arg2));
 
 
-  onElement(root_element + dyd_ns("connect"), connectHandler_);
-  onElement(root_element + dyd_ns("initConnect"), initConnectHandler_);
-  onElement(root_element + dyd_ns("macroConnect"), macroConnectHandler_);
-  onElement(root_element + dyd_ns("staticRef"), staticRefHandler_);
-  onElement(root_element + dyd_ns("macroStaticRef"), macroStaticRefHandler_);
-  onElement(root_element + dyd_ns("unitDynamicModel"), unitDynamicModelHandler_);
+  onElement(root_element + namespace_uri()("connect"), connectHandler_);
+  onElement(root_element + namespace_uri()("initConnect"), initConnectHandler_);
+  onElement(root_element + namespace_uri()("macroConnect"), macroConnectHandler_);
+  onElement(root_element + namespace_uri()("staticRef"), staticRefHandler_);
+  onElement(root_element + namespace_uri()("macroStaticRef"), macroStaticRefHandler_);
+  onElement(root_element + namespace_uri()("unitDynamicModel"), unitDynamicModelHandler_);
 
   connectHandler_.onEnd(lambda::bind(&ModelTemplateHandler::addConnect, lambda::ref(*this)));
   initConnectHandler_.onEnd(lambda::bind(&ModelTemplateHandler::addInitConnect, lambda::ref(*this)));
@@ -293,12 +297,12 @@ ModelTemplateHandler::addUnitDynamicModel() {
 }
 
 BlackBoxModelHandler::BlackBoxModelHandler(elementName_type const& root_element) :
-staticRefHandler_(parser::ElementName(dyd_ns, "staticRef")),
-macroStaticRefHandler_(parser::ElementName(dyd_ns, "macroStaticRef")) {
+staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")),
+macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")) {
   onStartElement(root_element, lambda::bind(&BlackBoxModelHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + dyd_ns("staticRef"), staticRefHandler_);
-  onElement(root_element + dyd_ns("macroStaticRef"), macroStaticRefHandler_);
+  onElement(root_element + namespace_uri()("staticRef"), staticRefHandler_);
+  onElement(root_element + namespace_uri()("macroStaticRef"), macroStaticRefHandler_);
 
   staticRefHandler_.onEnd(lambda::bind(&BlackBoxModelHandler::addStaticRef, lambda::ref(*this)));
   macroStaticRefHandler_.onEnd(lambda::bind(&BlackBoxModelHandler::addMacroStaticRef, lambda::ref(*this)));
@@ -336,12 +340,12 @@ BlackBoxModelHandler::get() const {
 }
 
 ModelTemplateExpansionHandler::ModelTemplateExpansionHandler(elementName_type const& root_element) :
-staticRefHandler_(parser::ElementName(dyd_ns, "staticRef")),
-macroStaticRefHandler_(parser::ElementName(dyd_ns, "macroStaticRef")) {
+staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")),
+macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")) {
   onStartElement(root_element, lambda::bind(&ModelTemplateExpansionHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + dyd_ns("staticRef"), staticRefHandler_);
-  onElement(root_element + dyd_ns("macroStaticRef"), macroStaticRefHandler_);
+  onElement(root_element + namespace_uri()("staticRef"), staticRefHandler_);
+  onElement(root_element + namespace_uri()("macroStaticRef"), macroStaticRefHandler_);
 
   staticRefHandler_.onEnd(lambda::bind(&ModelTemplateExpansionHandler::addStaticRef, lambda::ref(*this)));
   macroStaticRefHandler_.onEnd(lambda::bind(&ModelTemplateExpansionHandler::addMacroStaticRef, lambda::ref(*this)));
@@ -418,12 +422,12 @@ MacroConnectHandler::get() const {
 }
 
 MacroConnectorHandler::MacroConnectorHandler(const elementName_type& root_element) :
-macroConnectionHandler_(parser::ElementName(dyd_ns, "connect")),
-macroInitConnectionHandler_(parser::ElementName(dyd_ns, "initConnect")) {
+macroConnectionHandler_(parser::ElementName(namespace_uri(), "connect")),
+macroInitConnectionHandler_(parser::ElementName(namespace_uri(), "initConnect")) {
   onStartElement(root_element, lambda::bind(&MacroConnectorHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + dyd_ns("connect"), macroConnectionHandler_);
-  onElement(root_element + dyd_ns("initConnect"), macroInitConnectionHandler_);
+  onElement(root_element + namespace_uri()("connect"), macroConnectionHandler_);
+  onElement(root_element + namespace_uri()("initConnect"), macroInitConnectionHandler_);
 
   macroConnectionHandler_.onEnd(lambda::bind(&MacroConnectorHandler::addConnect, lambda::ref(*this)));
   macroInitConnectionHandler_.onEnd(lambda::bind(&MacroConnectorHandler::addInitConnect, lambda::ref(*this)));
@@ -496,10 +500,10 @@ MacroStaticRefHandler::get() const {
 }
 
 MacroStaticReferenceHandler::MacroStaticReferenceHandler(const elementName_type& root_element) :
-staticRefHandler_(parser::ElementName(dyd_ns, "staticRef")) {
+staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")) {
   onStartElement(root_element, lambda::bind(&MacroStaticReferenceHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + dyd_ns("staticRef"), staticRefHandler_);
+  onElement(root_element + namespace_uri()("staticRef"), staticRefHandler_);
 
   staticRefHandler_.onEnd(lambda::bind(&MacroStaticReferenceHandler::addStaticRef, lambda::ref(*this)));
 }

--- a/dynawo/sources/API/DYD/test/Test.cpp
+++ b/dynawo/sources/API/DYD/test/Test.cpp
@@ -30,10 +30,9 @@
 
 #include "TestUtil.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace dynamicdata {
-testing::Environment* const env = initXmlEnvironment();
 
 //------------------------------------------------------
 // TEST for read multiples files, wrong files

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.cpp
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.cpp
@@ -39,14 +39,18 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-parser::namespace_uri extvar_ns("http://www.rte-france.com/dynawo");  ///< namespace used to read external variables xml file
-
 namespace externalVariables {
+
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
 
 XmlHandler::XmlHandler() :
 variablesCollection_(VariablesCollectionFactory::newCollection()),
-variablesHandler_(parser::ElementName(extvar_ns, "variable")) {
-  onElement(extvar_ns("external_variables/variable"), variablesHandler_);
+variablesHandler_(parser::ElementName(namespace_uri(), "variable")) {
+  onElement(namespace_uri()("external_variables/variable"), variablesHandler_);
 
   variablesHandler_.onEnd(lambda::bind(&XmlHandler::addVariable, lambda::ref(*this)));
 }

--- a/dynawo/sources/API/EXTVAR/test/Test.cpp
+++ b/dynawo/sources/API/EXTVAR/test/Test.cpp
@@ -26,10 +26,9 @@
 #include "EXTVARIterators.h"
 #include "EXTVARVariable.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace externalVariables {
-testing::Environment* const env = initXmlEnvironment();
 
 //-----------------------------------------------------
 // TEST build external continuous variable

--- a/dynawo/sources/API/FS/FSXmlHandler.cpp
+++ b/dynawo/sources/API/FS/FSXmlHandler.cpp
@@ -40,18 +40,21 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-xml::sax::parser::namespace_uri fs_ns("http://www.rte-france.com/dynawo");  ///< namespace used to read final state xml file
-
-
 namespace finalState {
+
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
 
 XmlHandler::XmlHandler() :
 finalStateCollection_(FinalStateCollectionFactory::newInstance("")),
-modelHandler_(parser::ElementName(fs_ns, "model")),
-variableHandler_(parser::ElementName(fs_ns, "variable")),
+modelHandler_(parser::ElementName(namespace_uri(), "model")),
+variableHandler_(parser::ElementName(namespace_uri(), "variable")),
 level_(0) {
-  onElement(fs_ns("finalStateInput/model"), modelHandler_);
-  onElement(fs_ns("finalStateInput/variable"), variableHandler_);
+  onElement(namespace_uri()("finalStateInput/model"), modelHandler_);
+  onElement(namespace_uri()("finalStateInput/variable"), variableHandler_);
 
   modelHandler_.onStart(lambda::bind(&XmlHandler::beginFinalStateModel, lambda::ref(*this)));
   modelHandler_.onEnd(lambda::bind(&XmlHandler::endFinalStateModel, lambda::ref(*this)));

--- a/dynawo/sources/API/FS/test/TestXmlImporter.cpp
+++ b/dynawo/sources/API/FS/test/TestXmlImporter.cpp
@@ -23,10 +23,9 @@
 #include "FSXmlExporter.h"
 #include "FSFinalStateCollection.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace finalState {
-testing::Environment* const env = initXmlEnvironment();
 
 //-----------------------------------------------------
 // TEST import missing file

--- a/dynawo/sources/API/JOB/JOBXmlHandler.cpp
+++ b/dynawo/sources/API/JOB/JOBXmlHandler.cpp
@@ -56,14 +56,18 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-xml::sax::parser::namespace_uri jobs_ns("http://www.rte-france.com/dynawo");  ///< namespace used to read jobs xml file
-
 namespace job {
+
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
 
 XmlHandler::XmlHandler() :
 jobsCollection_(JobsCollectionFactory::newInstance()),
-jobHandler_(parser::ElementName(jobs_ns, "job")) {
-  onElement(jobs_ns("jobs/job"), jobHandler_);
+jobHandler_(parser::ElementName(namespace_uri(), "job")) {
+  onElement(namespace_uri()("jobs/job"), jobHandler_);
   jobHandler_.onEnd(lambda::bind(&XmlHandler::addJob, lambda::ref(*this)));
 }
 
@@ -81,16 +85,16 @@ XmlHandler::getJobsCollection() const {
 }
 
 JobHandler::JobHandler(elementName_type const& root_element) :
-solverHandler_(parser::ElementName(jobs_ns, "solver")),
-modelerHandler_(parser::ElementName(jobs_ns, "modeler")),
-simulationHandler_(parser::ElementName(jobs_ns, "simulation")),
-outputsHandler_(parser::ElementName(jobs_ns, "outputs")) {
+solverHandler_(parser::ElementName(namespace_uri(), "solver")),
+modelerHandler_(parser::ElementName(namespace_uri(), "modeler")),
+simulationHandler_(parser::ElementName(namespace_uri(), "simulation")),
+outputsHandler_(parser::ElementName(namespace_uri(), "outputs")) {
   onStartElement(root_element, lambda::bind(&JobHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + jobs_ns("solver"), solverHandler_);
-  onElement(root_element + jobs_ns("modeler"), modelerHandler_);
-  onElement(root_element + jobs_ns("simulation"), simulationHandler_);
-  onElement(root_element + jobs_ns("outputs"), outputsHandler_);
+  onElement(root_element + namespace_uri()("solver"), solverHandler_);
+  onElement(root_element + namespace_uri()("modeler"), modelerHandler_);
+  onElement(root_element + namespace_uri()("simulation"), simulationHandler_);
+  onElement(root_element + namespace_uri()("outputs"), outputsHandler_);
 
 
   solverHandler_.onEnd(lambda::bind(&JobHandler::addSolver, lambda::ref(*this)));
@@ -148,16 +152,16 @@ SolverHandler::get() const {
 }
 
 ModelerHandler::ModelerHandler(elementName_type const& root_element) :
-networkHandler_(parser::ElementName(jobs_ns, "network")),
-dynModelsHandler_(parser::ElementName(jobs_ns, "dynModels")),
-initialStateHandler_(parser::ElementName(jobs_ns, "initialState")),
-preCompiledModelsHandler_(parser::ElementName(jobs_ns, "precompiledModels")),
-modelicaModelsHandler_(parser::ElementName(jobs_ns, "modelicaModels")) {
-  onElement(root_element + jobs_ns("network"), networkHandler_);
-  onElement(root_element + jobs_ns("dynModels"), dynModelsHandler_);
-  onElement(root_element + jobs_ns("initialState"), initialStateHandler_);
-  onElement(root_element + jobs_ns("precompiledModels"), preCompiledModelsHandler_);
-  onElement(root_element + jobs_ns("modelicaModels"), modelicaModelsHandler_);
+networkHandler_(parser::ElementName(namespace_uri(), "network")),
+dynModelsHandler_(parser::ElementName(namespace_uri(), "dynModels")),
+initialStateHandler_(parser::ElementName(namespace_uri(), "initialState")),
+preCompiledModelsHandler_(parser::ElementName(namespace_uri(), "precompiledModels")),
+modelicaModelsHandler_(parser::ElementName(namespace_uri(), "modelicaModels")) {
+  onElement(root_element + namespace_uri()("network"), networkHandler_);
+  onElement(root_element + namespace_uri()("dynModels"), dynModelsHandler_);
+  onElement(root_element + namespace_uri()("initialState"), initialStateHandler_);
+  onElement(root_element + namespace_uri()("precompiledModels"), preCompiledModelsHandler_);
+  onElement(root_element + namespace_uri()("modelicaModels"), modelicaModelsHandler_);
 
   onStartElement(root_element, lambda::bind(&ModelerHandler::create, lambda::ref(*this), lambda_args::arg2));
 
@@ -218,9 +222,9 @@ CriteriaFileHandler::get() const {
 }
 
 SimulationHandler::SimulationHandler(elementName_type const& root_element) :
-criteriaFileHandler_(parser::ElementName(jobs_ns, "criteria")) {
+criteriaFileHandler_(parser::ElementName(namespace_uri(), "criteria")) {
   onStartElement(root_element, lambda::bind(&SimulationHandler::create, lambda::ref(*this), lambda_args::arg2));
-  onElement(root_element + jobs_ns("criteria"), criteriaFileHandler_);
+  onElement(root_element + namespace_uri()("criteria"), criteriaFileHandler_);
 
   criteriaFileHandler_.onEnd(lambda::bind(&SimulationHandler::addCriteriaFile, lambda::ref(*this)));
 }
@@ -250,24 +254,24 @@ SimulationHandler::addCriteriaFile() {
 }
 
 OutputsHandler::OutputsHandler(elementName_type const& root_element) :
-initValuesHandler_(parser::ElementName(jobs_ns, "dumpInitValues")),
-constraintsHandler_(parser::ElementName(jobs_ns, "constraints")),
-timelineHandler_(parser::ElementName(jobs_ns, "timeline")),
-timetableHandler_(parser::ElementName(jobs_ns, "timetable")),
-finalStateHandler_(parser::ElementName(jobs_ns, "finalState")),
-curvesHandler_(parser::ElementName(jobs_ns, "curves")),
-lostEquipmentsHandler_(parser::ElementName(jobs_ns, "lostEquipments")),
-logsHandler_(parser::ElementName(jobs_ns, "logs")) {
+initValuesHandler_(parser::ElementName(namespace_uri(), "dumpInitValues")),
+constraintsHandler_(parser::ElementName(namespace_uri(), "constraints")),
+timelineHandler_(parser::ElementName(namespace_uri(), "timeline")),
+timetableHandler_(parser::ElementName(namespace_uri(), "timetable")),
+finalStateHandler_(parser::ElementName(namespace_uri(), "finalState")),
+curvesHandler_(parser::ElementName(namespace_uri(), "curves")),
+lostEquipmentsHandler_(parser::ElementName(namespace_uri(), "lostEquipments")),
+logsHandler_(parser::ElementName(namespace_uri(), "logs")) {
   onStartElement(root_element, lambda::bind(&OutputsHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + jobs_ns("dumpInitValues"), initValuesHandler_);
-  onElement(root_element + jobs_ns("constraints"), constraintsHandler_);
-  onElement(root_element + jobs_ns("timeline"), timelineHandler_);
-  onElement(root_element + jobs_ns("timetable"), timetableHandler_);
-  onElement(root_element + jobs_ns("finalState"), finalStateHandler_);
-  onElement(root_element + jobs_ns("curves"), curvesHandler_);
-  onElement(root_element + jobs_ns("lostEquipments"), lostEquipmentsHandler_);
-  onElement(root_element + jobs_ns("logs"), logsHandler_);
+  onElement(root_element + namespace_uri()("dumpInitValues"), initValuesHandler_);
+  onElement(root_element + namespace_uri()("constraints"), constraintsHandler_);
+  onElement(root_element + namespace_uri()("timeline"), timelineHandler_);
+  onElement(root_element + namespace_uri()("timetable"), timetableHandler_);
+  onElement(root_element + namespace_uri()("finalState"), finalStateHandler_);
+  onElement(root_element + namespace_uri()("curves"), curvesHandler_);
+  onElement(root_element + namespace_uri()("lostEquipments"), lostEquipmentsHandler_);
+  onElement(root_element + namespace_uri()("logs"), logsHandler_);
 
   initValuesHandler_.onEnd(lambda::bind(&OutputsHandler::addInitValuesEntry, lambda::ref(*this)));
   constraintsHandler_.onEnd(lambda::bind(&OutputsHandler::addConstraints, lambda::ref(*this)));
@@ -441,8 +445,8 @@ LostEquipmentsHandler::get() const {
 }
 
 LogsHandler::LogsHandler(elementName_type const& root_element) :
-appenderHandler_(parser::ElementName(jobs_ns, "appender")) {
-  onElement(root_element + jobs_ns("appender"), appenderHandler_);
+appenderHandler_(parser::ElementName(namespace_uri(), "appender")) {
+  onElement(root_element + namespace_uri()("appender"), appenderHandler_);
 
   onStartElement(root_element, lambda::bind(&LogsHandler::create, lambda::ref(*this), lambda_args::arg2));
 
@@ -542,10 +546,10 @@ InitialStateHandler::get() const {
 }
 
 ModelsDirHandler::ModelsDirHandler(elementName_type const& root_element) :
-directoryHandler_(parser::ElementName(jobs_ns, "directory")) {
+directoryHandler_(parser::ElementName(namespace_uri(), "directory")) {
   onStartElement(root_element, lambda::bind(&ModelsDirHandler::create, lambda::ref(*this), lambda_args::arg2));
 
-  onElement(root_element + jobs_ns("directory"), directoryHandler_);
+  onElement(root_element + namespace_uri()("directory"), directoryHandler_);
 
   directoryHandler_.onEnd(lambda::bind(&ModelsDirHandler::addDirectory, lambda::ref(*this)));
 }

--- a/dynawo/sources/API/JOB/test/TestXmlImporter.cpp
+++ b/dynawo/sources/API/JOB/test/TestXmlImporter.cpp
@@ -39,10 +39,9 @@
 #include "JOBAppenderEntry.h"
 #include "JOBModelsDirEntry.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace job {
-testing::Environment* const env = initXmlEnvironment();
 
 TEST(APIJOBTest, testXmlImporterMissingFile) {
   XmlImporter importer;

--- a/dynawo/sources/API/PAR/PARXmlHandler.cpp
+++ b/dynawo/sources/API/PAR/PARXmlHandler.cpp
@@ -49,16 +49,20 @@ namespace lambda = boost::phoenix;
 namespace lambda_args = lambda::placeholders;
 namespace parser = xml::sax::parser;
 
-xml::sax::parser::namespace_uri par_ns("http://www.rte-france.com/dynawo");  ///< namespace used to read parameters xml file
-
 namespace parameters {
 
+// namespace used to read xml file
+static parser::namespace_uri& namespace_uri() {
+  static parser::namespace_uri namespace_uri("http://www.rte-france.com/dynawo");
+  return namespace_uri;
+}
+
 XmlHandler::XmlHandler() :
-setHandler_(parser::ElementName(par_ns, "set")),
+setHandler_(parser::ElementName(namespace_uri(), "set")),
 parametersSetCollection_(ParametersSetCollectionFactory::newCollection()),
-macroParameterSetHandler_(parser::ElementName(par_ns, "macroParameterSet")) {
-  onElement(par_ns("parametersSet/set"), setHandler_);
-  onElement(par_ns("parametersSet/macroParameterSet"), macroParameterSetHandler_);
+macroParameterSetHandler_(parser::ElementName(namespace_uri(), "macroParameterSet")) {
+  onElement(namespace_uri()("parametersSet/set"), setHandler_);
+  onElement(namespace_uri()("parametersSet/macroParameterSet"), macroParameterSetHandler_);
   setHandler_.onEnd(lambda::bind(&XmlHandler::addSet, lambda::ref(*this)));
   macroParameterSetHandler_.onEnd(lambda::bind(&XmlHandler::addMacroParameterSet, lambda::ref(*this)));
 }
@@ -82,14 +86,14 @@ XmlHandler::addMacroParameterSet() {
 }
 
 SetHandler::SetHandler(elementName_type const & root_element) :
-parHandler_(parser::ElementName(par_ns, "par")),
-parTableHandler_(parser::ElementName(par_ns, "parTable")),
-refHandler_(parser::ElementName(par_ns, "reference")),
-macroParSetHandler_(parser::ElementName(par_ns, "macroParSet")) {
-  onElement(root_element + par_ns("par"), parHandler_);
-  onElement(root_element + par_ns("parTable"), parTableHandler_);
-  onElement(root_element + par_ns("reference"), refHandler_);
-  onElement(root_element + par_ns("macroParSet"), macroParSetHandler_);
+parHandler_(parser::ElementName(namespace_uri(), "par")),
+parTableHandler_(parser::ElementName(namespace_uri(), "parTable")),
+refHandler_(parser::ElementName(namespace_uri(), "reference")),
+macroParSetHandler_(parser::ElementName(namespace_uri(), "macroParSet")) {
+  onElement(root_element + namespace_uri()("par"), parHandler_);
+  onElement(root_element + namespace_uri()("parTable"), parTableHandler_);
+  onElement(root_element + namespace_uri()("reference"), refHandler_);
+  onElement(root_element + namespace_uri()("macroParSet"), macroParSetHandler_);
 
   onStartElement(root_element, lambda::bind(&SetHandler::create, lambda::ref(*this), lambda_args::arg2));
 
@@ -149,8 +153,8 @@ SetHandler::addTable() {
 }
 
 ParTableHandler::ParTableHandler(elementName_type const & root_element) :
-parInTableHandler_(parser::ElementName(par_ns, "par")) {
-  onElement(root_element + par_ns("par"), parInTableHandler_);
+parInTableHandler_(parser::ElementName(namespace_uri(), "par")) {
+  onElement(root_element + namespace_uri()("par"), parInTableHandler_);
   onStartElement(root_element, lambda::bind(&ParTableHandler::create, lambda::ref(*this), lambda_args::arg2));
   parInTableHandler_.onEnd(lambda::bind(&ParTableHandler::addPar, lambda::ref(*this)));
 }
@@ -235,11 +239,11 @@ RefHandler::get() const {
 }
 
 MacroParameterSetHandler::MacroParameterSetHandler(elementName_type const& root_element) :
-refHandler_(parser::ElementName(par_ns, "reference")),
-parHandler_(parser::ElementName(par_ns, "par")) {
+refHandler_(parser::ElementName(namespace_uri(), "reference")),
+parHandler_(parser::ElementName(namespace_uri(), "par")) {
   onStartElement(root_element, lambda::bind(&MacroParameterSetHandler::create, lambda::ref(*this), lambda_args::arg2));
-  onElement(root_element + par_ns("reference"), refHandler_);
-  onElement(root_element + par_ns("par"), parHandler_);
+  onElement(root_element + namespace_uri()("reference"), refHandler_);
+  onElement(root_element + namespace_uri()("par"), parHandler_);
   refHandler_.onEnd(lambda::bind(&MacroParameterSetHandler::addReference, lambda::ref(*this)));
   parHandler_.onEnd(lambda::bind(&MacroParameterSetHandler::addParameter, lambda::ref(*this)));
 }

--- a/dynawo/sources/API/PAR/test/TestXmlImporter.cpp
+++ b/dynawo/sources/API/PAR/test/TestXmlImporter.cpp
@@ -25,10 +25,9 @@
 
 using boost::shared_ptr;
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace parameters {
-testing::Environment* const env = initXmlEnvironment();
 
 //-----------------------------------------------------
 // TEST import missing file

--- a/dynawo/sources/Common/gtest_dynawo.h
+++ b/dynawo/sources/Common/gtest_dynawo.h
@@ -178,4 +178,34 @@ inline std::string key2Str(const int key) {
   } else  /* NOLINT */                                             \
     ASSERT_EQ(doubleEquals(A, B), true)
 
+/**
+ * @brief Macro replacement for GTest TEST macro for CLang only
+ */
+#ifdef __clang__
+#define TEST_DYNAWO_(test_case_name, test_name)                    \
+  _Pragma("clang diagnostic push")                                 \
+  _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"")    \
+  GTEST_TEST(test_case_name, test_name)                            \
+  _Pragma("clang diagnostic pop")
+
+#undef TEST
+#define TEST(test_case_name, test_name) TEST_DYNAWO_(test_case_name, test_name)
+#endif
+
+/**
+ * @brief Macro to initialize Xml environment
+ */
+#ifdef __clang__
+#define INIT_XML_DYNAWO                                            \
+  testing::Environment* initXmlEnvironment();                      \
+  _Pragma("clang diagnostic push")                                 \
+  _Pragma("clang diagnostic ignored \"-Wglobal-constructors\"")    \
+  static testing::Environment* const env_ = initXmlEnvironment()   \
+  _Pragma("clang diagnostic pop")
+#else
+#define INIT_XML_DYNAWO                                            \
+  testing::Environment* initXmlEnvironment();                      \
+  static testing::Environment* const env = initXmlEnvironment()
+#endif
+
 #endif  // COMMON_GTEST_DYNAWO_H_

--- a/dynawo/sources/Modeler/Common/DYNSubModelFactory.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModelFactory.h
@@ -74,9 +74,6 @@ class SubModelFactory : private boost::noncopyable {
   static boost::shared_ptr<SubModel> createSubModelFromLib(const std::string& lib);
 
   boost::shared_ptr<boost::dll::shared_library> lib_;  ///< Library of the submodel
-
- private:
-  static SubModelFactories factories_;  ///< Factories already available
 };
 
 /**
@@ -101,6 +98,12 @@ class SubModelFactories : private boost::noncopyable {
    * @brief destructor
    */
   ~SubModelFactories();
+
+  /**
+   * @brief Get unique instance
+   * @return  The unique instance
+   */
+  static SubModelFactories& getInstance();
 
   /**
   * @brief iterator type on SubModelFactory map.

--- a/dynawo/sources/Modeler/Common/test/CompilerTest.cpp
+++ b/dynawo/sources/Modeler/Common/test/CompilerTest.cpp
@@ -20,10 +20,9 @@
 #include "DYNDynamicData.h"
 #include "DYNMacrosMessage.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace DYN {
-testing::Environment* const env = initXmlEnvironment();
 
 TEST(CompilerTest, testMissingModelicaFile) {
   boost::shared_ptr<DynamicData> dyd(new DynamicData());

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNIIDMExtensions.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNIIDMExtensions.cpp
@@ -24,8 +24,6 @@
 
 namespace DYN {
 
-std::unordered_map<IIDMExtensions::LibraryPath, std::shared_ptr<boost::dll::shared_library> > IIDMExtensions::libraries_;
-std::unordered_set<IIDMExtensions::LibraryPath> IIDMExtensions::librariesLoadingIssues_;
 std::mutex IIDMExtensions::librariesMutex_;
 
 boost::filesystem::path

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.cpp
@@ -38,8 +38,6 @@
 
 namespace DYN {
 
-static memoryManagerChars mmChars;  ///< instance of modelica chars manager : chars created and which should be deleted at the end of the execution
-
 void printLogToStdOut_(ModelManager *model, const std::string & message) {
   SubModel * sub = dynamic_cast<SubModel*> (model);
   if (sub == NULL)
@@ -140,59 +138,43 @@ const char* modelica_integer_to_modelica_string(modelica_integer i, modelica_int
   // @todo warning: no thread safe
   std::stringstream ss("");
   ss << i;
-  const std::string tmp = ss.str();
-
-  mmChars.string2Keep_.push_back(tmp);
-
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* cat_modelica_string(modelica_string_const s1, modelica_string_const s2) {
   std::stringstream ss("");
   ss << s1 << s2;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* cat_modelica_string(std::string s1, modelica_string_const s2) {
   std::stringstream ss("");
   ss << s1 << s2;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* cat_modelica_string(modelica_string_const s1, std::string s2) {
   std::stringstream ss("");
   ss << s1 << s2;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* stringAppend(const modelica_string s1, const modelica_string s2) {
   std::stringstream ss("");
   ss << s1 << s2;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* stringAppend(const modelica_string s1, const std::string s2) {
   std::stringstream ss("");
   ss << s1 << s2;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* stringAppend(const std::string s1, const modelica_string s2) {
   std::stringstream ss("");
   ss << s1 << s2;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 std::string mmc_strings_len1(unsigned int size) {
@@ -203,20 +185,13 @@ std::string mmc_strings_len1(unsigned int size) {
 const char* modelica_real_to_modelica_string_format(modelica_real r, std::string /*format*/) {
   std::stringstream ss("");
   ss << std::setprecision(3) << std::fixed << r;
-  const std::string tmp = ss.str();
-
-  mmChars.string2Keep_.push_back(tmp);
-
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char* modelica_integer_to_modelica_string_format(modelica_integer i, std::string /*format*/) {
   std::stringstream ss("");
   ss << i;
-  const std::string tmp = ss.str();
-  mmChars.string2Keep_.push_back(tmp);
-
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char * modelica_real_to_modelica_string(modelica_real r, modelica_integer /*minLen*/, modelica_boolean /*leftJustified*/,
@@ -224,11 +199,7 @@ const char * modelica_real_to_modelica_string(modelica_real r, modelica_integer 
   // @todo warning: no thread safe
   std::stringstream ss("");
   ss << std::setprecision(signDigits) << std::fixed << r;
-  const std::string tmp = ss.str();
-
-  mmChars.string2Keep_.push_back(tmp);
-
-  return mmChars.string2Keep_.back().c_str();
+  return memoryManagerChars::keep(ss.str());
 }
 
 const char * modelica_boolean_to_modelica_string(modelica_boolean b, modelica_integer /*minLen*/, modelica_boolean /*leftJustified*/) {

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
@@ -294,23 +294,42 @@ class DYNDATA : public DATA {
 namespace DYN {
 
 /**
- * class memoryManagerChars
+ * @class memoryManagerChars
+ * @brief Keep track of chars created and which should be deleted at the end of the execution
  */
 class memoryManagerChars {
- public:
+ private:
   /**
    * @brief Default constructor
-   *
    */
   memoryManagerChars() { }
 
   /**
+   * @brief Get instance of modelica chars manager
+   * @return the unique instance
+   */
+  static memoryManagerChars& getInstance() {
+    static memoryManagerChars mmChars;
+    return mmChars;
+  }
+
+ public:
+  /**
    * @brief Default destructor
-   *
    */
   ~memoryManagerChars() { }
 
- public:
+  /**
+   * @brief Keep track of a string
+   * @param str the string to keep track of
+   * @return the string as null-terminated const char pointer
+   */
+  static const char* keep(const std::string& str) {
+    getInstance().string2Keep_.push_back(str);
+    return getInstance().string2Keep_.back().c_str();
+  }
+
+ private:
   std::list<std::string> string2Keep_;  ///< string created along the simulation and that should be deleted at the end of the simulation
 };
 

--- a/dynawo/sources/Solvers/AlgebraicSolvers/test/TestBasics.cpp
+++ b/dynawo/sources/Solvers/AlgebraicSolvers/test/TestBasics.cpp
@@ -45,10 +45,9 @@
 #include "DYNExecUtils.h"
 #include "TLTimelineFactory.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace DYN {
-testing::Environment* const env = initXmlEnvironment();
 
 boost::shared_ptr<Model> initModelFromDyd(std::string dydFileName) {
   // DYD

--- a/dynawo/sources/Solvers/Common/DYNSolverFactory.h
+++ b/dynawo/sources/Solvers/Common/DYNSolverFactory.h
@@ -69,9 +69,6 @@ class SolverFactory {
   static boost::shared_ptr<Solver> createSolverFromLib(const std::string& lib);
 
   boost::shared_ptr<boost::dll::shared_library> lib_;  ///< Library of the solver
-
- private:
-  static SolverFactories factories_;  ///< Factories already available
 };
 
 /**
@@ -96,6 +93,12 @@ class SolverFactories : private boost::noncopyable {
    * @brief destructor
    */
   ~SolverFactories();
+
+  /**
+   * @brief Get unique instance
+   * @return  The unique instance
+   */
+  static SolverFactories& getInstance();
 
   /**
   * @brief iterator type on SolverFactory map.

--- a/dynawo/sources/Solvers/SolverIDA/test/TestBasics.cpp
+++ b/dynawo/sources/Solvers/SolverIDA/test/TestBasics.cpp
@@ -63,10 +63,9 @@
 #include "TLTimelineFactory.h"
 #include "DYNMacrosMessage.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace DYN {
-testing::Environment* const env = initXmlEnvironment();
 
 boost::shared_ptr<Solver> initSolver(bool enableSilentZ = true) {
   // Solver

--- a/dynawo/sources/Solvers/SolverSIM/test/TestBasics.cpp
+++ b/dynawo/sources/Solvers/SolverSIM/test/TestBasics.cpp
@@ -66,10 +66,9 @@
 #include "TLTimelineFactory.h"
 #include "DYNTrace.h"
 
-testing::Environment* initXmlEnvironment();
+INIT_XML_DYNAWO;
 
 namespace DYN {
-testing::Environment* const env = initXmlEnvironment();
 
 boost::shared_ptr<Solver> initSolver(bool optimizeAlgebraicResidualsEvaluations, bool skipNR, bool enableSilentZ) {
   // Solver


### PR DESCRIPTION
Removing -Wno-global-constructors causes errors !

```
error: declaration requires a global constructor [-Werror,-Wglobal-constructors]
error: declaration requires a global destructor [-Werror,-Wglobal-constructors]
```

See #125 
