### PR TITLE
#125 fix clang compilation -Wweak-vtables

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -128,7 +128,6 @@ elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang')
   # error: operand of ? changes signedness: 'something unsigned' to 'something signed' [-Werror,-Wsign-conversion]
   # => occurs many times in particular when a signed value is used as an index which must be an unsigned (size_t) !
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sign-conversion")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-weak-vtables")
   # error: 'arg2' was marked unused but was used [-Werror,-Wused-but-marked-unused]
   # => occurs in all API Xml handlers (using boost::phoenix::placeholders)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-used-but-marked-unused")

--- a/dynawo/sources/API/CRT/CRTImporter.h
+++ b/dynawo/sources/API/CRT/CRTImporter.h
@@ -27,6 +27,11 @@
 
 namespace criteria {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -39,6 +44,7 @@ class Importer {
    * @brief Destructor
    */
   virtual ~Importer() {}
+
   /**
    * @brief Import criteria from file
    *
@@ -57,6 +63,10 @@ class Importer {
    */
   virtual boost::shared_ptr<CriteriaCollection> importFromStream(std::istream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace criteria
 

--- a/dynawo/sources/API/CRT/CRTXmlHandler.cpp
+++ b/dynawo/sources/API/CRT/CRTXmlHandler.cpp
@@ -100,6 +100,8 @@ countryHandler_(parser::ElementName(namespace_uri(), "country")) {
   countryHandler_.onEnd(lambda::bind(&CriteriaHandler::addCountry, lambda::ref(*this)));
 }
 
+CriteriaHandler::~CriteriaHandler() {}
+
 void CriteriaHandler::create(attributes_type const & /*attributes*/) {
   criteriaRead_ = CriteriaFactory::newCriteria();
 }
@@ -128,6 +130,8 @@ CriteriaHandler::addCountry() {
 CriteriaParamsHandler::CriteriaParamsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CriteriaParamsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+CriteriaParamsHandler::~CriteriaParamsHandler() {}
 
 void CriteriaParamsHandler::create(attributes_type const & attributes) {
   criteriaParamsRead_ = CriteriaParamsFactory::newCriteriaParams();
@@ -158,6 +162,8 @@ ElementWithIdHandler::ElementWithIdHandler(elementName_type const& root_element)
   onStartElement(root_element, lambda::bind(&ElementWithIdHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+ElementWithIdHandler::~ElementWithIdHandler() {}
+
 void ElementWithIdHandler::create(attributes_type const & attributes) {
   idRead_ = attributes["id"].as_string();
 }
@@ -171,6 +177,8 @@ ElementWithIdHandler::getId() const {
 ComponentHandler::ComponentHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&ComponentHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+ComponentHandler::~ComponentHandler() {}
 
 void ComponentHandler::create(attributes_type const & attributes) {
   idRead_ = attributes["id"].as_string();

--- a/dynawo/sources/API/CRT/CRTXmlHandler.h
+++ b/dynawo/sources/API/CRT/CRTXmlHandler.h
@@ -37,9 +37,9 @@ class ElementWithIdHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ElementWithIdHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ElementWithIdHandler() { }
+  ~ElementWithIdHandler();
 
   /**
    * @brief return the id read in xml file
@@ -71,9 +71,9 @@ class ComponentHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ComponentHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  virtual ~ComponentHandler() { }
+  virtual ~ComponentHandler();
 
   /**
    * @brief return the id read in xml file
@@ -112,9 +112,9 @@ class CriteriaParamsHandler : public xml::sax::parser::ComposableElementHandler 
   explicit CriteriaParamsHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~CriteriaParamsHandler() { }
+  ~CriteriaParamsHandler();
 
   /**
    * @brief return the criteria params read in xml file
@@ -146,9 +146,9 @@ class CriteriaHandler : public xml::sax::parser::ComposableElementHandler {
   explicit CriteriaHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~CriteriaHandler() { }
+  ~CriteriaHandler();
 
   /**
    * @brief return the criteria read in xml file

--- a/dynawo/sources/API/CRT/CRTXmlImporter.h
+++ b/dynawo/sources/API/CRT/CRTXmlImporter.h
@@ -34,10 +34,6 @@ namespace criteria {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-  /**
    * @copydoc Importer::importFromFile()
    */
   boost::shared_ptr<CriteriaCollection> importFromFile(const std::string& fileName) const;

--- a/dynawo/sources/API/CRV/CRVCsvExporter.h
+++ b/dynawo/sources/API/CRV/CRVCsvExporter.h
@@ -33,10 +33,6 @@ namespace curves {
 class CsvExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~CsvExporter() {}
-  /**
    * @brief Export method in csv format
    *
    * @param curves curves to export

--- a/dynawo/sources/API/CRV/CRVExporter.h
+++ b/dynawo/sources/API/CRV/CRVExporter.h
@@ -26,6 +26,12 @@
 #include "CRVCurvesCollection.h"
 
 namespace curves {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -38,6 +44,7 @@ class Exporter {
    * @brief Destructor
    */
   virtual ~Exporter() {}
+
   /**
    * @brief Export method for this exporter
    *
@@ -54,6 +61,10 @@ class Exporter {
    */
   virtual void exportToStream(const boost::shared_ptr<CurvesCollection>& curves, std::ostream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace curves
 

--- a/dynawo/sources/API/CRV/CRVImporter.h
+++ b/dynawo/sources/API/CRV/CRVImporter.h
@@ -26,6 +26,12 @@
 #include "CRVCurvesCollection.h"
 
 namespace curves {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -38,6 +44,7 @@ class Importer {
    * @brief Destructor
    */
   virtual ~Importer() {}
+
   /**
    * @brief Import curves's collection from file
    *
@@ -56,6 +63,10 @@ class Importer {
    */
   virtual boost::shared_ptr<CurvesCollection> importFromStream(std::istream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace curves
 

--- a/dynawo/sources/API/CRV/CRVXmlExporter.h
+++ b/dynawo/sources/API/CRV/CRVXmlExporter.h
@@ -33,10 +33,6 @@ namespace curves {
 class XmlExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlExporter() {}
-  /**
    * @brief Export method in XML format
    *
    * @param curves curves to export

--- a/dynawo/sources/API/CRV/CRVXmlHandler.cpp
+++ b/dynawo/sources/API/CRV/CRVXmlHandler.cpp
@@ -73,6 +73,8 @@ CurveHandler::CurveHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CurveHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+CurveHandler::~CurveHandler() {}
+
 void CurveHandler::create(attributes_type const & attributes) {
   curveRead_ = CurveFactory::newCurve();
   curveRead_->setModelName(attributes["model"]);

--- a/dynawo/sources/API/CRV/CRVXmlHandler.h
+++ b/dynawo/sources/API/CRV/CRVXmlHandler.h
@@ -45,9 +45,9 @@ class CurveHandler : public xml::sax::parser::ComposableElementHandler {
   explicit CurveHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~CurveHandler() { }
+  ~CurveHandler();
 
   /**
    * @brief return the curve read in xml file

--- a/dynawo/sources/API/CRV/CRVXmlImporter.h
+++ b/dynawo/sources/API/CRV/CRVXmlImporter.h
@@ -34,10 +34,6 @@ namespace curves {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-  /**
    * @copydoc Importer::importFromFile()
    */
   boost::shared_ptr<CurvesCollection> importFromFile(const std::string& fileName) const;

--- a/dynawo/sources/API/CSTR/CSTRExporter.h
+++ b/dynawo/sources/API/CSTR/CSTRExporter.h
@@ -28,6 +28,11 @@
 
 namespace constraints {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -40,6 +45,7 @@ class Exporter {
    * @brief Destructor
    */
   virtual ~Exporter() {}
+
   /**
    * @brief Export method for this exporter
    *
@@ -56,6 +62,10 @@ class Exporter {
    */
   virtual void exportToStream(const boost::shared_ptr<ConstraintsCollection>& constraints, std::ostream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace constraints
 

--- a/dynawo/sources/API/CSTR/CSTRTxtExporter.h
+++ b/dynawo/sources/API/CSTR/CSTRTxtExporter.h
@@ -34,10 +34,6 @@ namespace constraints {
 class TxtExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~TxtExporter() {}
-  /**
    * @brief Export method in txt format
    *
    * @param constraints Constraints to export

--- a/dynawo/sources/API/CSTR/CSTRXmlExporter.h
+++ b/dynawo/sources/API/CSTR/CSTRXmlExporter.h
@@ -34,10 +34,6 @@ namespace constraints {
 class XmlExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlExporter() {}
-  /**
    * @brief Export method in XML format
    *
    * @param constraints Constraints to export

--- a/dynawo/sources/API/DYD/DYDBlackBoxModel.cpp
+++ b/dynawo/sources/API/DYD/DYDBlackBoxModel.cpp
@@ -27,6 +27,8 @@ namespace dynamicdata {
 
 BlackBoxModel::BlackBoxModel(const string& id) : Model(id, Model::BLACK_BOX_MODEL) {}
 
+BlackBoxModel::~BlackBoxModel() {}
+
 const std::string&
 BlackBoxModel::getLib() const {
   return lib_;

--- a/dynawo/sources/API/DYD/DYDBlackBoxModel.h
+++ b/dynawo/sources/API/DYD/DYDBlackBoxModel.h
@@ -44,6 +44,11 @@ class BlackBoxModel : public Model {
   explicit BlackBoxModel(const std::string& id);
 
   /**
+   * @brief Destructor
+   */
+  virtual ~BlackBoxModel();
+
+  /**
    * @brief Model library getter
    *
    * @returns Model library absolute path

--- a/dynawo/sources/API/DYD/DYDExporter.h
+++ b/dynawo/sources/API/DYD/DYDExporter.h
@@ -26,6 +26,11 @@
 
 namespace dynamicdata {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -38,6 +43,7 @@ class Exporter {
    * @brief Destructor
    */
   virtual ~Exporter() {}
+
   /**
    * @brief Export method for this exporter
    *
@@ -56,6 +62,10 @@ class Exporter {
    */
   virtual void exportToStream(const boost::shared_ptr<DynamicModelsCollection>& collection, std::ostream& stream, const std::string& encoding) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace dynamicdata
 

--- a/dynawo/sources/API/DYD/DYDImporter.h
+++ b/dynawo/sources/API/DYD/DYDImporter.h
@@ -28,6 +28,11 @@
 
 namespace dynamicdata {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -40,6 +45,7 @@ class Importer {
    * @brief Destructor
    */
   virtual ~Importer() {}
+
   /**
    * @brief Import dynamic models collection from files
    *
@@ -58,6 +64,10 @@ class Importer {
    */
   virtual void importFromStream(std::istream& stream, XmlHandler& dydHandler, xml::sax::parser::ParserPtr& parser, bool xsdValidation) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace dynamicdata
 

--- a/dynawo/sources/API/DYD/DYDModel.cpp
+++ b/dynawo/sources/API/DYD/DYDModel.cpp
@@ -37,6 +37,8 @@ namespace dynamicdata {
 
 Model::Model(const string& id, ModelType type) : id_(IdentifiableFactory::newIdentifiable(id)), type_(type) {}
 
+Model::~Model() {}
+
 const string&
 Model::getId() const {
   return id_->get();

--- a/dynawo/sources/API/DYD/DYDModel.h
+++ b/dynawo/sources/API/DYD/DYDModel.h
@@ -54,7 +54,7 @@ class Model {
   /**
    * @brief Destructor
    */
-  virtual ~Model() {}
+  virtual ~Model();
 
   /**
    * @brief Model id getter

--- a/dynawo/sources/API/DYD/DYDModelTemplate.cpp
+++ b/dynawo/sources/API/DYD/DYDModelTemplate.cpp
@@ -56,6 +56,8 @@ namespace dynamicdata {
 
 ModelTemplate::ModelTemplate(const string& id) : Model(id, Model::MODEL_TEMPLATE), useAliasing_(true), generateCalculatedVariables_(true) {}
 
+ModelTemplate::~ModelTemplate() {}
+
 void
 ModelTemplate::setCompilationOptions(bool useAliasing, bool generateCalculatedVariables) {
   useAliasing_ = useAliasing;

--- a/dynawo/sources/API/DYD/DYDModelTemplate.h
+++ b/dynawo/sources/API/DYD/DYDModelTemplate.h
@@ -49,6 +49,11 @@ class ModelTemplate : public Model {
   explicit ModelTemplate(const std::string& id);
 
   /**
+   * @brief Destructor
+   */
+  virtual ~ModelTemplate();
+
+  /**
    * @brief Set compilation options
    * @param useAliasing activate OpenModelica aliasing
    * @param generateCalculatedVariables activate automatic computation of calculated variables

--- a/dynawo/sources/API/DYD/DYDModelTemplateExpansion.cpp
+++ b/dynawo/sources/API/DYD/DYDModelTemplateExpansion.cpp
@@ -29,6 +29,8 @@ namespace dynamicdata {
 
 ModelTemplateExpansion::ModelTemplateExpansion(const string& id) : Model(id, Model::MODEL_TEMPLATE_EXPANSION) {}
 
+ModelTemplateExpansion::~ModelTemplateExpansion() {}
+
 const std::string&
 ModelTemplateExpansion::getTemplateId() const {
   return templateId_;

--- a/dynawo/sources/API/DYD/DYDModelTemplateExpansion.h
+++ b/dynawo/sources/API/DYD/DYDModelTemplateExpansion.h
@@ -45,6 +45,11 @@ class ModelTemplateExpansion : public Model {
   explicit ModelTemplateExpansion(const std::string& id);
 
   /**
+   * @brief Destructor
+   */
+  virtual ~ModelTemplateExpansion();
+
+  /**
    * @brief Template Model getter
    *
    * @returns Template Model absolute path

--- a/dynawo/sources/API/DYD/DYDModelicaModel.cpp
+++ b/dynawo/sources/API/DYD/DYDModelicaModel.cpp
@@ -49,6 +49,8 @@ namespace dynamicdata {
 
 ModelicaModel::ModelicaModel(const string& id) : Model(id, Model::MODELICA_MODEL), useAliasing_(true), generateCalculatedVariables_(true) {}
 
+ModelicaModel::~ModelicaModel() {}
+
 const string&
 ModelicaModel::getStaticId() const {
   return staticId_;

--- a/dynawo/sources/API/DYD/DYDModelicaModel.h
+++ b/dynawo/sources/API/DYD/DYDModelicaModel.h
@@ -52,6 +52,11 @@ class ModelicaModel : public Model {
   explicit ModelicaModel(const std::string& id);
 
   /**
+   * @brief Destructor
+   */
+  virtual ~ModelicaModel();
+
+  /**
    * @brief Network Identifiable device modeled getter
 
    * @returns Id of Network Identifiable device modeled

--- a/dynawo/sources/API/DYD/DYDXmlHandler.cpp
+++ b/dynawo/sources/API/DYD/DYDXmlHandler.cpp
@@ -97,6 +97,8 @@ macroStaticReferenceHandler_(parser::ElementName(namespace_uri(), "macroStaticRe
   macroStaticReferenceHandler_.onEnd(lambda::bind(&XmlHandler::addMacroStaticReference, lambda::ref(*this)));
 }
 
+XmlHandler::~XmlHandler() {}
+
 boost::shared_ptr<DynamicModelsCollection>
 XmlHandler::getDynamicModelsCollection() {
   return dynamicModelsCollection_;
@@ -168,6 +170,8 @@ unitDynamicModelHandler_(parser::ElementName(namespace_uri(), "unitDynamicModel"
   macroStaticRefHandler_.onEnd(lambda::bind(&ModelicaModelHandler::addMacroStaticRef, lambda::ref(*this)));
   unitDynamicModelHandler_.onEnd(lambda::bind(&ModelicaModelHandler::addUnitDynamicModel, lambda::ref(*this)));
 }
+
+ModelicaModelHandler::~ModelicaModelHandler() {}
 
 void
 ModelicaModelHandler::create(attributes_type const& attributes) {
@@ -246,6 +250,8 @@ unitDynamicModelHandler_(parser::ElementName(namespace_uri(), "unitDynamicModel"
   unitDynamicModelHandler_.onEnd(lambda::bind(&ModelTemplateHandler::addUnitDynamicModel, lambda::ref(*this)));
 }
 
+ModelTemplateHandler::~ModelTemplateHandler() {}
+
 void
 ModelTemplateHandler::create(attributes_type const& attributes) {
   modelTemplate_ = ModelTemplateFactory::newModel(attributes["id"]);
@@ -308,6 +314,8 @@ macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")) {
   macroStaticRefHandler_.onEnd(lambda::bind(&BlackBoxModelHandler::addMacroStaticRef, lambda::ref(*this)));
 }
 
+BlackBoxModelHandler::~BlackBoxModelHandler() {}
+
 void
 BlackBoxModelHandler::create(attributes_type const& attributes) {
   blackBoxModel_ = BlackBoxModelFactory::newModel(attributes["id"]);
@@ -351,6 +359,8 @@ macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")) {
   macroStaticRefHandler_.onEnd(lambda::bind(&ModelTemplateExpansionHandler::addMacroStaticRef, lambda::ref(*this)));
 }
 
+ModelTemplateExpansionHandler::~ModelTemplateExpansionHandler() {}
+
 void
 ModelTemplateExpansionHandler::create(attributes_type const& attributes) {
   modelTemplateExpansion_ = ModelTemplateExpansionFactory::newModel(attributes["id"]);
@@ -386,6 +396,8 @@ ConnectHandler::ConnectHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&ConnectHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+ConnectHandler::~ConnectHandler() {}
+
 void
 ConnectHandler::create(attributes_type const& attributes) {
   connector_.id1 = attributes["id1"].as_string();
@@ -402,6 +414,8 @@ ConnectHandler::get() const {
 MacroConnectHandler::MacroConnectHandler(const elementName_type& root_element) {
   onStartElement(root_element, lambda::bind(&MacroConnectHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+MacroConnectHandler::~MacroConnectHandler() {}
 
 void
 MacroConnectHandler::create(attributes_type const& attributes) {
@@ -433,6 +447,8 @@ macroInitConnectionHandler_(parser::ElementName(namespace_uri(), "initConnect"))
   macroInitConnectionHandler_.onEnd(lambda::bind(&MacroConnectorHandler::addInitConnect, lambda::ref(*this)));
 }
 
+MacroConnectorHandler::~MacroConnectorHandler() {}
+
 void
 MacroConnectorHandler::create(attributes_type const & attributes) {
   macroConnector_ = MacroConnectorFactory::newMacroConnector(attributes["id"]);
@@ -459,6 +475,8 @@ MacroConnectionHandler::MacroConnectionHandler(elementName_type const& root_elem
   onStartElement(root_element, lambda::bind(&MacroConnectionHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+MacroConnectionHandler::~MacroConnectionHandler() {}
+
 void
 MacroConnectionHandler::create(attributes_type const& attributes) {
   macroConnection_.var1 = attributes["var1"].as_string();
@@ -474,6 +492,8 @@ StaticRefHandler::StaticRefHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&StaticRefHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+StaticRefHandler::~StaticRefHandler() {}
+
 void
 StaticRefHandler::create(attributes_type const& attributes) {
   staticRef_.var = attributes["var"].as_string();
@@ -488,6 +508,8 @@ StaticRefHandler::get() const {
 MacroStaticRefHandler::MacroStaticRefHandler(const elementName_type& root_element) {
   onStartElement(root_element, lambda::bind(&MacroStaticRefHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+MacroStaticRefHandler::~MacroStaticRefHandler() {}
 
 void
 MacroStaticRefHandler::create(attributes_type const& attributes) {
@@ -508,6 +530,8 @@ staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")) {
   staticRefHandler_.onEnd(lambda::bind(&MacroStaticReferenceHandler::addStaticRef, lambda::ref(*this)));
 }
 
+MacroStaticReferenceHandler::~MacroStaticReferenceHandler() {}
+
 void
 MacroStaticReferenceHandler::create(attributes_type const & attributes) {
   macroStaticReference_ = MacroStaticReferenceFactory::newMacroStaticReference(attributes["id"]);
@@ -527,6 +551,8 @@ MacroStaticReferenceHandler::get() const {
 UnitDynamicModelHandler::UnitDynamicModelHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&UnitDynamicModelHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+UnitDynamicModelHandler::~UnitDynamicModelHandler() {}
 
 void
 UnitDynamicModelHandler::create(attributes_type const& attributes) {

--- a/dynawo/sources/API/DYD/DYDXmlHandler.h
+++ b/dynawo/sources/API/DYD/DYDXmlHandler.h
@@ -83,9 +83,9 @@ class UnitDynamicModelHandler : public xml::sax::parser::ComposableElementHandle
   explicit UnitDynamicModelHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~UnitDynamicModelHandler() {}
+  ~UnitDynamicModelHandler();
 
   /**
    * @brief return the unit dynamic model read in xml file
@@ -117,9 +117,9 @@ class StaticRefHandler : public xml::sax::parser::ComposableElementHandler {
   explicit StaticRefHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~StaticRefHandler() {}
+  ~StaticRefHandler();
 
   /**
    * @brief return the static ref read in xml file
@@ -151,9 +151,9 @@ class MacroStaticRefHandler : public xml::sax::parser::ComposableElementHandler 
   explicit MacroStaticRefHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroStaticRefHandler() {}
+  ~MacroStaticRefHandler();
 
   /**
    * return the macroStaticRef read in xml file
@@ -185,9 +185,9 @@ class MacroStaticReferenceHandler : public xml::sax::parser::ComposableElementHa
   explicit MacroStaticReferenceHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroStaticReferenceHandler() {}
+  ~MacroStaticReferenceHandler();
 
   /**
    * return the macroStaticReference read in xml file
@@ -225,9 +225,9 @@ class ConnectHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ConnectHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ConnectHandler() {}
+  ~ConnectHandler();
 
   /**
    * @brief return the connector read in xml file
@@ -260,9 +260,9 @@ class MacroConnectHandler : public xml::sax::parser::ComposableElementHandler {
   explicit MacroConnectHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroConnectHandler() {}
+  ~MacroConnectHandler();
 
   /**
    * return the macro connect read in xml file
@@ -294,9 +294,9 @@ class MacroConnectionHandler : public xml::sax::parser::ComposableElementHandler
   explicit MacroConnectionHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroConnectionHandler() {}
+  ~MacroConnectionHandler();
 
   /**
    * return the macro connection read in xml file
@@ -328,9 +328,9 @@ class MacroConnectorHandler : public xml::sax::parser::ComposableElementHandler 
   explicit MacroConnectorHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroConnectorHandler() {}
+  ~MacroConnectorHandler();
 
   /**
    * return the macro connector read in xml file
@@ -374,9 +374,9 @@ class ModelicaModelHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ModelicaModelHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ModelicaModelHandler() {}
+  ~ModelicaModelHandler();
 
   /**
    * @brief return the modelica model read in xml file
@@ -444,9 +444,9 @@ class ModelTemplateHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ModelTemplateHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ModelTemplateHandler() {}
+  ~ModelTemplateHandler();
 
   /**
    * @brief return the model template read in xml file
@@ -514,9 +514,9 @@ class BlackBoxModelHandler : public xml::sax::parser::ComposableElementHandler {
   explicit BlackBoxModelHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~BlackBoxModelHandler() {}
+  ~BlackBoxModelHandler();
 
   /**
    * @brief add a static reference to the black box model
@@ -560,9 +560,9 @@ class ModelTemplateExpansionHandler : public xml::sax::parser::ComposableElement
   explicit ModelTemplateExpansionHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ModelTemplateExpansionHandler() {}
+  ~ModelTemplateExpansionHandler();
 
   /**
    * @brief add a static reference to the model template expansion
@@ -610,7 +610,7 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
   /**
    * @brief Destructor
    */
-  ~XmlHandler() {}
+  ~XmlHandler();
 
   /**
    * @brief Parsed parameters set collection getter

--- a/dynawo/sources/API/DYD/DYDXmlImporter.h
+++ b/dynawo/sources/API/DYD/DYDXmlImporter.h
@@ -35,10 +35,6 @@ namespace dynamicdata {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-  /**
    * @copydoc Importer::importFromDydFiles()
    */
   boost::shared_ptr<DynamicModelsCollection> importFromDydFiles(const std::vector<std::string>& fileNames) const;

--- a/dynawo/sources/API/EXTVAR/EXTVARExporter.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARExporter.h
@@ -24,6 +24,12 @@
 
 #include "EXTVARVariablesCollection.h"
 namespace externalVariables {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -36,6 +42,7 @@ class Exporter {
    * @brief Destructor
    */
   virtual ~Exporter() {}
+
   /**
    * @brief Export method for this exporter
    *
@@ -52,6 +59,10 @@ class Exporter {
    */
   virtual void exportToStream(const VariablesCollection& collection, std::ostream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace externalVariables
 

--- a/dynawo/sources/API/EXTVAR/EXTVARImporter.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARImporter.h
@@ -25,6 +25,11 @@
 #include "EXTVARVariablesCollection.h"
 namespace externalVariables {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -37,6 +42,7 @@ class Importer {
    * @brief Destructor
    */
   virtual ~Importer() {}
+
   /**
    * @brief Import external (i.e. C++-connected) variables
    *
@@ -53,6 +59,10 @@ class Importer {
    */
   virtual boost::shared_ptr<VariablesCollection> importFromStream(std::istream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace externalVariables
 

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlExporter.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlExporter.h
@@ -43,10 +43,6 @@ namespace externalVariables {
 class XmlExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlExporter() {}
-  /**
    * @brief Export method in XML format
    *
    * @param collection Collection to export

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.cpp
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.cpp
@@ -55,6 +55,8 @@ variablesHandler_(parser::ElementName(namespace_uri(), "variable")) {
   variablesHandler_.onEnd(lambda::bind(&XmlHandler::addVariable, lambda::ref(*this)));
 }
 
+XmlHandler::~XmlHandler() {}
+
 boost::shared_ptr<VariablesCollection>
 XmlHandler::getVariablesCollection() {
   return variablesCollection_;
@@ -74,6 +76,8 @@ VariableHandler::get() const {
 VariableHandler::VariableHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&VariableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+VariableHandler::~VariableHandler() {}
 
 void
 VariableHandler::create(attributes_type const& attributes) {

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.h
@@ -41,6 +41,11 @@ class VariableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit VariableHandler(elementName_type const& root_element);
 
   /**
+   * @brief Destructor
+   */
+  ~VariableHandler();
+
+  /**
    * @brief Variable getter
    * @return the Variable object
    */
@@ -73,7 +78,7 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
   /**
    * @brief Destructor
    */
-  ~XmlHandler() { }
+  ~XmlHandler();
 
   /**
    * @brief Parsed parameters set collection getter

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlImporter.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlImporter.h
@@ -35,10 +35,6 @@ namespace externalVariables {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-  /**
    * @copydoc Importer::importFromFile()
    */
   boost::shared_ptr<VariablesCollection> importFromFile(const std::string& fileName) const;

--- a/dynawo/sources/API/FS/FSExporter.h
+++ b/dynawo/sources/API/FS/FSExporter.h
@@ -27,6 +27,11 @@
 
 namespace finalState {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -56,6 +61,10 @@ class Exporter {
    */
   virtual void exportToStream(const boost::shared_ptr<FinalStateCollection>& finalState, std::ostream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace finalState
 

--- a/dynawo/sources/API/FS/FSImporter.h
+++ b/dynawo/sources/API/FS/FSImporter.h
@@ -27,6 +27,11 @@
 
 namespace finalState {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -58,6 +63,10 @@ class Importer {
    */
   virtual boost::shared_ptr<FinalStateCollection> importFromStream(std::istream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace finalState
 

--- a/dynawo/sources/API/FS/FSXmlExporter.h
+++ b/dynawo/sources/API/FS/FSXmlExporter.h
@@ -34,11 +34,6 @@ namespace finalState {
 class XmlExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlExporter() {}
-
-  /**
    * @brief Export method in XML format
    *
    * @param finalState final state to export

--- a/dynawo/sources/API/FS/FSXmlHandler.cpp
+++ b/dynawo/sources/API/FS/FSXmlHandler.cpp
@@ -110,6 +110,8 @@ ModelHandler::ModelHandler(elementName_type const & root_element) {
   onStartElement(root_element, lambda::bind(&ModelHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+ModelHandler::~ModelHandler() {}
+
 void
 ModelHandler::create(attributes_type const & attributes) {
   modelRead_ = ModelFactory::newModel(attributes["id"]);
@@ -123,6 +125,8 @@ ModelHandler::get() const {
 VariableHandler::VariableHandler(elementName_type const & root_element) {
   onStartElement(root_element, lambda::bind(&VariableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+VariableHandler::~VariableHandler() {}
 
 void
 VariableHandler::create(attributes_type const & attributes) {

--- a/dynawo/sources/API/FS/FSXmlHandler.h
+++ b/dynawo/sources/API/FS/FSXmlHandler.h
@@ -46,9 +46,9 @@ class ModelHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ModelHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ModelHandler() {}
+  ~ModelHandler();
 
   /**
    * @brief return the model object read in xml file
@@ -80,9 +80,9 @@ class VariableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit VariableHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~VariableHandler() {}
+  ~VariableHandler();
 
   /**
    * @brief return the variable object read in xml file

--- a/dynawo/sources/API/FS/FSXmlImporter.h
+++ b/dynawo/sources/API/FS/FSXmlImporter.h
@@ -34,11 +34,6 @@ namespace finalState {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-
-  /**
    * @copydoc Importer::importFromFile()
    */
   boost::shared_ptr<FinalStateCollection> importFromFile(const std::string& fileName) const;

--- a/dynawo/sources/API/JOB/JOBImporter.h
+++ b/dynawo/sources/API/JOB/JOBImporter.h
@@ -26,6 +26,12 @@
 #include <boost/shared_ptr.hpp>
 
 namespace job {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -57,6 +63,10 @@ class Importer {
    */
   virtual boost::shared_ptr<JobsCollection> importFromStream(std::istream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace job
 

--- a/dynawo/sources/API/JOB/JOBXmlHandler.cpp
+++ b/dynawo/sources/API/JOB/JOBXmlHandler.cpp
@@ -103,6 +103,8 @@ outputsHandler_(parser::ElementName(namespace_uri(), "outputs")) {
   outputsHandler_.onEnd(lambda::bind(&JobHandler::addOutputs, lambda::ref(*this)));
 }
 
+JobHandler::~JobHandler() {}
+
 void
 JobHandler::addSolver() {
   job_->setSolverEntry(solverHandler_.get());
@@ -138,6 +140,8 @@ SolverHandler::SolverHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&SolverHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+SolverHandler::~SolverHandler() {}
+
 void
 SolverHandler::create(attributes_type const & attributes) {
   solver_ = shared_ptr<SolverEntry>(new SolverEntry());
@@ -171,6 +175,8 @@ modelicaModelsHandler_(parser::ElementName(namespace_uri(), "modelicaModels")) {
   preCompiledModelsHandler_.onEnd(lambda::bind(&ModelerHandler::addPreCompiledModels, lambda::ref(*this)));
   modelicaModelsHandler_.onEnd(lambda::bind(&ModelerHandler::addModelicaModel, lambda::ref(*this)));
 }
+
+ModelerHandler::~ModelerHandler() {}
 
 void
 ModelerHandler::addNetwork() {
@@ -207,9 +213,12 @@ shared_ptr<ModelerEntry>
 ModelerHandler::get() const {
   return modeler_;
 }
+
 CriteriaFileHandler::CriteriaFileHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CriteriaFileHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+CriteriaFileHandler::~CriteriaFileHandler() {}
 
 void
 CriteriaFileHandler::create(attributes_type const& attributes) {
@@ -228,6 +237,8 @@ criteriaFileHandler_(parser::ElementName(namespace_uri(), "criteria")) {
 
   criteriaFileHandler_.onEnd(lambda::bind(&SimulationHandler::addCriteriaFile, lambda::ref(*this)));
 }
+
+SimulationHandler::~SimulationHandler() {}
 
 void
 SimulationHandler::create(attributes_type const& attributes) {
@@ -282,6 +293,8 @@ logsHandler_(parser::ElementName(namespace_uri(), "logs")) {
   lostEquipmentsHandler_.onEnd(lambda::bind(&OutputsHandler::addLostEquipments, lambda::ref(*this)));
   logsHandler_.onEnd(lambda::bind(&OutputsHandler::addLog, lambda::ref(*this)));
 }
+
+OutputsHandler::~OutputsHandler() {}
 
 void
 OutputsHandler::addInitValuesEntry() {
@@ -338,6 +351,8 @@ InitValuesHandler::InitValuesHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&InitValuesHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+InitValuesHandler::~InitValuesHandler() {}
+
 void
 InitValuesHandler::create(attributes_type const& attributes) {
   initValuesEntry_ = shared_ptr<InitValuesEntry>(new InitValuesEntry());
@@ -354,6 +369,8 @@ ConstraintsHandler::ConstraintsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&ConstraintsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+ConstraintsHandler::~ConstraintsHandler() {}
+
 void
 ConstraintsHandler::create(attributes_type const& attributes) {
   constraints_ = shared_ptr<ConstraintsEntry>(new ConstraintsEntry());
@@ -368,6 +385,8 @@ ConstraintsHandler::get() const {
 TimelineHandler::TimelineHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&TimelineHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+TimelineHandler::~TimelineHandler() {}
 
 void
 TimelineHandler::create(attributes_type const& attributes) {
@@ -388,6 +407,8 @@ TimetableHandler::TimetableHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&TimetableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+TimetableHandler::~TimetableHandler() {}
+
 void
 TimetableHandler::create(attributes_type const& attributes) {
   timetable_ = shared_ptr<TimetableEntry>(new TimetableEntry());
@@ -402,6 +423,8 @@ TimetableHandler::get() const {
 FinalStateHandler::FinalStateHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&FinalStateHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+FinalStateHandler::~FinalStateHandler() {}
 
 void
 FinalStateHandler::create(attributes_type const& attributes) {
@@ -422,6 +445,8 @@ CurvesHandler::CurvesHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CurvesHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+CurvesHandler::~CurvesHandler() {}
+
 void
 CurvesHandler::create(attributes_type const& attributes) {
   curves_ = shared_ptr<CurvesEntry>(new CurvesEntry());
@@ -437,6 +462,8 @@ CurvesHandler::get() const {
 LostEquipmentsHandler::LostEquipmentsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&LostEquipmentsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+LostEquipmentsHandler::~LostEquipmentsHandler() {}
 
 void
 LostEquipmentsHandler::create(attributes_type const& /*attributes*/) {
@@ -458,6 +485,8 @@ appenderHandler_(parser::ElementName(namespace_uri(), "appender")) {
   appenderHandler_.onEnd(lambda::bind(&LogsHandler::addAppender, lambda::ref(*this)));
 }
 
+LogsHandler::~LogsHandler() {}
+
 void
 LogsHandler::addAppender() {
   logs_->addAppenderEntry(appenderHandler_.get());
@@ -476,6 +505,8 @@ LogsHandler::get() const {
 AppenderHandler::AppenderHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&AppenderHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+AppenderHandler::~AppenderHandler() {}
 
 void
 AppenderHandler::create(attributes_type const& attributes) {
@@ -507,6 +538,8 @@ NetworkHandler::NetworkHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&NetworkHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+NetworkHandler::~NetworkHandler() {}
+
 void
 NetworkHandler::create(attributes_type const& attributes) {
   network_ = shared_ptr<NetworkEntry>(new NetworkEntry());
@@ -524,6 +557,8 @@ DynModelsHandler::DynModelsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&DynModelsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+DynModelsHandler::~DynModelsHandler() {}
+
 void
 DynModelsHandler::create(attributes_type const& attributes) {
   dynModels_ = shared_ptr<DynModelsEntry>(new DynModelsEntry());
@@ -538,6 +573,8 @@ DynModelsHandler::get() const {
 InitialStateHandler::InitialStateHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&InitialStateHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+InitialStateHandler::~InitialStateHandler() {}
 
 void
 InitialStateHandler::create(attributes_type const& attributes) {
@@ -558,6 +595,8 @@ directoryHandler_(parser::ElementName(namespace_uri(), "directory")) {
 
   directoryHandler_.onEnd(lambda::bind(&ModelsDirHandler::addDirectory, lambda::ref(*this)));
 }
+
+ModelsDirHandler::~ModelsDirHandler() {}
 
 void
 ModelsDirHandler::create(attributes_type const& attributes) {
@@ -582,6 +621,8 @@ DirectoryHandler::DirectoryHandler(elementName_type const& root_element) {
   dir_.isRecursive = false;
   onStartElement(root_element, lambda::bind(&DirectoryHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+DirectoryHandler::~DirectoryHandler() {}
 
 void
 DirectoryHandler::create(attributes_type const& attributes) {

--- a/dynawo/sources/API/JOB/JOBXmlHandler.h
+++ b/dynawo/sources/API/JOB/JOBXmlHandler.h
@@ -63,9 +63,9 @@ class AppenderHandler : public xml::sax::parser::ComposableElementHandler {
   explicit AppenderHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~AppenderHandler() {}
+  ~AppenderHandler();
 
   /**
    * @brief return the appender read in xml file
@@ -97,9 +97,9 @@ class DirectoryHandler : public xml::sax::parser::ComposableElementHandler {
   explicit DirectoryHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~DirectoryHandler() {}
+  ~DirectoryHandler();
 
   /**
    * @brief return the directory read in xml file
@@ -131,9 +131,9 @@ class ModelsDirHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ModelsDirHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ModelsDirHandler() {}
+  ~ModelsDirHandler();
 
   /**
    * @brief add a directory to the list of directory
@@ -171,9 +171,9 @@ class InitialStateHandler : public xml::sax::parser::ComposableElementHandler {
   explicit InitialStateHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~InitialStateHandler() {}
+  ~InitialStateHandler();
 
   /**
    * @brief get the initial state element read in xml file
@@ -205,9 +205,9 @@ class DynModelsHandler : public xml::sax::parser::ComposableElementHandler {
   explicit DynModelsHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~DynModelsHandler() {}
+  ~DynModelsHandler();
 
   /**
    * @brief get the dynModels objects read in xml file
@@ -239,9 +239,9 @@ class NetworkHandler : public xml::sax::parser::ComposableElementHandler {
   explicit NetworkHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~NetworkHandler() {}
+  ~NetworkHandler();
 
   /**
    * @brief return the network entry element read in xml file
@@ -273,9 +273,9 @@ class InitValuesHandler : public xml::sax::parser::ComposableElementHandler {
   explicit InitValuesHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~InitValuesHandler() {}
+  ~InitValuesHandler();
 
   /**
    * @brief return the init values entry read in xml file
@@ -307,9 +307,9 @@ class ConstraintsHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ConstraintsHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ConstraintsHandler() {}
+  ~ConstraintsHandler();
 
   /**
    * @brief return the constraints entry read in xml file
@@ -341,9 +341,9 @@ class TimelineHandler : public xml::sax::parser::ComposableElementHandler {
   explicit TimelineHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~TimelineHandler() {}
+  ~TimelineHandler();
 
   /**
    * @brief return the timeline entry read in xml file
@@ -375,9 +375,9 @@ class TimetableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit TimetableHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~TimetableHandler() {}
+  ~TimetableHandler();
 
   /**
    * @brief return the timetable entry read in xml file
@@ -409,9 +409,9 @@ class FinalStateHandler : public xml::sax::parser::ComposableElementHandler {
   explicit FinalStateHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~FinalStateHandler() {}
+  ~FinalStateHandler();
 
   /**
    * @brief return the final state entry read in xml file
@@ -443,9 +443,9 @@ class CurvesHandler : public xml::sax::parser::ComposableElementHandler {
   explicit CurvesHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~CurvesHandler() {}
+  ~CurvesHandler();
 
   /**
    * @brief return the curves entry read in xml file
@@ -477,9 +477,9 @@ class LostEquipmentsHandler : public xml::sax::parser::ComposableElementHandler 
   explicit LostEquipmentsHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~LostEquipmentsHandler() {}
+  ~LostEquipmentsHandler();
 
   /**
    * @brief return the lostEquipments entry read in xml file
@@ -511,9 +511,9 @@ class LogsHandler : public xml::sax::parser::ComposableElementHandler {
   explicit LogsHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~LogsHandler() {}
+  ~LogsHandler();
 
   /**
    * @brief return the logs entry read in xml file
@@ -551,9 +551,9 @@ class OutputsHandler : public xml::sax::parser::ComposableElementHandler {
   explicit OutputsHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~OutputsHandler() {}
+  ~OutputsHandler();
 
   /**
    * @brief return the outputs entry read in xml file
@@ -633,9 +633,9 @@ class CriteriaFileHandler : public xml::sax::parser::ComposableElementHandler {
   explicit CriteriaFileHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~CriteriaFileHandler() {}
+  ~CriteriaFileHandler();
 
   /**
    * @brief return the simulation entry read in xml file
@@ -667,9 +667,9 @@ class SimulationHandler : public xml::sax::parser::ComposableElementHandler {
   explicit SimulationHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~SimulationHandler() {}
+  ~SimulationHandler();
 
   /**
    * @brief return the simulation entry read in xml file
@@ -707,9 +707,9 @@ class ModelerHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ModelerHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ModelerHandler() {}
+  ~ModelerHandler();
 
   /**
    * @brief return the modeler entry read in xml file
@@ -771,9 +771,9 @@ class SolverHandler : public xml::sax::parser::ComposableElementHandler {
   explicit SolverHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~SolverHandler() {}
+  ~SolverHandler();
 
   /**
    * @brief return the solver entry read in xml file
@@ -805,9 +805,9 @@ class JobHandler : public xml::sax::parser::ComposableElementHandler {
   explicit JobHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~JobHandler() {}
+  ~JobHandler();
 
   /**
    * @brief return the job read in xml file

--- a/dynawo/sources/API/JOB/JOBXmlImporter.h
+++ b/dynawo/sources/API/JOB/JOBXmlImporter.h
@@ -34,11 +34,6 @@ namespace job {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-
-  /**
    * @copydoc Importer::importFromFile()
    */
   boost::shared_ptr<JobsCollection> importFromFile(const std::string& fileName) const;

--- a/dynawo/sources/API/LEQ/LEQExporter.h
+++ b/dynawo/sources/API/LEQ/LEQExporter.h
@@ -29,6 +29,11 @@
 
 namespace lostEquipments {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -41,6 +46,7 @@ class Exporter {
    * @brief Destructor
    */
   virtual ~Exporter() {}
+
   /**
    * @brief Export method for this exporter
    *
@@ -57,6 +63,10 @@ class Exporter {
    */
   virtual void exportToStream(const boost::shared_ptr<LostEquipmentsCollection>& lostEquipments, std::ostream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace lostEquipments
 

--- a/dynawo/sources/API/LEQ/LEQXmlExporter.h
+++ b/dynawo/sources/API/LEQ/LEQXmlExporter.h
@@ -34,10 +34,6 @@ namespace lostEquipments {
 class XmlExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlExporter() {}
-  /**
    * @brief Export method in XML format
    *
    * @param lostEquipments Lost equipments to export

--- a/dynawo/sources/API/PAR/PARExporter.h
+++ b/dynawo/sources/API/PAR/PARExporter.h
@@ -26,6 +26,11 @@
 
 namespace parameters {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -57,6 +62,10 @@ class Exporter {
    */
   virtual void exportToStream(const boost::shared_ptr<ParametersSetCollection>& collection, std::ostream& stream, const std::string& encoding) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace parameters
 

--- a/dynawo/sources/API/PAR/PARImporter.h
+++ b/dynawo/sources/API/PAR/PARImporter.h
@@ -26,6 +26,11 @@
 
 namespace parameters {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Importer
  * @brief Importer interface class
@@ -55,6 +60,10 @@ class Importer {
    */
   virtual boost::shared_ptr<ParametersSetCollection> importFromStream(std::istream& stream) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace parameters
 

--- a/dynawo/sources/API/PAR/PARXmlHandler.cpp
+++ b/dynawo/sources/API/PAR/PARXmlHandler.cpp
@@ -103,6 +103,8 @@ macroParSetHandler_(parser::ElementName(namespace_uri(), "macroParSet")) {
   macroParSetHandler_.onEnd(lambda::bind(&SetHandler::addMacroParSet, lambda::ref(*this)));
 }
 
+SetHandler::~SetHandler() {}
+
 void
 SetHandler::create(attributes_type const & attributes) {
   setRead_ = shared_ptr<ParametersSet>(new ParametersSet(attributes["id"].as_string()));
@@ -159,6 +161,8 @@ parInTableHandler_(parser::ElementName(namespace_uri(), "par")) {
   parInTableHandler_.onEnd(lambda::bind(&ParTableHandler::addPar, lambda::ref(*this)));
 }
 
+ParTableHandler::~ParTableHandler() {}
+
 void
 ParTableHandler::create(attributes_type const & attributes) {
   pars_.clear();
@@ -180,6 +184,8 @@ ParInTableHandler::ParInTableHandler(elementName_type const & root_element) {
   onStartElement(root_element, lambda::bind(&ParInTableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+ParInTableHandler::~ParInTableHandler() {}
+
 void
 ParInTableHandler::create(attributes_type const & attributes) {
   par_.value = attributes["value"].as_string();
@@ -195,6 +201,8 @@ ParInTableHandler::get() const {
 ParHandler::ParHandler(elementName_type const & root_element) {
   onStartElement(root_element, lambda::bind(&ParHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+ParHandler::~ParHandler() {}
 
 void
 ParHandler::create(attributes_type const & attributes) {
@@ -224,6 +232,8 @@ RefHandler::RefHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&RefHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
+RefHandler::~RefHandler() {}
+
 void RefHandler::create(attributes_type const & attributes) {
   referenceRead_ = ReferenceFactory::newReference(attributes["name"]);
   referenceRead_->setType(attributes["type"]);
@@ -248,6 +258,8 @@ parHandler_(parser::ElementName(namespace_uri(), "par")) {
   parHandler_.onEnd(lambda::bind(&MacroParameterSetHandler::addParameter, lambda::ref(*this)));
 }
 
+MacroParameterSetHandler::~MacroParameterSetHandler() {}
+
 void
 MacroParameterSetHandler::create(attributes_type const & attributes) {
   macroParameterSet_ = shared_ptr<MacroParameterSet>(new MacroParameterSet(attributes["id"].as_string()));
@@ -271,6 +283,8 @@ MacroParameterSetHandler::get() const {
 MacroParSetHandler::MacroParSetHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&MacroParSetHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
+
+MacroParSetHandler::~MacroParSetHandler() {}
 
 void
 MacroParSetHandler::create(attributes_type const & attributes) {

--- a/dynawo/sources/API/PAR/PARXmlHandler.h
+++ b/dynawo/sources/API/PAR/PARXmlHandler.h
@@ -57,9 +57,9 @@ class ParInTableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ParInTableHandler(elementName_type const & root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ParInTableHandler() { }
+  ~ParInTableHandler();
 
   /**
    * @brief return the parameter in xml file
@@ -91,9 +91,9 @@ class ParTableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ParTableHandler(elementName_type const & root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ParTableHandler() { }
+  ~ParTableHandler();
 
   /**
    * @brief get the type of the current parTable
@@ -165,9 +165,9 @@ class ParHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ParHandler(elementName_type const & root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~ParHandler() { }
+  ~ParHandler();
 
   /**
    * @brief return the parameter read in xml file
@@ -199,9 +199,9 @@ class RefHandler : public xml::sax::parser::ComposableElementHandler {
   explicit RefHandler(elementName_type const & root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~RefHandler() { }
+  ~RefHandler();
 
   /**
    * @brief return the reference read in xml file
@@ -233,9 +233,9 @@ class MacroParSetHandler : public xml::sax::parser::ComposableElementHandler {
   explicit MacroParSetHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroParSetHandler() {}
+  ~MacroParSetHandler();
 
   /**
    * @brief return the macroParSet read in xml file
@@ -267,9 +267,9 @@ class SetHandler : public xml::sax::parser::ComposableElementHandler {
   explicit SetHandler(elementName_type const & root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~SetHandler() { }
+  ~SetHandler();
 
   /**
    * @brief return the set of parameters read in xml file
@@ -325,9 +325,9 @@ class MacroParameterSetHandler : public xml::sax::parser::ComposableElementHandl
   explicit MacroParameterSetHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
+   * @brief Destructor
    */
-  ~MacroParameterSetHandler() {}
+  ~MacroParameterSetHandler();
 
   /**
    * @brief return the macroParameterSet read in xml file

--- a/dynawo/sources/API/PAR/PARXmlImporter.h
+++ b/dynawo/sources/API/PAR/PARXmlImporter.h
@@ -33,11 +33,6 @@ namespace parameters {
 class XmlImporter : public Importer {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlImporter() {}
-
-  /**
    * @copydoc Importer::importFromFile()
    */
   boost::shared_ptr<ParametersSetCollection> importFromFile(const std::string& fileName) const;

--- a/dynawo/sources/API/TL/TLCsvExporter.h
+++ b/dynawo/sources/API/TL/TLCsvExporter.h
@@ -33,11 +33,6 @@ namespace timeline {
 class CsvExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~CsvExporter() {}
-
-  /**
    * @brief Export method in csv format
    *
    * @param timeline Timeline to export

--- a/dynawo/sources/API/TL/TLExporter.h
+++ b/dynawo/sources/API/TL/TLExporter.h
@@ -27,6 +27,12 @@
 #include <string>
 
 namespace timeline {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class Exporter
  * @brief Exporter interface class
@@ -81,6 +87,10 @@ class Exporter {
   bool exportWithTime_;  ///< boolean indicating whether to export time when exporting timeline
   boost::optional<int> maxPriority_;  ///< maximum priority allowed when exporting timeline
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace timeline
 

--- a/dynawo/sources/API/TL/TLTxtExporter.h
+++ b/dynawo/sources/API/TL/TLTxtExporter.h
@@ -33,11 +33,6 @@ namespace timeline {
 class TxtExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~TxtExporter() {}
-
-  /**
    * @brief Export method in txt format
    *
    * @param timeline Timeline to export

--- a/dynawo/sources/API/TL/TLXmlExporter.h
+++ b/dynawo/sources/API/TL/TLXmlExporter.h
@@ -32,11 +32,6 @@ namespace timeline {
 class XmlExporter : public Exporter {
  public:
   /**
-   * @brief Destructor
-   */
-  virtual ~XmlExporter() {}
-
-  /**
    * @brief Export method in XML format
    *
    * @param timeline Timeline to export

--- a/dynawo/sources/Common/DYNParameter.cpp
+++ b/dynawo/sources/Common/DYNParameter.cpp
@@ -40,6 +40,8 @@ mandatory_(parameter.mandatory_) {
 }
 #endif
 
+ParameterCommon::~ParameterCommon() {}
+
 void
 ParameterCommon::setIndex(const unsigned int& index) {
   if (indexSet())

--- a/dynawo/sources/Common/DYNParameter.h
+++ b/dynawo/sources/Common/DYNParameter.h
@@ -58,10 +58,10 @@ class ParameterCommon {
 #endif
 
 #ifdef LANG_CXX11
-  /**
-   * @brief Default copy assigment operator
-   */
-  ParameterCommon& operator=(const ParameterCommon&) = default;
+    /**
+     * @brief Default copy assigment operator
+     */
+    ParameterCommon& operator=(const ParameterCommon&) = delete;
 #endif
 
   /**

--- a/dynawo/sources/Common/DYNParameter.h
+++ b/dynawo/sources/Common/DYNParameter.h
@@ -57,14 +57,17 @@ class ParameterCommon {
   ParameterCommon(const ParameterCommon& parameter);
 #endif
 
+#ifdef LANG_CXX11
+  /**
+   * @brief Default copy assigment operator
+   */
+  ParameterCommon& operator=(const ParameterCommon&) = default;
+#endif
+
   /**
    * @brief Destructor
    */
-#ifdef LANG_CXX11
-  virtual ~ParameterCommon() = default;
-#else
-  virtual ~ParameterCommon() { }
-#endif
+  virtual ~ParameterCommon();
 
   /**
    * @brief Getter for parameter's name

--- a/dynawo/sources/Common/test/TestParameter.cpp
+++ b/dynawo/sources/Common/test/TestParameter.cpp
@@ -26,6 +26,8 @@ class ParameterCommonMock : public ParameterCommon {
  public:
   ParameterCommonMock(const std::string& name, const typeVarC_t& valueType, bool mandatory);
 
+  ~ParameterCommonMock();
+
   boost::any getAnyValue() const {
     // unused
     return boost::any();
@@ -44,6 +46,8 @@ class ParameterCommonMock : public ParameterCommon {
 
 ParameterCommonMock::ParameterCommonMock(const std::string& name, const typeVarC_t& valueType, bool mandatory) : ParameterCommon(name, valueType, mandatory) {
 }
+
+ParameterCommonMock::~ParameterCommonMock() {}
 
 TEST(CommonTest, testClassParameter) {
   ParameterCommonMock parameter("Parameter1", VAR_TYPE_DOUBLE, true);

--- a/dynawo/sources/Modeler/Common/DYNConnectInterface.h
+++ b/dynawo/sources/Modeler/Common/DYNConnectInterface.h
@@ -22,6 +22,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class ConnectInterface
  * @brief connections of a model
@@ -104,6 +109,9 @@ class ConnectInterface {  ///< Generic class for connecting two dynamic models
   std::string model2Var_;  ///< second model's variable
 };  ///< interface class for dynamic connections
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/Common/DYNModel.h
+++ b/dynawo/sources/Modeler/Common/DYNModel.h
@@ -47,6 +47,11 @@ class CurvesCollection;
 namespace DYN {
 class SparseMatrix;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Generic model
  */
@@ -519,6 +524,11 @@ class Model {
    */
   virtual void notifyTimeStep() = 0;
 };  ///< Generic class for Model
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_COMMON_DYNMODEL_H_

--- a/dynawo/sources/Modeler/Common/DYNStaticRefInterface.h
+++ b/dynawo/sources/Modeler/Common/DYNStaticRefInterface.h
@@ -22,6 +22,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class StaticRefInterface
  * @brief StaticRefInterface
@@ -87,6 +92,9 @@ class StaticRefInterface {
   std::string staticVar_; /**< Pin name of the static Device */
 };  ///< interface class for static reference
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/Common/DYNSubModelFactory.cpp
+++ b/dynawo/sources/Modeler/Common/DYNSubModelFactory.cpp
@@ -33,6 +33,8 @@ using std::string;
 namespace DYN {
 typedef SubModelFactory* getSubModelFactory_t();
 
+SubModelFactory::~SubModelFactory() {}
+
 SubModelFactories::SubModelFactories() {
 }
 

--- a/dynawo/sources/Modeler/Common/DYNSubModelFactory.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModelFactory.h
@@ -50,7 +50,7 @@ class SubModelFactory : private boost::noncopyable {
   /**
    * @brief Destructor
    */
-  virtual ~SubModelFactory() { }
+  virtual ~SubModelFactory();
 
   /**
    * @brief create a new instance of a submodel

--- a/dynawo/sources/Modeler/Common/DYNVariable.cpp
+++ b/dynawo/sources/Modeler/Common/DYNVariable.cpp
@@ -28,4 +28,6 @@ name_(name),
 isAlias_(isAlias) {
 }
 
+Variable::~Variable() {}
+
 }  // namespace DYN

--- a/dynawo/sources/Modeler/Common/DYNVariable.h
+++ b/dynawo/sources/Modeler/Common/DYNVariable.h
@@ -36,7 +36,7 @@ class Variable {
   /**
    * @brief Destructor
    */
-  virtual ~Variable() { }
+  virtual ~Variable();
 
   /**
    * @brief Getter for variable's name

--- a/dynawo/sources/Modeler/Common/test/Test.cpp
+++ b/dynawo/sources/Modeler/Common/test/Test.cpp
@@ -187,11 +187,7 @@ class SubModelMockBase : public SubModel {
     // Dummy class used for testing
   }
 
-  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
-    variables.push_back(VariableNativeFactory::createState("MyVar", CONTINUOUS));
-    variables.push_back(VariableAliasFactory::create("MyAliasVar", "MyVar", FLOW, false));
-    variables.push_back(VariableNativeFactory::createState("MyDiscreteVar", DISCRETE));
-  }
+  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   void defineParameters(std::vector<ParameterModeler>&) {
     // Dummy class used for testing
@@ -243,17 +239,25 @@ class SubModelMockBase : public SubModel {
   }
 };
 
+void SubModelMockBase::defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
+  variables.push_back(VariableNativeFactory::createState("MyVar", CONTINUOUS));
+  variables.push_back(VariableAliasFactory::create("MyAliasVar", "MyVar", FLOW, false));
+  variables.push_back(VariableNativeFactory::createState("MyDiscreteVar", DISCRETE));
+}
+
 class SubModelMock : public SubModelMockBase {
  public:
   SubModelMock(unsigned nbY, unsigned nbZ) : SubModelMockBase(nbY, nbZ) {}
 
   SubModelMock() : SubModelMockBase(1, 1) {}
 
-  modeChangeType_t evalMode(const double) {
-    // Dummy class used for testing
-    return NO_MODE;
-  }
+  modeChangeType_t evalMode(const double);
 };
+
+modeChangeType_t SubModelMock::evalMode(const double) {
+  // Dummy class used for testing
+  return NO_MODE;
+}
 
 class SubModelMode : public SubModelMockBase {
  public:
@@ -261,20 +265,21 @@ class SubModelMode : public SubModelMockBase {
 
   SubModelMode() : SubModelMockBase(1, 1) {}
 
-  virtual ~SubModelMode() {}
-
-  modeChangeType_t evalMode(const double t) {
-    if (doubleEquals(t, 1))
-      return DIFFERENTIAL_MODE;
-    else if (doubleEquals(t, 2))
-      return ALGEBRAIC_MODE;
-    else if (doubleEquals(t, 3))
-      return DIFFERENTIAL_MODE;
-    else if (doubleEquals(t, 4))
-      return ALGEBRAIC_J_UPDATE_MODE;
-  return NO_MODE;
-  }
+  modeChangeType_t evalMode(const double t);
 };
+
+modeChangeType_t SubModelMode::evalMode(const double t) {
+  if (doubleEquals(t, 1))
+    return DIFFERENTIAL_MODE;
+  else if (doubleEquals(t, 2))
+    return ALGEBRAIC_MODE;
+  else if (doubleEquals(t, 3))
+    return DIFFERENTIAL_MODE;
+  else if (doubleEquals(t, 4))
+    return ALGEBRAIC_J_UPDATE_MODE;
+  return NO_MODE;
+}
+
 //-----------------------------------------------------
 // TEST DYNParameter
 //-----------------------------------------------------

--- a/dynawo/sources/Modeler/Common/test/TestGetNames.cpp
+++ b/dynawo/sources/Modeler/Common/test/TestGetNames.cpp
@@ -28,14 +28,12 @@
 
 namespace DYN {
 
-class SubModelMock : public SubModel {
+class SubModelMock0 : public SubModel {
  public:
-  SubModelMock(unsigned nbY, unsigned nbZ) : SubModel() {
+  SubModelMock0(unsigned nbY, unsigned nbZ) : SubModel() {
     sizeZ_ = nbZ;
     sizeY_ = nbY;
   }
-
-  virtual ~SubModelMock() {}
 
   void init(const double) {
     // Dummy class used for testing
@@ -166,9 +164,7 @@ class SubModelMock : public SubModel {
     // Dummy class used for testing
   }
 
-  void defineVariables(std::vector<boost::shared_ptr<Variable> >&) {
-    // Dummy class used for testing
-  }
+  void defineVariables(std::vector<boost::shared_ptr<Variable> >&);
 
   void defineParameters(std::vector<ParameterModeler>&) {
     // Dummy class used for testing
@@ -225,17 +221,17 @@ class SubModelMock : public SubModel {
   }
 };
 
-class SubModelMock1 : public SubModelMock {
+void SubModelMock0::defineVariables(std::vector<boost::shared_ptr<Variable> >&) {
+  // Dummy class used for testing
+}
+
+class SubModelMock1 : public SubModelMock0 {
  public:
-  SubModelMock1(unsigned nbY, unsigned nbZ) : SubModelMock(nbY, nbZ) {
+  SubModelMock1(unsigned nbY, unsigned nbZ) : SubModelMock0(nbY, nbZ) {
     sizeF_ = 2;
   }
 
-  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
-    variables.push_back(VariableNativeFactory::create("VarC", CONTINUOUS, true));
-    variables.push_back(VariableNativeFactory::create("VarD", DISCRETE, true));
-    variables.push_back(VariableNativeFactory::create("VarF", FLOW, true));
-  }
+  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   void setFequations() {
     fEquationIndex_[0] = "Eq1";
@@ -243,20 +239,28 @@ class SubModelMock1 : public SubModelMock {
   }
 };
 
-class SubModelMock2 : public SubModelMock {
+void SubModelMock1::defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
+  variables.push_back(VariableNativeFactory::create("VarC", CONTINUOUS, true));
+  variables.push_back(VariableNativeFactory::create("VarD", DISCRETE, true));
+  variables.push_back(VariableNativeFactory::create("VarF", FLOW, true));
+}
+
+class SubModelMock2 : public SubModelMock0 {
  public:
-  SubModelMock2(unsigned nbY, unsigned nbZ) : SubModelMock(nbY, nbZ) {
+  SubModelMock2(unsigned nbY, unsigned nbZ) : SubModelMock0(nbY, nbZ) {
     sizeF_ = 1;
   }
 
-  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
-    variables.push_back(VariableNativeFactory::create("VarF2", FLOW, true));
-  }
+  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   void setFequations() {
     fEquationIndex_[0] = "Eq2_1";
   }
 };
+
+void SubModelMock2::defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
+  variables.push_back(VariableNativeFactory::create("VarF2", FLOW, true));
+}
 
 TEST(TestGetName, getVariableName) {
   ModelMulti model;

--- a/dynawo/sources/Modeler/DataInterface/DYNBusBarSectionInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNBusBarSectionInterface.h
@@ -25,6 +25,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class BusBarSectionInterface
  * @brief bus bar section data interface
@@ -54,6 +59,11 @@ class BusBarSectionInterface {
    */
   virtual void setAngle(const double& angle) = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNBUSBARSECTIONINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNBusInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNBusInterface.h
@@ -26,6 +26,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Bus interface
  */
@@ -124,6 +129,11 @@ class BusInterface : public ComponentInterface {
    */
   virtual bool isFictitious() const = 0;
 };  ///< Interface class for Bus model
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNBUSINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNConverterInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNConverterInterface.h
@@ -20,6 +20,11 @@ namespace DYN {
 class BusInterface;
 class VoltageLevelInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Converter interface
  */
@@ -139,7 +144,11 @@ class ConverterInterface : public ComponentInterface {
     }
   }
 };  ///< common interface class for converters
-}  // namespace DYN
 
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
+}  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNCONVERTERINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNCurrentLimitInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNCurrentLimitInterface.h
@@ -22,6 +22,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Current limit interface
  */
@@ -44,6 +49,11 @@ class CurrentLimitInterface {
    */
   virtual int getAcceptableDuration() const = 0;
 };  ///< class for current limit interface
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNCURRENTLIMITINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNDanglingLineInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNDanglingLineInterface.h
@@ -27,6 +27,11 @@ class BusInterface;
 class VoltageLevelInterface;
 class CurrentLimitInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Dangling line interface
  */
@@ -138,6 +143,11 @@ class DanglingLineInterface : public ComponentInterface {
    */
   virtual void exportStateVariablesUnitComponent() = 0;
 };  ///< class for dangling line model interface
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNDANGLINGLINEINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterface.h
@@ -32,6 +32,11 @@ namespace DYN {
 class NetworkInterface;
 class SubModel;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Data interface
  */
@@ -201,6 +206,11 @@ class DataInterface {
    */
   virtual boost::shared_ptr<DataInterface> clone() const = 0;
 };  ///< Class for data interface
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNDATAINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNGeneratorInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNGeneratorInterface.h
@@ -30,16 +30,16 @@ namespace DYN {
 class BusInterface;
 class VoltageLevelInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Generator component
  */
 class GeneratorInterface : public ComponentInterface, public ReactiveCurvePointsInterface {
  public:
-  /**
-   * @brief Destructor
-   */
-  virtual ~GeneratorInterface() { }
-
   /**
    * @brief Setter for the generator's bus interface
    * @param busInterface of the bus where the generator is connected
@@ -182,6 +182,11 @@ class GeneratorInterface : public ComponentInterface, public ReactiveCurvePoints
    */
   virtual boost::optional<bool> isParticipate() const = 0;
 };  ///< Class for Generator data interface
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNGENERATORINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNHvdcLineInterface.h
@@ -31,6 +31,11 @@ class CurrentLimitInterface;
 class VoltageLevelInterface;
 class ConverterInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class HvdcLineInterface
  */
@@ -149,6 +154,11 @@ class HvdcLineInterface : public ComponentInterface {
    */
   virtual boost::optional<double> getOprFromCS2toCS1() const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNHVDCLINEINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNLccConverterInterface.h
@@ -26,7 +26,12 @@
 
 namespace DYN {
 
-/**
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
+  /**
  * @brief LCC converter interface
  */
 class LccConverterInterface : public ConverterInterface {
@@ -42,6 +47,10 @@ class LccConverterInterface : public ConverterInterface {
    */
   virtual double getPowerFactor() const = 0;
 };  ///< Interface class for Lcc Converter
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNLineInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNLineInterface.h
@@ -30,6 +30,11 @@ class BusInterface;
 class CurrentLimitInterface;
 class VoltageLevelInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class LineInterface
  */
@@ -249,6 +254,11 @@ class LineInterface : public ComponentInterface {
    */
   virtual boost::optional<bool> getCurrentLimitTemporaryFictitious(const std::string& season, CurrentLimitSide side, unsigned int indexTemporary) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNLINEINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNLoadInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNLoadInterface.h
@@ -27,6 +27,11 @@ class BusInterface;
 class VoltageLevelInterface;
 class ModelLoad;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class LoadInterface
  */
@@ -102,6 +107,11 @@ class LoadInterface : public ComponentInterface {
    */
   virtual double getPUnderVoltage() = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNLOADINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNNetworkInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNNetworkInterface.h
@@ -31,6 +31,11 @@ class ThreeWTransformerInterface;
 class VoltageLevelInterface;
 class HvdcLineInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Network interface
  */
@@ -108,6 +113,10 @@ class NetworkInterface {
    */
   virtual boost::optional<std::string> getSlackNodeBusId() const = 0;
 };  ///< class for network data interface
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNPhaseTapChangerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNPhaseTapChangerInterface.h
@@ -26,6 +26,11 @@
 namespace DYN {
 class StepInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Phase tap changer interface
  */
@@ -133,6 +138,11 @@ class PhaseTapChangerInterface {
    */
   virtual double getTargetDeadBand() const = 0;
 };  ///< class for phase tap chagner interface
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNPHASETAPCHANGERINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNRatioTapChangerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNRatioTapChangerInterface.h
@@ -26,6 +26,11 @@
 namespace DYN {
 class StepInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class RatioTapChangerInterface
  */
@@ -138,6 +143,11 @@ class RatioTapChangerInterface {
    */
   virtual double getTargetDeadBand() const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNRATIOTAPCHANGERINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNReactiveCurvePointsInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNReactiveCurvePointsInterface.h
@@ -22,6 +22,12 @@
 #include <vector>
 
 namespace DYN {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /// @brief Curve points data interface
 class ReactiveCurvePointsInterface {
  public:
@@ -55,6 +61,11 @@ class ReactiveCurvePointsInterface {
    */
   virtual std::vector<ReactiveCurvePoint> getReactiveCurvesPoints() const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNREACTIVECURVEPOINTSINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNServiceManagerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNServiceManagerInterface.h
@@ -25,6 +25,12 @@
 #include "DYNBusInterface.h"
 
 namespace DYN {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Interface for dynawo service interface
  */
@@ -62,6 +68,11 @@ struct ServiceManagerInterface {
    */
   virtual boost::shared_ptr<BusInterface> getRegulatedBus(const std::string& regulatingComponent) const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNSERVICEMANAGERINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNShuntCompensatorInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNShuntCompensatorInterface.h
@@ -26,6 +26,11 @@ namespace DYN {
 class BusInterface;
 class VoltageLevelInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Shunt compensator interface
  */
@@ -114,6 +119,10 @@ class ShuntCompensatorInterface : public ComponentInterface {
    */
   virtual bool isLinear() const = 0;
 };  ///< Interface class for Shunt Compensator
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNStaticVarCompensatorInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNStaticVarCompensatorInterface.h
@@ -28,6 +28,11 @@ namespace DYN {
 class BusInterface;
 class VoltageLevelInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief Static var compensator interface
  */
@@ -188,6 +193,10 @@ class StaticVarCompensatorInterface : public ComponentInterface {
    */
   virtual double getSlope() const = 0;
 };  ///< Interface class for Static Var Compensator
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNStepInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNStepInterface.h
@@ -24,6 +24,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class StepInterface
  */
@@ -70,6 +75,11 @@ class StepInterface {
    */
   virtual double getAlpha() const = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNSTEPINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNSwitchInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNSwitchInterface.h
@@ -26,6 +26,11 @@
 namespace DYN {
 class BusInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class SwitchInterface
  */
@@ -87,6 +92,11 @@ class SwitchInterface : public ComponentInterface {
    */
   virtual void exportStateVariablesUnitComponent() = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNSWITCHINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNThreeWTransformerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNThreeWTransformerInterface.h
@@ -27,6 +27,11 @@ class BusInterface;
 class VoltageLevelInterface;
 class CurrentLimitInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief 3W transformator interface
  */
@@ -36,7 +41,6 @@ class ThreeWTransformerInterface : public ComponentInterface {
    * @brief Destructor
    */
   virtual ~ThreeWTransformerInterface() { }
-
 
   /**
    * @brief Add a curent limit interface for side 1
@@ -157,6 +161,11 @@ class ThreeWTransformerInterface : public ComponentInterface {
    */
   virtual void exportStateVariablesUnitComponent() = 0;
 };  ///< Three windings transformer data interface class
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNTHREEWTRANSFORMERINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNTwoWTransformerInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNTwoWTransformerInterface.h
@@ -29,6 +29,11 @@ class RatioTapChangerInterface;
 class CurrentLimitInterface;
 class VoltageLevelInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class TwoWTransformerInterface
  */
@@ -217,6 +222,11 @@ class TwoWTransformerInterface : public ComponentInterface {
    */
   virtual void exportStateVariablesUnitComponent() = 0;
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_DATAINTERFACE_DYNTWOWTRANSFORMERINTERFACE_H_

--- a/dynawo/sources/Modeler/DataInterface/DYNVoltageLevelInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNVoltageLevelInterface.h
@@ -35,6 +35,11 @@ class VscConverterInterface;
 class LccConverterInterface;
 class DanglingLineInterface;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class VoltageLevelInterface
  * @brief VoltageLevelInterface class
@@ -216,6 +221,10 @@ class VoltageLevelInterface {
    */
   virtual bool isNodeBreakerTopology() const = 0;
 };  /// end of class declaration
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNVscConverterInterface.h
@@ -27,7 +27,12 @@
 
 namespace DYN {
 
-/**
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
+  /**
  * @brief VSC converter interface
  */
 class VscConverterInterface : public ConverterInterface, public ReactiveCurvePointsInterface {
@@ -72,6 +77,10 @@ class VscConverterInterface : public ConverterInterface, public ReactiveCurvePoi
    */
   virtual std::vector<ReactiveCurvePoint> getReactiveCurvesPoints() const = 0;
 };  ///< Interface class for Vsc Converter
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
 
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNBusBarSectionInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNBusBarSectionInterfaceIIDM.h
@@ -32,6 +32,11 @@ class BusBarSection;
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @class BusBarSectionInterfaceIIDM
  * @brief Specialisation of BusBarSectionInterface class for IIDM
@@ -73,5 +78,10 @@ class BusBarSectionInterfaceIIDM : public BusBarSectionInterface {
  private:
   IIDM::BusBarSection& bbs_;  ///< instance of IIDM bus bar section
 };  ///< Interface class for BusBarSection
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  ///< namespace DYN
 #endif  // MODELER_DATAINTERFACE_IIDM_DYNBUSBARSECTIONINTERFACEIIDM_H_

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNActiveSeasonIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNActiveSeasonIIDMExtension.h
@@ -28,7 +28,7 @@ namespace DYN {
 class ActiveSeasonIIDMExtension {
  public:
   /// @brief Destructor
-  virtual ~ActiveSeasonIIDMExtension() {}
+  virtual ~ActiveSeasonIIDMExtension() = default;
 
   /**
    * @brief Retrieve the active season value

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNCurrentLimitsPerSeasonIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNCurrentLimitsPerSeasonIIDMExtension.h
@@ -39,7 +39,7 @@ class CurrentLimitsPerSeasonIIDMExtension {
 
  public:
   /// @brief Destructor
-  virtual ~CurrentLimitsPerSeasonIIDMExtension() {}
+  virtual ~CurrentLimitsPerSeasonIIDMExtension() = default;
 
   /**
    * @brief Retrieve current limits

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorActivePowerControlIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorActivePowerControlIIDMExtension.h
@@ -28,7 +28,7 @@ namespace DYN {
 class GeneratorActivePowerControlIIDMExtension {
  public:
   /// @brief Destructor
-  virtual ~GeneratorActivePowerControlIIDMExtension() {}
+  virtual ~GeneratorActivePowerControlIIDMExtension() = default;
 
   /**
    * @brief Get the droop parameter

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNHvdcAngleDroopActivePowerControlIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNHvdcAngleDroopActivePowerControlIIDMExtension.h
@@ -28,7 +28,7 @@ namespace DYN {
 class HvdcAngleDroopActivePowerControlIIDMExtension {
  public:
   /// @brief Destructor
-  virtual ~HvdcAngleDroopActivePowerControlIIDMExtension() {}
+  virtual ~HvdcAngleDroopActivePowerControlIIDMExtension() = default;
 
   /**
    * @brief Get droop

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNHvdcOperatorActivePowerRangeIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNHvdcOperatorActivePowerRangeIIDMExtension.h
@@ -27,7 +27,7 @@ namespace DYN {
 class HvdcOperatorActivePowerRangeIIDMExtension {
  public:
   /// @brief Destructor
-  virtual ~HvdcOperatorActivePowerRangeIIDMExtension() {}
+  virtual ~HvdcOperatorActivePowerRangeIIDMExtension() = default;
 
   /**
    * @brief Retrieve OPR from CS1 to CS2

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNInjectorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNInjectorInterfaceIIDM.h
@@ -37,6 +37,11 @@
 
 namespace DYN {
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * class InjectorInterfaceIIDM
  */
@@ -193,5 +198,10 @@ class InjectorInterfaceIIDM {
   std::string injectorId_;                                        ///< injector's id
   boost::optional<bool> initialConnected_;                        ///< whether the injector is initially connected or not
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 #endif  // MODELER_DATAINTERFACE_POWSYBLIIDM_DYNINJECTORINTERFACEIIDM_H_

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNStaticVarCompensatorInterfaceIIDMExtension.h
@@ -34,7 +34,7 @@ class StaticVarCompensatorInterfaceIIDMExtension {
   /**
    * @brief Destructor
    */
-  virtual ~StaticVarCompensatorInterfaceIIDMExtension() { }
+  virtual ~StaticVarCompensatorInterfaceIIDMExtension() = default;
 
   /**
    * @brief Interface to export the stand by mode of the svc

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManager.cpp
@@ -820,13 +820,13 @@ ModelManager::loadParameters(const string& parameters) {
   // copy of loaded parameters in the map
   const boost::unordered_map<string, ParameterModeler>& parametersMap = (this)->getParametersDynamic();
   // We need ordered parameters as Modelica structures are ordered in a certain way and we want to stick to this order to recover the param
-  vector<ParameterModeler> parametersList(parametersMap.size(), ParameterModeler("TMP", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
+  vector<string> parametersList(parametersMap.size(), "TMP");
   for (ParamIterator it = parametersMap.begin(), itEnd = parametersMap.end(); it != itEnd; ++it) {
     const ParameterModeler& currentParameter = it->second;
-    parametersList[currentParameter.getIndex()] = currentParameter;
+    parametersList[currentParameter.getIndex()] = it->first;
   }
   for (unsigned int i = 0; i < modelData()->nParametersReal; ++i) {
-    const ParameterModeler& currentParameter = parametersList[i];
+    const ParameterModeler& currentParameter = parametersMap.at(parametersList[i]);
     switch (currentParameter.getValueType()) {
       case VAR_TYPE_DOUBLE:
       {
@@ -851,15 +851,15 @@ ModelManager::loadParameters(const string& parameters) {
   }
   unsigned int offset = static_cast<unsigned int>(modelData()->nParametersReal);
   for (unsigned int i = 0; i < modelData()->nParametersBoolean; ++i) {
-    setLoadedParameter(parametersList[i + offset].getName(), parameterBoolValues[i]);
+    setLoadedParameter(parametersList[i + offset], parameterBoolValues[i]);
   }
   offset += modelData()->nParametersBoolean;
   for (unsigned int i = 0; i < modelData()->nParametersInteger; ++i) {
-    setLoadedParameter(parametersList[i + offset].getName(), parameterIntValues[i]);
+    setLoadedParameter(parametersList[i + offset], parameterIntValues[i]);
   }
   offset += modelData()->nParametersInteger;
   for (unsigned int i = 0; i < modelData()->nParametersString; ++i) {
-    setLoadedParameter(parametersList[i + offset].getName(), parameterStringValues[i]);
+    setLoadedParameter(parametersList[i + offset], parameterStringValues[i]);
   }
 }
 
@@ -1137,16 +1137,16 @@ void
 ModelManager::setInitialCalculatedParameters() {
   const boost::unordered_map<string, ParameterModeler>& parametersMap = getParametersInit();
   // We need ordered parameters as Modelica structures are ordered in a certain way and we want to stick to this order to recover the param
-  vector<ParameterModeler> parametersInitial(parametersMap.size(), ParameterModeler("TMP", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
+  vector<string> parametersInitial(parametersMap.size(), "TMP");
   for (ParamIterator it = parametersMap.begin(), itEnd = parametersMap.end(); it != itEnd; ++it) {
     const ParameterModeler& currentParameter = it->second;
-    parametersInitial[currentParameter.getIndex()] = currentParameter;
+    parametersInitial[currentParameter.getIndex()] = it->first;
   }
   // Copy init parameters
   assert(parametersInitial.size() == static_cast<size_t>(modelData()->nParametersReal + modelData()->nParametersBoolean
                                                        + modelData()->nParametersInteger + modelData()->nParametersString));
   for (unsigned int i = 0; i < modelData()->nParametersReal; ++i) {
-    const string& parName = parametersInitial[i].getName();
+    const string& parName = parametersInitial[i];
 
     if (hasParameterDynamic(parName)) {
       const ParameterModeler& parameter = findParameterDynamic(parName);
@@ -1178,7 +1178,7 @@ ModelManager::setInitialCalculatedParameters() {
   }
   int offset = static_cast<int>(modelData()->nParametersReal);
   for (unsigned int i = 0; i < modelData()->nParametersBoolean; ++i) {
-    const string& parName = parametersInitial[i + offset].getName();
+    const string& parName = parametersInitial[i + offset];
     if (hasParameterDynamic(parName)) {
       const ParameterModeler& parameter = findParameterDynamic(parName);
       if (!parameter.isFullyInternal()) {
@@ -1189,7 +1189,7 @@ ModelManager::setInitialCalculatedParameters() {
 
   offset += modelData()->nParametersBoolean;
   for (unsigned int i = 0; i < modelData()->nParametersInteger; ++i) {
-    const string& parName = parametersInitial[i + offset].getName();
+    const string& parName = parametersInitial[i + offset];
     if (hasParameterDynamic(parName)) {
       const ParameterModeler& parameter = findParameterDynamic(parName);
       if (!parameter.isFullyInternal()) {
@@ -1200,7 +1200,7 @@ ModelManager::setInitialCalculatedParameters() {
 
   offset += modelData()->nParametersInteger;
   for (unsigned int i = 0; i < modelData()->nParametersString; ++i) {
-    const string& parName = parametersInitial[i + offset].getName();
+    const string& parName = parametersInitial[i + offset];
     if (hasParameterDynamic(parName)) {
       const ParameterModeler& parameter = findParameterDynamic(parName);
       if (!parameter.isFullyInternal()) {
@@ -1239,31 +1239,31 @@ ModelManager::printInitValuesParameters(std::ofstream& fstream) {
   fstream << " ====== PARAMETERS VALUES ======\n";
   const boost::unordered_map<string, ParameterModeler>& parametersMap = (*this).getParametersDynamic();
   // We need ordered parameters as Modelica structures are ordered in a certain way and we want to stick to this order to recover the param
-  vector<ParameterModeler> parameters(parametersMap.size(), ParameterModeler("TMP", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER));
+  vector<string> parameters(parametersMap.size(), "TMP");
   for (ParamIterator it = parametersMap.begin(), itEnd = parametersMap.end(); it != itEnd; ++it) {
     const ParameterModeler& currentParameter = it->second;
-    parameters[currentParameter.getIndex()] = currentParameter;
+    parameters[currentParameter.getIndex()] = it->first;
   }
 
   // In Modelica models, parameters are ordered as follows : real, then boolean, integer and string
   for (unsigned int i = 0; i < modelData()->nParametersReal; ++i)
-    fstream << std::setw(50) << std::left << parameters[i].getName() << std::right << " =" << std::setw(15)
+    fstream << std::setw(50) << std::left << parameters[i] << std::right << " =" << std::setw(15)
       << DYN::double2String(simulationInfo()->realParameter[i]) << "\n";
 
   int offset = static_cast<int>(modelData()->nParametersReal);
 
   for (unsigned int i = 0; i < modelData()->nParametersBoolean; ++i)
-    fstream << std::setw(50) << std::left << parameters[i + offset].getName() << std::right << " =" << std::setw(15)
+    fstream << std::setw(50) << std::left << parameters[i + offset] << std::right << " =" << std::setw(15)
     << std::boolalpha << static_cast<bool> (simulationInfo()->booleanParameter[i]) << "\n";
 
   offset += modelData()->nParametersBoolean;
   for (unsigned int i = 0; i < modelData()->nParametersInteger; ++i)
-    fstream << std::setw(50) << std::left << parameters[i + offset].getName() << std::right << " =" << std::setw(15)
+    fstream << std::setw(50) << std::left << parameters[i + offset] << std::right << " =" << std::setw(15)
     << (simulationInfo()->integerParameter[i]) << "\n";
 
   offset += modelData()->nParametersInteger;
   for (unsigned int i = 0; i < modelData()->nParametersString; ++i)
-    fstream << std::setw(50) << std::left << parameters[i + offset].getName() << std::right << " =" << std::setw(15)
+    fstream << std::setw(50) << std::left << parameters[i + offset] << std::right << " =" << std::setw(15)
     << (simulationInfo()->stringParameter[i]) << "\n";
 }
 

--- a/dynawo/sources/Modeler/ModelManager/DYNModelModelica.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelModelica.h
@@ -42,6 +42,11 @@ class Element;
 class ModelManager;
 class Variable;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif  // __clang__
+
 /**
  * @brief ModelModelica
  *
@@ -288,6 +293,11 @@ class ModelModelica {
  protected:
   bool hasCheckDataCoherence_;  ///< Determines if the modelica model has a data check coherence operation
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif  // __clang__
+
 }  // namespace DYN
 
 #endif  // MODELER_MODELMANAGER_DYNMODELMODELICA_H_

--- a/dynawo/sources/Modeler/ModelManager/test/Test.cpp
+++ b/dynawo/sources/Modeler/ModelManager/test/Test.cpp
@@ -42,11 +42,6 @@ class MyModelica: public ModelModelica {
     nbCallDynamicYType_(0),
     nbCallCheckDataCoherence_(0)  { }
 
-  /**
-   * @brief default destructor
-   */
-  virtual ~MyModelica() { }
-
  public:
   /**
    * @brief initialise the dyn data structure
@@ -176,13 +171,7 @@ class MyModelica: public ModelModelica {
    *
    * @param variables vector to fill
    */
-  virtual void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
-    variables.push_back(DYN::VariableNativeFactory::createState("MyVariable", DISCRETE, false));
-    variables.push_back(DYN::VariableNativeFactory::createState("MyVariable2", CONTINUOUS, false));
-    variables.push_back(DYN::VariableNativeFactory::createState("MyVariable3", CONTINUOUS, false));
-    variables.push_back(DYN::VariableNativeFactory::createCalculated("MyVariable4", CONTINUOUS, false));
-    variables.push_back(DYN::VariableAliasFactory::create("MyAliasVariable", "MyVariable2", FLOW, false));
-  }
+  virtual void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   /**
    * @brief defines the parameters of the model
@@ -344,7 +333,13 @@ class MyModelica: public ModelModelica {
   unsigned nbCallCheckDataCoherence_;
 };
 
-
+void MyModelica::defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
+  variables.push_back(DYN::VariableNativeFactory::createState("MyVariable", DISCRETE, false));
+  variables.push_back(DYN::VariableNativeFactory::createState("MyVariable2", CONTINUOUS, false));
+  variables.push_back(DYN::VariableNativeFactory::createState("MyVariable3", CONTINUOUS, false));
+  variables.push_back(DYN::VariableNativeFactory::createCalculated("MyVariable4", CONTINUOUS, false));
+  variables.push_back(DYN::VariableAliasFactory::create("MyAliasVariable", "MyVariable2", FLOW, false));
+}
 
 class MyModelicaInit: public MyModelica {
  public:
@@ -352,15 +347,7 @@ class MyModelicaInit: public MyModelica {
     MyModelica(parent),
     data_(NULL) { }
 
-  /**
-   * @brief default destructor
-   */
-  virtual ~MyModelicaInit() { }
-
-  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
-    variables.push_back(DYN::VariableNativeFactory::createState("MyParam2", CONTINUOUS, false));
-    variables.push_back(DYN::VariableNativeFactory::createState("MyParam", INTEGER, false));
-  }
+  void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables);
 
   void defineParameters(std::vector<ParameterModeler>& /*parameters*/) {
   }
@@ -421,6 +408,12 @@ class MyModelicaInit: public MyModelica {
   DYNDATA* data_;
 };
 
+void MyModelicaInit::defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) {
+  variables.push_back(DYN::VariableNativeFactory::createState("MyParam2", CONTINUOUS, false));
+  variables.push_back(DYN::VariableNativeFactory::createState("MyParam", INTEGER, false));
+}
+
+
 class MyModelManager : public ModelManager {
  public:
   MyModelManager() :
@@ -431,7 +424,7 @@ class MyModelManager : public ModelManager {
     name("MyModelManager");
   }
 
-  virtual ~MyModelManager() {}
+  virtual ~MyModelManager();
 
   void testSize() {
     ASSERT_EQ(dataInit_->nbF, 1);
@@ -492,6 +485,9 @@ class MyModelManager : public ModelManager {
     return true;
   }
 };
+
+MyModelManager::~MyModelManager() {}
+
 
 TEST(TestModelManager, TestModelManagerBasics) {
   boost::shared_ptr<MyModelManager> mm = boost::shared_ptr<MyModelManager>(new MyModelManager());

--- a/dynawo/sources/Modeler/ModelManager/test/TestCommon.cpp
+++ b/dynawo/sources/Modeler/ModelManager/test/TestCommon.cpp
@@ -31,13 +31,15 @@ class MyEmptyModelManager : public ModelManager {
     ModelManager() {
   }
 
-  virtual ~MyEmptyModelManager() {
-  }
+  virtual ~MyEmptyModelManager();
+
  protected:
   bool hasInit() const {
     return false;
   }
 };
+
+MyEmptyModelManager::~MyEmptyModelManager() {}
 
 TEST(TestModelManager, TestModelManagerCommonLogs) {
   MyEmptyModelManager mm;

--- a/dynawo/sources/Modeler/util/DYNDumpModel.cpp
+++ b/dynawo/sources/Modeler/util/DYNDumpModel.cpp
@@ -174,7 +174,7 @@ int main(int argc, char ** argv) {
   boost::unordered_map<std::string, DYN::ParameterModeler>::const_iterator parameterIterator;
   for (parameterIterator = parametersInit.begin(); parameterIterator != parametersInit.end(); ++parameterIterator) {
     const DYN::ParameterModeler& parameterInit = parameterIterator->second;
-    // only keep parameters which
+    // only keep parameters
     // which can either be displayed or set
     if ((model->hasParameterDynamic(parameterInit.getName()) || !parameterInit.isFullyInternal()) &&
         fillParameterDescription(parameterInit, model->modelType(), parametersAttributes) != 0) {
@@ -184,19 +184,22 @@ int main(int argc, char ** argv) {
 
   // add dynamic parameters
   for (parameterIterator = parametersDynamic.begin(); parameterIterator != parametersDynamic.end(); ++parameterIterator) {
-    DYN::ParameterModeler itParameter = parameterIterator->second;
-    const string itParameterName = itParameter.getName();
+    const DYN::ParameterModeler* parameterDynamic = &(parameterIterator->second);
+    const string parameterName = parameterDynamic->getName();
 
     // initial parameters have already been described => nothing to do
-    if (model->hasParameterInit(itParameterName))
+    if (model->hasParameterInit(parameterName))
       continue;
 
     // when the dynamic parameter is set through the init process, it should be considered as internal for the description file
-    if ((!itParameter.isFullyInternal()) && (model->hasVariableInit(itParameterName))) {
-      itParameter = DYN::ParameterModeler(itParameter.getName(), itParameter.getValueType(), DYN::INTERNAL_PARAMETER, itParameter.getCardinality());
+    const DYN::ParameterModeler parameterInternal(parameterName, parameterDynamic->getValueType(),
+                                                  DYN::INTERNAL_PARAMETER,
+                                                  parameterDynamic->getCardinality());
+    if ((!parameterDynamic->isFullyInternal()) && (model->hasVariableInit(parameterName))) {
+      parameterDynamic = &parameterInternal;
     }
 
-    if (fillParameterDescription(itParameter, model->modelType(), parametersAttributes) != 0) {
+    if (fillParameterDescription(*parameterDynamic, model->modelType(), parametersAttributes) != 0) {
       return 1;
     }
   }

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponent.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponent.h
@@ -61,7 +61,7 @@ class NetworkComponent {  ///< Base class for network component models
   /**
    * @brief destructor
    */
-  virtual ~NetworkComponent() { }
+  virtual ~NetworkComponent();
 
   /**
    * @brief add bus neighbors

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponentImpl.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponentImpl.cpp
@@ -35,6 +35,8 @@ using parameters::ParametersSet;
 
 namespace DYN {
 
+NetworkComponent::~NetworkComponent() {}
+
 NetworkComponent::Impl::Impl() :
 y_(NULL),
 yp_(NULL),

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestLoad.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestLoad.cpp
@@ -150,55 +150,57 @@ createModelLoad(bool open, bool initModel) {
 static void
 fillParameters(shared_ptr<ModelLoad> load) {
   boost::unordered_map<std::string, ParameterModeler> parametersModels;
-  std::string paramName = "load_alpha";
-  ParameterModeler param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(1., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
 
-  paramName = "load_beta";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(0.5, PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_isRestorative";
-  param = ParameterModeler(paramName, VAR_TYPE_BOOL, EXTERNAL_PARAMETER);
-  param.setValue<bool>(true, PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_isControllable";
-  param = ParameterModeler(paramName, VAR_TYPE_BOOL, EXTERNAL_PARAMETER);
-  param.setValue<bool>(true, PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_Tp";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(2., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_Tq";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(4., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_zPMax";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(6., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_zQMax";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(8., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_alphaLong";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(2., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-
-  paramName = "load_betaLong";
-  param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(0.2, PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
+  {
+    ParameterModeler param = ParameterModeler("load_alpha", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(1., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_beta", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(0.5, PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_isRestorative", VAR_TYPE_BOOL, EXTERNAL_PARAMETER);
+    param.setValue<bool>(true, PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_isControllable", VAR_TYPE_BOOL, EXTERNAL_PARAMETER);
+    param.setValue<bool>(true, PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_Tp", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(2., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_Tq", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(4., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_zPMax", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(6., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_zQMax", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(8., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_alphaLong", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(2., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
+  {
+    ParameterModeler param = ParameterModeler("load_betaLong", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(0.2, PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+  }
 
   load->setSubModelParameters(parametersModels);
 }

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestTwoWindingsTransformer.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestTwoWindingsTransformer.cpp
@@ -1096,41 +1096,47 @@ TEST(ModelsModelNetwork, ModelNetworkTwoWindingsTransformerDefineInstantiate) {
     ASSERT_EQ(definedVariables[i]->getType(), instantiatedVariables[i]->getType());
   }
 
-
   std::vector<ParameterModeler> parameters;
   t2w->defineNonGenericParameters(parameters);
   ASSERT_EQ(parameters.size(), 0);
   boost::unordered_map<std::string, ParameterModeler> parametersModels;
-  const std::string paramName = "transformer_currentLimit_maxTimeOperation";
-  ParameterModeler param = ParameterModeler(paramName, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param.setValue<double>(10., PAR);
-  parametersModels.insert(std::make_pair(paramName, param));
-  ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
-  std::string param2Name = "transformer_t1st_THT";
-  ParameterModeler param2 = ParameterModeler(param2Name, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param2.setValue<double>(1., PAR);
-  parametersModels.insert(std::make_pair(param2Name, param2));
-  ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
-  param2Name = "transformer_tNext_THT";
-  param2 = ParameterModeler(param2Name, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param2.setValue<double>(1., PAR);
-  parametersModels.insert(std::make_pair(param2Name, param2));
-  ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
-  param2Name = "transformer_t1st_HT";
-  param2 = ParameterModeler(param2Name, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param2.setValue<double>(1., PAR);
-  parametersModels.insert(std::make_pair(param2Name, param2));
-  ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
-  param2Name = "transformer_tNext_HT";
-  param2 = ParameterModeler(param2Name, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param2.setValue<double>(1., PAR);
-  parametersModels.insert(std::make_pair(param2Name, param2));
-  ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
-  param2Name = "transformer_tolV";
-  param2 = ParameterModeler(param2Name, VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
-  param2.setValue<double>(1., PAR);
-  parametersModels.insert(std::make_pair(param2Name, param2));
-  ASSERT_NO_THROW(t2w->setSubModelParameters(parametersModels));
+
+  {
+    ParameterModeler param = ParameterModeler("transformer_currentLimit_maxTimeOperation", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(10., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+    ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
+  }
+  {
+    ParameterModeler param = ParameterModeler("transformer_t1st_THT", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(1., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+    ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
+  }
+  {
+    ParameterModeler param = ParameterModeler("transformer_tNext_THT", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(1., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+    ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
+  }
+  {
+    ParameterModeler param = ParameterModeler("transformer_t1st_HT", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(1., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+    ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
+  }
+  {
+    ParameterModeler param = ParameterModeler("transformer_tNext_HT", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(1., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+    ASSERT_THROW_DYNAWO(t2w->setSubModelParameters(parametersModels), Error::MODELER, KeyError_t::NetworkParameterNotFoundFor);
+  }
+  {
+    ParameterModeler param = ParameterModeler("transformer_tolV", VAR_TYPE_DOUBLE, EXTERNAL_PARAMETER);
+    param.setValue<double>(1., PAR);
+    parametersModels.insert(std::make_pair(param.getName(), param));
+    ASSERT_NO_THROW(t2w->setSubModelParameters(parametersModels));
+  }
 }
 
 TEST(ModelsModelNetwork, ModelNetworkTwoWindingsTransformerJt) {

--- a/dynawo/sources/Solvers/AlgebraicSolvers/test/TestBasics.cpp
+++ b/dynawo/sources/Solvers/AlgebraicSolvers/test/TestBasics.cpp
@@ -111,7 +111,7 @@ class SolverMock : public Solver::Impl {
  public:
   SolverMock() : Solver::Impl::Impl() {}
 
-  ~SolverMock() {}
+  ~SolverMock();
 
   void defineSpecificParameters() {}
 
@@ -137,6 +137,8 @@ class SolverMock : public Solver::Impl {
 
   void solveStep(double /*tAim*/, double& /*tNxt*/) {}
 };
+
+SolverMock::~SolverMock() {}
 
 TEST(AlgebraicSolvers, testInit) {
   boost::shared_ptr<SolverKINCommon> solver(new SolverKINCommon());

--- a/dynawo/sources/Solvers/Common/DYNParameterSolver.h
+++ b/dynawo/sources/Solvers/Common/DYNParameterSolver.h
@@ -57,11 +57,6 @@ class ParameterSolver : public ParameterCommon {
 #endif
 
   /**
-   * @brief Destructor
-   */
-  ~ParameterSolver() { }
-
-  /**
     * @brief check whether the parameter's value is set
     * @return whether the parameter's value is set
     */

--- a/dynawo/sources/Solvers/Common/DYNSolver.h
+++ b/dynawo/sources/Solvers/Common/DYNSolver.h
@@ -74,7 +74,7 @@ class Solver {
    * @brief destructor
    *
    */
-  virtual ~Solver() { }
+  virtual ~Solver();
 
   /**
    * @brief get the current solver's state

--- a/dynawo/sources/Solvers/Common/DYNSolverFactory.cpp
+++ b/dynawo/sources/Solvers/Common/DYNSolverFactory.cpp
@@ -67,6 +67,8 @@ void SolverFactories::add(const std::string& lib, const boost::function<deleteSo
   factoryMapDelete_.insert(std::make_pair(lib, deleteFactory));
 }
 
+SolverFactory::~SolverFactory() {}
+
 boost::shared_ptr<Solver> SolverFactory::createSolverFromLib(const std::string& lib) {
   SolverFactories::SolverFactoryIterator iter = SolverFactories::getInstance().find(lib);
   Solver* solver;

--- a/dynawo/sources/Solvers/Common/DYNSolverFactory.h
+++ b/dynawo/sources/Solvers/Common/DYNSolverFactory.h
@@ -45,7 +45,7 @@ class SolverFactory {
   /**
    * @brief Destructor
    */
-  virtual ~SolverFactory() { }
+  virtual ~SolverFactory();
 
   /**
    * @brief create a new instance of a solver

--- a/dynawo/sources/Solvers/Common/DYNSolverImpl.cpp
+++ b/dynawo/sources/Solvers/Common/DYNSolverImpl.cpp
@@ -63,6 +63,8 @@ BOOST_STATIC_ASSERT_MSG(sizeof (double) == sizeof (realtype), "wrong size of sun
 #endif
 }  // namespace conditions
 
+Solver::~Solver() {}
+
 Solver::Impl::Impl() :
 sundialsVectorY_(NULL),
 sundialsVectorYp_(NULL),

--- a/dynawo/sources/Test/initXml.cpp
+++ b/dynawo/sources/Test/initXml.cpp
@@ -16,7 +16,7 @@
 
 class XmlEnvironment : public testing::Environment {
  public:
-  ~XmlEnvironment() {}
+  ~XmlEnvironment();
 
   // Override this to define how to set up the environment.
   void SetUp() {
@@ -34,6 +34,8 @@ class XmlEnvironment : public testing::Environment {
 #endif
   }
 };
+
+XmlEnvironment::~XmlEnvironment() {}
 
 testing::Environment* initXmlEnvironment();
 


### PR DESCRIPTION
Removing -Wno-weak-vtables causes errors !

`error: 'XXX' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]`

See #125 
