### PR TITLE
#2180 Fix exploration of graph to find all paths between two nodes, and

### DIFF
--- a/dynawo/sources/Common/DYNGraph.cpp
+++ b/dynawo/sources/Common/DYNGraph.cpp
@@ -134,12 +134,13 @@ Graph::findAllPaths(const unsigned int& vertexOrigin, const unsigned int& vertex
     const unsigned int neighbour = verticesIds_[static_cast<unsigned int>(*neighbourIt)];
     if (encountered.count(neighbour) > 0)
       continue;
+    boost::unordered_set<unsigned int> encounteredIds = encountered;
 
     std::pair<Edge, bool> edgePair = edge(vertices_[vertexOrigin], vertices_[neighbour], filteredGraph);
     string edgeId = boost::get(boost::edge_name, filteredGraph, edgePair.first);
 
     PathDescription currentPath2 = currentPath;
-    if (findAllPaths(edgeId, neighbour, vertexExtremity, currentPath2, encountered, paths, filteredGraph, stopWhenExtremityReached)) {
+    if (findAllPaths(edgeId, neighbour, vertexExtremity, currentPath2, encounteredIds, paths, filteredGraph, stopWhenExtremityReached)) {
       currentPath.insert(currentPath.end(), currentPath2.begin(), currentPath2.end());
       if (stopWhenExtremityReached)
         return true;

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNVoltageLevelInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNVoltageLevelInterfaceIIDM.cpp
@@ -207,6 +207,18 @@ VoltageLevelInterfaceIIDM::isNodeConnected(const unsigned int& nodeToCheck) {
   return false;
 }
 
+unsigned
+VoltageLevelInterfaceIIDM::countNumberOfSwitchesToClose(const std::vector<std::string>& path) const {
+  unsigned res = 0;
+  for (std::vector<std::string>::const_iterator it =  path.begin(), itEnd = path.end(); it != itEnd; ++it) {
+    IIDM::Switch sw = *(voltageLevelIIDM_.find_switch(*it));
+    if (sw.opened()) {
+      ++res;
+    }
+  }
+  return res;
+}
+
 void
 VoltageLevelInterfaceIIDM::connectNode(const unsigned int& nodeToConnect) {
   // should be removed once a solution has been found to propagate switches (de)connection
@@ -215,13 +227,25 @@ VoltageLevelInterfaceIIDM::connectNode(const unsigned int& nodeToConnect) {
 
   // close the shortest path to one bus bar section
   vector<string> shortestPath;
+  unsigned nbSwitchToClose = 0;
   for (IIDM::Contains<IIDM::BusBarSection>::iterator itBBS = voltageLevelIIDM_.busBarSections().begin();
       itBBS != voltageLevelIIDM_.busBarSections().end(); ++itBBS) {
     int nodeBBS = itBBS->node();
     vector<string> ret;
     graph_.shortestPath(nodeToConnect, nodeBBS, weights1_, ret);
-    if (!ret.empty() && ( ret.size() < shortestPath.size() || shortestPath.size() == 0) )
+    if (shortestPath.empty()) {
       shortestPath = ret;
+      nbSwitchToClose = countNumberOfSwitchesToClose(ret);
+    } else if (!ret.empty() && ret.size() < shortestPath.size()) {
+      shortestPath = ret;
+      nbSwitchToClose = countNumberOfSwitchesToClose(ret);
+    } else if (!ret.empty() && shortestPath.size() == ret.size()) {  // Tie-breaker
+      unsigned currentNbSwitchToClose = countNumberOfSwitchesToClose(ret);
+      if (currentNbSwitchToClose < nbSwitchToClose) {
+        shortestPath = ret;
+        nbSwitchToClose = currentNbSwitchToClose;
+      }
+    }
   }
 
   for (vector<string>::iterator iter = shortestPath.begin(); iter != shortestPath.end(); ++iter) {

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNVoltageLevelInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNVoltageLevelInterfaceIIDM.h
@@ -206,6 +206,15 @@ class VoltageLevelInterfaceIIDM : public VoltageLevelInterface {
   }
 
  private:
+  /**
+   * @brief Count the number of switches that should be closed to connect this path
+   *
+   * @param path path to be analyzed
+   * @return the number of switches that should be closed to connect this path
+   */
+  unsigned countNumberOfSwitchesToClose(const std::vector<std::string>& path) const;
+
+ private:
   IIDM::VoltageLevel& voltageLevelIIDM_;  ///< reference to the iidm voltageLevel instance
   bool isNodeBreakerTopology_;  ///< @b true if the topology of the voltageLevel is node breaker topology
   std::map< std::string, boost::shared_ptr<SwitchInterface> > switchesById_;  ///< switch interface by Id

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVoltageLevelInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNVoltageLevelInterfaceIIDM.h
@@ -217,6 +217,15 @@ class VoltageLevelInterfaceIIDM : public VoltageLevelInterface {
   }
 
  private:
+  /**
+   * @brief Count the number of switches that should be closed to connect this path
+   *
+   * @param path path to be analyzed
+   * @return the number of switches that should be closed to connect this path
+   */
+  unsigned countNumberOfSwitchesToClose(const std::vector<std::string>& path) const;
+
+ private:
   powsybl::iidm::VoltageLevel& voltageLevelIIDM_;  ///< reference to the iidm voltageLevel instance
   bool isNodeBreakerTopology_;  ///< @b true if the topology of the voltageLevel is node breaker topology
   boost::unordered_map<boost::shared_ptr<SwitchInterface>, double > switchState_;  ///< state to apply to switch (due to topology change)


### PR DESCRIPTION
add a tie-breaker in connectNode to select the path with the lowest number of switches to activate
closes #2180 