### PR TITLE
#125 fix clang compilation -Wreserved-id-macro

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -123,7 +123,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-prototypes")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-missing-variable-declarations")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-padded")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-reserved-id-macro")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-return-type")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-shadow")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-shorten-64-to-32")

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
@@ -50,13 +50,19 @@
 #pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wextra-semi-stmt"
 #pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif  // __clang__
 #include "simulation_data.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
 #endif  // __clang__
 #include "ModelicaStandardTables.h"
 #include "ModelicaStrings.h"
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 #include "DYNModelManagerOwnFunctions.h"  ///< redefinition of local own functions
 #include "ModelicaUtilities.h"
 

--- a/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINCommon.h
+++ b/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINCommon.h
@@ -20,8 +20,15 @@
 #ifndef SOLVERS_ALGEBRAICSOLVERS_DYNSOLVERKINCOMMON_H_
 #define SOLVERS_ALGEBRAICSOLVERS_DYNSOLVERKINCOMMON_H_
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif  // __clang__
 #include <kinsol/kinsol.h>
 #include <sundials/sundials_nvector.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 #include <boost/shared_ptr.hpp>
 #include <string>
 #include <vector>

--- a/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINSubModel.h
+++ b/dynawo/sources/Solvers/AlgebraicSolvers/DYNSolverKINSubModel.h
@@ -23,8 +23,15 @@
 
 #include <boost/core/noncopyable.hpp>
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#endif  // __clang__
 #include <sundials/sundials_nvector.h>
 #include <sundials/sundials_linearsolver.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 #include "DYNSolverKINCommon.h"
 
 namespace DYN {


### PR DESCRIPTION
Removing -Wno-reserved-id-macro causes errors !

`error: macro name is a reserved identifier [-Werror,-Wreserved-id-macro]`

See #125 
