### PR TITLE
#125 fix clang compilation -Wundef

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -126,7 +126,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}'
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-shadow")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sign-conversion")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sometimes-uninitialized")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-undef")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-undefined-func-template")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unreachable-code-break")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unreachable-code-loop-increment")

--- a/dynawo/sources/Common/DYNTimer.cpp
+++ b/dynawo/sources/Common/DYNTimer.cpp
@@ -95,7 +95,7 @@ double Timer::elapsed() const {
   if (isStopped_) {
     return 0.;
   }
-#if LANG_CXX11
+#ifdef LANG_CXX11
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - startPoint_);
   return static_cast<double>(duration.count()) / 1000000;  // For the result in seconds
 #else

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
@@ -51,6 +51,7 @@
 #pragma clang diagnostic ignored "-Wextra-semi-stmt"
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#pragma clang diagnostic ignored "-Wundef"
 #endif  // __clang__
 #include "simulation_data.h"
 #ifdef __clang__
@@ -64,7 +65,14 @@
 #pragma clang diagnostic pop
 #endif  // __clang__
 #include "DYNModelManagerOwnFunctions.h"  ///< redefinition of local own functions
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundef"
+#endif  // __clang__
 #include "ModelicaUtilities.h"
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 #ifdef _MSC_VER
 #undef isnan    // undef macros defined in omc.msvc.h !


### PR DESCRIPTION
Removing -Wno-undef causes errors !

```
error: '__STDC_VERSION__' is not defined, evaluates to 0 [-Werror,-Wundef]
error: 'LANG_CXX11' is not defined, evaluates to 0 [-Werror,-Wundef]
```

See #125 
