### PR TITLE
#125 fix clang compilation -Wunused-exception-parameter -Wunused-private-field

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -128,9 +128,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang')
   # error: operand of ? changes signedness: 'something unsigned' to 'something signed' [-Werror,-Wsign-conversion]
   # => occurs many times in particular when a signed value is used as an index which must be an unsigned (size_t) !
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sign-conversion")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-exception-parameter")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-macros")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-private-field")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-weak-vtables")
   # error: 'arg2' was marked unused but was used [-Werror,-Wused-but-marked-unused]
   # => occurs in all API Xml handlers (using boost::phoenix::placeholders)

--- a/dynawo/sources/Modeler/Common/DYNCompiler.cpp
+++ b/dynawo/sources/Modeler/Common/DYNCompiler.cpp
@@ -374,7 +374,7 @@ Compiler::compileModelicaModelDescription(const shared_ptr<ModelDescription>& mo
     throw DYNError(Error::MODELER, CompilationFailed, libName);
 
 #ifdef _DEBUG_
-  (void)rmModels_;  // shut up clang -Wunused-private-field
+  static_cast<void>(rmModels_);  // shut up clang -Wunused-private-field
 #else
   // remove .mo, -init.mo
   if (rmModels_) {

--- a/dynawo/sources/Modeler/Common/DYNCompiler.cpp
+++ b/dynawo/sources/Modeler/Common/DYNCompiler.cpp
@@ -373,7 +373,9 @@ Compiler::compileModelicaModelDescription(const shared_ptr<ModelDescription>& mo
   if ((!exists(lib)) || hasUndefinedSymbol)
     throw DYNError(Error::MODELER, CompilationFailed, libName);
 
-#ifndef _DEBUG_
+#ifdef _DEBUG_
+  (void)rmModels_;  // shut up clang -Wunused-private-field
+#else
   // remove .mo, -init.mo
   if (rmModels_) {
     remove(modelConcatFile_);

--- a/dynawo/sources/Modeler/Common/test/TestDelay.cpp
+++ b/dynawo/sources/Modeler/Common/test/TestDelay.cpp
@@ -179,13 +179,7 @@ TEST(CommonTest, testDelayManagerClass) {
   ASSERT_TRUE(manager.isIdAcceptable(id2));
   ASSERT_FALSE(manager.isIdAcceptable(id_none));
 
-  try {
-    manager.getDelay(id_none, 2);
-
-    // exception should be raised
-    ASSERT_TRUE(false);
-  } catch (const std::exception& e) {
-  }
+  ASSERT_ANY_THROW(manager.getDelay(id_none, 2));
 
   // for id
   double val = manager.getDelay(id, 2);
@@ -275,13 +269,8 @@ TEST(CommonTest, testDelayManagerClassTrigger) {
   std::vector<DYN::state_g> states(3, DYN::NO_ROOT);
 
   ASSERT_FALSE(manager.isTriggered());
-  try {
-    manager.triggerDelay(id_none);
+  ASSERT_ANY_THROW(manager.triggerDelay(id_none));
 
-    // exception should be caught
-    ASSERT_TRUE(false);
-  } catch (const std::exception&) {
-  }
   manager.triggerDelay(id);
   manager.setGomc(&states[0], 1);
   ASSERT_EQ(DYN::NO_ROOT, states[0]);


### PR DESCRIPTION
Removing `-Wno-unused-exception-parameter` causes an error !

`error: unused exception parameter 'e' [-Werror,-Wunused-exception-parameter]`

Removing `-Wno-unused-private-field` causes an error !

`error: private field 'rmModels_' is not used [-Werror,-Wunused-private-field]`

`-Wno-unused-macros` is useless and can be removed.

See #125
