### PR TITLE
#1689 put back static to avoid missing-prototypes warning in clang

### DIFF
--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestBus.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestBus.cpp
@@ -47,7 +47,7 @@ using boost::shared_ptr;
 
 namespace DYN {
 
-std::pair<shared_ptr<ModelBus>, shared_ptr<ModelVoltageLevel> >  // need to return the voltage level so that it is not destroyed
+static std::pair<shared_ptr<ModelBus>, shared_ptr<ModelVoltageLevel> >  // need to return the voltage level so that it is not destroyed
 createModelBus(bool initModel, bool isNodeBreaker, bool hasConnection = true) {
 #ifdef USE_POWSYBL
   powsybl::iidm::Network networkIIDM("test", "test");


### PR DESCRIPTION
closes #1689 