### PR TITLE
#125 fix clang compilation -Wmissing-noreturn

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -123,7 +123,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-global-constructors")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-gnu-zero-variadic-macro-arguments")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-mismatched-tags")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-noreturn")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-prototypes")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-variable-declarations")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-old-style-cast")

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.cpp
@@ -123,6 +123,11 @@ void addLogConstraintEnd_(ModelManager* model, const Message& message) {
   model->addConstraint(model->name(), false, message);
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif  // __clang__
+
 void assert_(ModelManager* model, const Message& message) {
   throw MessageError(model->name() + " : " + message.str());
 }
@@ -135,6 +140,10 @@ void terminate_(ModelManager* model, const MessageTimeline& messageTimeline) {
   model->addEvent(model->name(), messageTimeline);
   throw DYNTerminate(TerminateInModel, model->name(), messageTimeline.str());
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 const char* modelica_integer_to_modelica_string(modelica_integer i, modelica_integer /*minLen*/, modelica_boolean /*leftJustified*/) {
   // @todo warning: no thread safe


### PR DESCRIPTION
Removing -Wno-missing-noreturn causes errors !

`error: function 'XXX' could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]`

See #125 
