### PR TITLE
#125 fix clang compilation -Wshadow-field-in-constructor

### DIFF
--- a/dynawo/sources/Simulation/DYNSimulation.cpp
+++ b/dynawo/sources/Simulation/DYNSimulation.cpp
@@ -419,12 +419,12 @@ Simulation::configureFinalStateOutputs() {
       // case no timestamp given, meaning final state
       // ---- exportDumpFile ----
       if ((*it)->getExportDumpFile()) {
-        finalState_.dumpFile = createAbsolutePath("outputState.dmp", finalStateDir);
+        finalState_.dumpFile_ = createAbsolutePath("outputState.dmp", finalStateDir);
       }
 
       // --- exportIIDMFile ----
       if ((*it)->getExportIIDMFile()) {
-        finalState_.iidmFile = createAbsolutePath("outputIIDM.xml", finalStateDir);
+        finalState_.iidmFile_ = createAbsolutePath("outputIIDM.xml", finalStateDir);
       }
     } else {
       if (!(*it)->getExportDumpFile() && !(*it)->getExportIIDMFile()) {
@@ -435,12 +435,12 @@ Simulation::configureFinalStateOutputs() {
       if ((*it)->getExportDumpFile()) {
         std::stringstream ss;
         ss << *timestamp << "_outputState.dmp";
-        dumpStateDefinition.dumpFile = createAbsolutePath(ss.str(), finalStateDir);
+        dumpStateDefinition.dumpFile_ = createAbsolutePath(ss.str(), finalStateDir);
       }
       if ((*it)->getExportIIDMFile()) {
         std::stringstream ss;
         ss << *timestamp << "_outputIIDM.xml";
-        dumpStateDefinition.iidmFile = createAbsolutePath(ss.str(), finalStateDir);
+        dumpStateDefinition.iidmFile_ = createAbsolutePath(ss.str(), finalStateDir);
       }
       dumpStateDefinitionsMap.insert(std::make_pair(*timestamp, dumpStateDefinition));
     }
@@ -844,7 +844,7 @@ Simulation::simulate() {
   bool criteriaChecked = true;
   try {
     // update state variable only if the IIDM final state is exported, or criteria is checked, or lost equipments are exported
-    if (data_ && (finalState_.iidmFile || activateCriteria_ || isLostEquipmentsExported())) {
+    if (data_ && (finalState_.iidmFile_ || activateCriteria_ || isLostEquipmentsExported())) {
       data_->getStateVariableReference();   // Each state variable in DataInterface has a mapped reference variable in dynamic model,
                                          // either in a modelica model or in a C++ model.
       // save initial connection state at t0 for each equipment
@@ -911,18 +911,18 @@ Simulation::simulate() {
       while (hasIntermediateStateToDump()) {
         const ExportStateDefinition& dumpDefinition = intermediateStates_.front();
         data_->exportStateVariables();
-        if (dumpDefinition.dumpFile) {
-          dumpState(*dumpDefinition.dumpFile);
+        if (dumpDefinition.dumpFile_) {
+          dumpState(*dumpDefinition.dumpFile_);
         }
-        if (dumpDefinition.iidmFile) {
-          dumpIIDMFile(*dumpDefinition.iidmFile);
+        if (dumpDefinition.iidmFile_) {
+          dumpIIDMFile(*dumpDefinition.iidmFile_);
         }
         intermediateStates_.pop();
       }
     }
 
     // If we haven't evaluated the calculated variables for the last iteration before, we must do it here if it might be used in the post process
-    if (finalState_.iidmFile || exportCurvesMode_ != EXPORT_CURVES_NONE || activateCriteria_)
+    if (finalState_.iidmFile_ || exportCurvesMode_ != EXPORT_CURVES_NONE || activateCriteria_)
       model_->evalCalculatedVariables(tCurrent_, solver_->getCurrentY(), solver_->getCurrentYP(), zCurrent_);
 
     if (SignalHandler::gotExitSignal() && !end()) {
@@ -967,7 +967,7 @@ bool
 Simulation::hasIntermediateStateToDump() const {
   // Intermediate timestamp of the simulation reached
   return !intermediateStates_.empty() &&
-        (doubleEquals(tCurrent_, intermediateStates_.front().timestamp) || tCurrent_ > intermediateStates_.front().timestamp);
+        (doubleEquals(tCurrent_, intermediateStates_.front().timestamp_) || tCurrent_ > intermediateStates_.front().timestamp_);
 }
 
 void
@@ -1114,7 +1114,7 @@ Simulation::terminate() {
     fileConstraints.close();
   }
 
-  if (data_ && (finalState_.iidmFile || isLostEquipmentsExported())) {
+  if (data_ && (finalState_.iidmFile_ || isLostEquipmentsExported())) {
 #if defined(_DEBUG_) || defined(PRINT_TIMERS)
     Timer timer2("DataInterfaceIIDM::exportStateVariables");
 #endif
@@ -1128,10 +1128,10 @@ Simulation::terminate() {
     fileLostEquipments.close();
   }
 
-  if (finalState_.dumpFile)
+  if (finalState_.dumpFile_)
     dumpState();
 
-  if (finalState_.iidmFile)
+  if (finalState_.iidmFile_)
     dumpIIDMFile();
 
   printEnd();
@@ -1260,15 +1260,15 @@ Simulation::dumpIIDMFile(const boost::filesystem::path& iidmFile) {
 
 void
 Simulation::dumpIIDMFile() {
-  if (finalState_.iidmFile) {
-    dumpIIDMFile(*finalState_.iidmFile);
+  if (finalState_.iidmFile_) {
+    dumpIIDMFile(*finalState_.iidmFile_);
   }
 }
 
 void
 Simulation::dumpState() {
-  if (finalState_.dumpFile) {
-    dumpState(*finalState_.dumpFile);
+  if (finalState_.dumpFile_) {
+    dumpState(*finalState_.dumpFile_);
   }
 }
 
@@ -1338,9 +1338,9 @@ Simulation::printCurrentTime(const string& fileName) {
 Simulation::ExportStateDefinition::ExportStateDefinition(double timestamp,
       boost::optional<boost::filesystem::path> dumpFile,
       boost::optional<boost::filesystem::path> iidmFile):
-  timestamp(timestamp),
-  dumpFile(dumpFile),
-  iidmFile(iidmFile) {
+  timestamp_(timestamp),
+  dumpFile_(dumpFile),
+  iidmFile_(iidmFile) {
 }
 
 }  // end of namespace DYN

--- a/dynawo/sources/Simulation/DYNSimulation.h
+++ b/dynawo/sources/Simulation/DYNSimulation.h
@@ -142,9 +142,9 @@ class Simulation {
       boost::optional<boost::filesystem::path> dumpFile = boost::none,
       boost::optional<boost::filesystem::path> iidmFile = boost::none);
 
-    double timestamp;                                   ///< Timestamp of the export (can be max for final state)
-    boost::optional<boost::filesystem::path> dumpFile;  ///< Path of the dump state file, if requested
-    boost::optional<boost::filesystem::path> iidmFile;  ///< Path of the IIDM export file, if requested
+    double timestamp_;                                   ///< Timestamp of the export (can be max for final state)
+    boost::optional<boost::filesystem::path> dumpFile_;  ///< Path of the dump state file, if requested
+    boost::optional<boost::filesystem::path> iidmFile_;  ///< Path of the IIDM export file, if requested
   };
 
  public:
@@ -394,7 +394,7 @@ class Simulation {
    * @param file final state dump output file
    */
   inline void setDumpFinalStateFile(const std::string& file) {
-    finalState_.dumpFile = file;
+    finalState_.dumpFile_ = file;
   }
 
   /**
@@ -402,21 +402,21 @@ class Simulation {
    * @param file final state IIDM output file
    */
   inline void setExportIIDMFile(const std::string& file) {
-    finalState_.iidmFile = file;
+    finalState_.iidmFile_ = file;
   }
 
   /**
    * @brief disable IIDM export for final state
    */
   inline void disableExportIIDM() {
-    finalState_.iidmFile.reset();
+    finalState_.iidmFile_.reset();
   }
 
   /**
    * @brief disable dump export for final state
    */
   inline void disableDumpFinalState() {
-    finalState_.dumpFile.reset();
+    finalState_.dumpFile_.reset();
   }
 
   /**


### PR DESCRIPTION
Recent commits cause errors:

`error: constructor parameter 'iidmFile' shadows the field 'iidmFile' of 'ExportStateDefinition' [-Werror,-Wshadow-field-in-constructor]`

See #125 and #1878 