### PR TITLE
#125 fix clang compilation: remove useless flags, keep needed

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -111,25 +111,32 @@ if('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'GNU')
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror -fdiagnostics-show-option -Wno-unused-local-typedefs")
   # -Wswitch-enum : Warn whenever a switch statement has an index of enumerated type and lacks a case for one or more of the named codes of that enumeration
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wswitch-enum -Wunused")
-elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang' OR '${CMAKE_CXX_COMPILER_ID}')
+elseif('${CMAKE_CXX_COMPILER_ID}' STREQUAL 'Clang')
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Weverything")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-conditional-uninitialized")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-covered-switch-default")
-  # error: unknown command tag name (@copydoc @n) [-Werror,-Wdocumentation-unknown-command]
+  # error: unknown command tag name [-Werror,-Wdocumentation-unknown-command]
+  # => used command tag names (@copydoc and @n) are legal !
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-documentation-unknown-command")
+  # error: declaration requires an exit-time destructor [-Werror,-Wexit-time-destructors]
+  # => occurs with static objects, including singleton implementations
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-extra-semi")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-mismatched-tags")
+  # error: padding class 'DYN::Message' with 7 bytes to align 'key_' [-Werror,-Wpadded]
+  # error: padding size of 'DYN::ParameterCommon' with 3 bytes to alignment boundary [-Werror,-Wpadded]
+  # => it's better to let compiler generate correct padding
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-padded")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-return-type")
+  # error: implicit conversion changes signedness: 'something signed' to 'something unsigned' [-Werror,-Wsign-conversion]
+  # error: operand of ? changes signedness: 'something unsigned' to 'something signed' [-Werror,-Wsign-conversion]
+  # => occurs many times in particular when a signed value is used as an index which must be an unsigned (size_t) !
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sign-conversion")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-sometimes-uninitialized")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-exception-parameter")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-macros")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-unused-private-field")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-weak-vtables")
+  # error: 'arg2' was marked unused but was used [-Werror,-Wused-but-marked-unused]
+  # => occurs in all API Xml handlers (using boost::phoenix::placeholders)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-used-but-marked-unused")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-overloaded-virtual")
+  # error: zero as null pointer constant [-Werror,-Wzero-as-null-pointer-constant]
+  # => caused by NULL macro use in many places (mandatory with c++98, should be replaced by nullptr with c++11)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wno-zero-as-null-pointer-constant")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror")
   if(CXX11_ENABLED)

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNBatteryInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNBatteryInterfaceIIDM.h
@@ -56,7 +56,7 @@ class BatteryInterfaceIIDM : public GeneratorInterface, public InjectorInterface
 
   /**
    * @brief Constructor
-   * @param battery: battery iidm instance
+   * @param battery battery iidm instance
    */
   explicit BatteryInterfaceIIDM(IIDM::Battery& battery);
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNBatteryInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNBatteryInterfaceIIDM.h
@@ -55,7 +55,7 @@ class BatteryInterfaceIIDM : public GeneratorInterface, public InjectorInterface
 
   /**
    * @brief Constructor
-   * @param battery: battery iidm instance
+   * @param battery battery iidm instance
    */
   explicit BatteryInterfaceIIDM(powsybl::iidm::Battery& battery);
 


### PR DESCRIPTION
Following flags must be kept (comments added in root CMakeLists.txt):
```
-Wno-exit-time-destructors
-Wno-padded
-Wno-sign-conversion
-Wno-used-but-marked-unused
-Wno-zero-as-null-pointer-constant
```

Following flags are useless and could be removed:
```
-Wno-conditional-uninitialized
-Wno-extra-semi
-Wno-mismatched-tags
-Wno-return-type
-Wno-sometimes-uninitialized
-Wno-overloaded-virtual
```

See #125 
