### PR TITLE
#125 fix clang compilation -Wold-style-cast

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -122,7 +122,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-mismatched-tags")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-prototypes")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-variable-declarations")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-old-style-cast")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-padded")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-reserved-id-macro")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-return-type")

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
@@ -1143,7 +1143,8 @@ ModelManager::setInitialCalculatedParameters() {
     parametersInitial[currentParameter.getIndex()] = currentParameter;
   }
   // Copy init parameters
-  assert(parametersInitial.size() == (unsigned int) (modelData()->nParametersReal + modelData()->nParametersBoolean + modelData()->nParametersInteger + modelData()->nParametersString));   // NOLINT(whitespace/line_length)
+  assert(parametersInitial.size() == static_cast<size_t>(modelData()->nParametersReal + modelData()->nParametersBoolean
+                                                       + modelData()->nParametersInteger + modelData()->nParametersString));
   for (unsigned int i = 0; i < modelData()->nParametersReal; ++i) {
     const string& parName = parametersInitial[i].getName();
 

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
@@ -49,6 +49,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wextra-semi-stmt"
+#pragma clang diagnostic ignored "-Wold-style-cast"
 #endif  // __clang__
 #include "simulation_data.h"
 #ifdef __clang__

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerOwnFunctions.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerOwnFunctions.cpp
@@ -19,6 +19,7 @@
  */
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
 #pragma clang diagnostic ignored "-Wunused-function"
 # endif  // __clang__
 

--- a/dynawo/sources/Models/CPP/Events/ModelVariationArea/DYNModelVariationArea.cpp
+++ b/dynawo/sources/Models/CPP/Events/ModelVariationArea/DYNModelVariationArea.cpp
@@ -163,7 +163,7 @@ ModelVariationArea::setFequations() {
     fEquationIndex_[i * 2] = "deltaP_" + ss.str();
     fEquationIndex_[i * 2 + 1] = "deltaQ_" + ss.str();
   }
-  assert(fEquationIndex_.size() == (unsigned int) sizeF() && "Model VariationArea: fEquationIndex_.size() != fLocal_.size()");
+  assert(fEquationIndex_.size() == static_cast<size_t>(sizeF()) && "Model VariationArea: fEquationIndex_.size() != fLocal_.size()");
 }
 
 void
@@ -171,7 +171,7 @@ ModelVariationArea::setGequations() {
   gEquationIndex_[0] = "stopTime > t >= startTime";
   gEquationIndex_[1] = "t >= stopTime";
 
-  assert(gEquationIndex_.size() == (unsigned int) sizeG() && "Model VariationArea: gEquationIndex.size() != gLocal_.size()");
+  assert(gEquationIndex_.size() == static_cast<size_t>(sizeG()) && "Model VariationArea: gEquationIndex.size() != gLocal_.size()");
 }
 
 // evaluation of the transpose Jacobian Jt - sparse matrix

--- a/dynawo/sources/Models/CPP/Events/ModelVoltageSetPointChange/DYNModelVoltageSetPointChange.cpp
+++ b/dynawo/sources/Models/CPP/Events/ModelVoltageSetPointChange/DYNModelVoltageSetPointChange.cpp
@@ -133,7 +133,7 @@ ModelVoltageSetPointChange::setGequations() {
   gEquationIndex_[0] = "stopTime > t >= startTime";
   gEquationIndex_[1] = "t >= stopTime";
 
-  assert(gEquationIndex_.size() == (unsigned int) sizeG() && "Model VoltageSetPointChange: gEquationIndex.size() != gLocal_.size()");
+  assert(gEquationIndex_.size() == static_cast<size_t>(sizeG()) && "Model VoltageSetPointChange: gEquationIndex.size() != gLocal_.size()");
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
+++ b/dynawo/sources/Models/CPP/ModelFrequency/ModelOmegaRef/DYNModelOmegaRef.cpp
@@ -533,7 +533,7 @@ ModelOmegaRef::setFequations() {
     fEquationIndex_[k + nbMaxCC] = f.str();
   }
 
-  assert(fEquationIndex_.size() == (unsigned int) sizeF() && "ModelOmegaRef:fEquationIndex_.size() != f_.size()");
+  assert(fEquationIndex_.size() == static_cast<size_t>(sizeF()) && "ModelOmegaRef:fEquationIndex_.size() != f_.size()");
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.cpp
@@ -407,7 +407,7 @@ ModelBus::setFequations(std::map<int, std::string>& fEquationIndex) {
     }
   }
 
-  assert(fEquationIndex.size() == (unsigned int) sizeF() && "ModelBus: fEquationIndex.size != f_.size()");
+  assert(fEquationIndex.size() == static_cast<size_t>(sizeF()) && "ModelBus: fEquationIndex.size != f_.size()");
 }
 
 void
@@ -707,7 +707,7 @@ ModelBus::setGequations(std::map<int, std::string>& gEquationIndex) {
   gEquationIndex[0] = "U > UMax localModel:"+id();
   gEquationIndex[1] = "U < UMin localModel:"+id();
 
-  assert(gEquationIndex.size() == (unsigned int) sizeG() && "Model Bus: gEquationIndex.size() != g_.size()");
+  assert(gEquationIndex.size() == static_cast<size_t>(sizeG()) && "Model Bus: gEquationIndex.size() != g_.size()");
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelDanglingLine.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelDanglingLine.cpp
@@ -252,7 +252,7 @@ ModelDanglingLine::setFequations(std::map<int, std::string>& fEquationIndex) {
     fEquationIndex[1] = std::string("y_[uiFictNum_] localModel:").append(id());
   }
 
-  assert(fEquationIndex.size() == (unsigned int) sizeF_ && "ModelDanglingLine: fEquationIndex.size() != f_.size()");
+  assert(fEquationIndex.size() == static_cast<size_t>(sizeF_) && "ModelDanglingLine: fEquationIndex.size() != f_.size()");
 }
 
 void
@@ -271,7 +271,7 @@ ModelDanglingLine::setGequations(std::map<int, std::string>& gEquationIndex) {
     }
   }
 
-  assert(gEquationIndex.size() == (unsigned int) sizeG_ && "ModelDanglingLine: gEquationIndex.size() != sizeG_");
+  assert(gEquationIndex.size() == static_cast<size_t>(sizeG_) && "ModelDanglingLine: gEquationIndex.size() != sizeG_");
 }
 
 double

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLine.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLine.cpp
@@ -1110,7 +1110,7 @@ ModelLine::setGequations(std::map<int, std::string>& gEquationIndex) {
     }
   }
 
-  assert(gEquationIndex.size() == (unsigned int) sizeG_ && "ModelLine: gEquationIndex.size() != sizeG_");
+  assert(gEquationIndex.size() == static_cast<size_t>(sizeG_) && "ModelLine: gEquationIndex.size() != sizeG_");
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLoad.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelLoad.cpp
@@ -199,7 +199,7 @@ ModelLoad::setFequations(std::map<int, std::string>& fEquationIndex) {
     ++index;
   }
 
-  assert(fEquationIndex.size() == (unsigned int) sizeF() && "ModelLoad:fEquationIndex.size() != f_.size()");
+  assert(fEquationIndex.size() == static_cast<size_t>(sizeF()) && "ModelLoad:fEquationIndex.size() != f_.size()");
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelShuntCompensator.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelShuntCompensator.cpp
@@ -395,7 +395,7 @@ void
 ModelShuntCompensator::setGequations(std::map<int, std::string>& gEquationIndex) {
   gEquationIndex[0] = "Time out reached for reclosing delay";
 
-  assert(gEquationIndex.size() == (unsigned int) sizeG() && "Shunt compensator model: gEquationIndex.size() != gLocal_.size()");
+  assert(gEquationIndex.size() == static_cast<size_t>(sizeG()) && "Shunt compensator model: gEquationIndex.size() != gLocal_.size()");
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.cpp
@@ -161,7 +161,7 @@ ModelSwitch::setFequations(std::map<int, std::string>& fEquationIndex) {
     fEquationIndex[1] = std::string("y_[iiNum_] localModel:").append(id());
   }
 
-  assert(fEquationIndex.size() == (unsigned int) sizeF_ && "ModelSwitch: fEquationIndex.size() != f_.size()");
+  assert(fEquationIndex.size() == static_cast<size_t>(sizeF_) && "ModelSwitch: fEquationIndex.size() != f_.size()");
 }
 
 void

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.cpp
@@ -1453,7 +1453,7 @@ ModelTwoWindingsTransformer::setGequations(std::map<int, std::string>& gEquation
   }
 
 
-  assert(gEquationIndex.size() == (unsigned int) sizeG_ && "Model TwoWindingsTransformer: gEquationIndex.size() != sizeG_");
+  assert(gEquationIndex.size() == static_cast<size_t>(sizeG_) && "Model TwoWindingsTransformer: gEquationIndex.size() != sizeG_");
 }
 
 double

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestDerivatives.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestDerivatives.cpp
@@ -102,7 +102,7 @@ TEST(ModelsModelNetwork, ModelNetworkBusDerivative) {
   ASSERT_EQ(derivatives.empty(), true);
 
 
-  ASSERT_THROW_DYNAWO(derivatives.addDerivative((typeDerivative_t)42, 4, 8.), Error::MODELER, KeyError_t::InvalidDerivativeType);
-  ASSERT_THROW_DYNAWO(derivatives.getValues((typeDerivative_t)42), Error::MODELER, KeyError_t::InvalidDerivativeType);
+  ASSERT_THROW_DYNAWO(derivatives.addDerivative(static_cast<typeDerivative_t>(42), 4, 8.), Error::MODELER, KeyError_t::InvalidDerivativeType);
+  ASSERT_THROW_DYNAWO(derivatives.getValues(static_cast<typeDerivative_t>(42)), Error::MODELER, KeyError_t::InvalidDerivativeType);
 }
 }  // namespace DYN


### PR DESCRIPTION
Removing -Wno-old-style-cast causes errors !

`error: use of old-style cast [-Werror,-Wold-style-cast]`

See #125 
