### PR TITLE
#2064 remove assert that test that if the time added is the same as t…

### DIFF
--- a/dynawo/sources/Modeler/Common/DYNRingBuffer.cpp
+++ b/dynawo/sources/Modeler/Common/DYNRingBuffer.cpp
@@ -30,9 +30,6 @@ RingBuffer::RingBuffer(double maxDelay) : queue_(), maxDelay_(maxDelay) {}
 void
 RingBuffer::add(double time, double value) {
   if (queue_.size() > 0 && doubleEquals(queue_.back().first, time)) {
-#if _DEBUG_
-    assert(doubleEquals(queue_.back().second, value));
-#endif
     // ignore if we add multiple time the same value
     return;
   }


### PR DESCRIPTION
…he last one in the queue then the value should be the same.

This might fail if the precisions of dynawo and solvers are different
closes #2064