### PR TITLE
#2289 Refactor preassembled models compilation and add mechanism to c…

### DIFF
--- a/dynawo/CMakeLists.txt
+++ b/dynawo/CMakeLists.txt
@@ -314,13 +314,6 @@ else()
   )
 endif()
 
-#
-# Target used to ensure that ddbdir directory is created
-#
-add_custom_target(CREATE_DDBDIR
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${ddbdir}
-)
-
 if(MSVC)
   set(runtime_PATH "PATH=${ADEPT_HOME}/bin;${Boost_INCLUDE_DIR}/../bin;${INSTALL_OPENMODELICA}/bin;${SUITESPARSE_HOME}/bin;${SUNDIALS_HOME}/bin;${XercesC_INCLUDE_DIRS}/../bin;${LibIIDM_BIN_DIR};${LIBIIDM_HOME}/bin;${LibXML_BIN_DIR};${LIBXML2_HOME}/bin;${libdir};$ENV{PATH}")
   if(BUILD_TESTS OR BUILD_TESTS_COVERAGE)

--- a/dynawo/sources/API/EXTVAR/test/res/ExternalVariablesDuplicateId.extvar
+++ b/dynawo/sources/API/EXTVAR/test/res/ExternalVariablesDuplicateId.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="discrete" id="var1"/>
   <variable type="continuous" id="var1"/>
   <variable type="continuous" id="var2"/>

--- a/dynawo/sources/API/EXTVAR/test/res/ExternalVariablesTest.extvar
+++ b/dynawo/sources/API/EXTVAR/test/res/ExternalVariablesTest.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="var1"/>
   <variable type="continuous" id="var2"/>
   <variable type="continuous" id="var3"/>

--- a/dynawo/sources/Modeler/Common/DYNCompiler.cpp
+++ b/dynawo/sources/Modeler/Common/DYNCompiler.cpp
@@ -369,7 +369,7 @@ Compiler::compileModelicaModelDescription(const shared_ptr<ModelDescription>& mo
 #endif
 
   // testing if the lib was successfully compiled (test if it exists, and if no undefined symbol was noticed)
-  string lib = modelDirPath_ + "/" + libName;
+  string lib = absolute(libName, modelDirPath_);
   if ((!exists(lib)) || hasUndefinedSymbol)
     throw DYNError(Error::MODELER, CompilationFailed, libName);
 

--- a/dynawo/sources/Modeler/util/CMakeLists.txt
+++ b/dynawo/sources/Modeler/util/CMakeLists.txt
@@ -64,6 +64,8 @@ target_link_libraries(generate-preassembled
 
 set_target_properties(generate-preassembled PROPERTIES VERSION ${DYNAWO_VERSION_STRING})
 
+add_dependencies(generate-preassembled compileModelicaModel)
+
 install(TARGETS generate-preassembled EXPORT dynawo-targets DESTINATION ${SBINDIR_NAME})
 
 if(BUILD_TESTS OR BUILD_TESTS_COVERAGE)

--- a/dynawo/sources/Modeler/util/test/res/Model1.extvar
+++ b/dynawo/sources/Modeler/util/test/res/Model1.extvar
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="v"/>
 </external_variables>

--- a/dynawo/sources/Modeler/util/test/res/Model2.extvar
+++ b/dynawo/sources/Modeler/util/test/res/Model2.extvar
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="v"/>
   <variable type="continuous" id="w"/>
 </external_variables>

--- a/dynawo/sources/ModelicaCompiler/DYNCompileModelicaModel.cpp
+++ b/dynawo/sources/ModelicaCompiler/DYNCompileModelicaModel.cpp
@@ -107,19 +107,19 @@ int main(int argc, char ** argv) {
   if (vm.count("help")) {
     cout << desc << endl;
     return 0;
-  } else if (modelName == "") {
+  } else if (modelName.empty()) {
     cout << " Model name is required " << endl;
     cout << desc << endl;
     return 1;
   }
-  if (modelDir == "") {
+  if (modelDir.empty()) {
     modelDir = ".";
   }
-  if (compilationDir == "") {
-    compilationDir = modelDir + "/" + modelName;
+  if (compilationDir.empty()) {
+    compilationDir = absolute(modelName, modelDir);
   }
 
-  if (packageName != "" && strcmp(&packageName.at(packageName.length() - 1), ".")) {
+  if (!packageName.empty() && strcmp(&packageName.at(packageName.length() - 1), ".")) {
     packageName += ".";
   }
   if (!useAliasing) {
@@ -159,9 +159,9 @@ int main(int argc, char ** argv) {
       throw DYNError(DYN::Error::MODELER, ModelCompilationFailed, modelName);
 
     // Creation of the lib .so
-    if (libName != "") {
+    if (!libName.empty()) {
       // 1) on efface la lib a generer
-      string lib = compilationDir1 + "/" + libName;
+      string lib = absolute(libName, compilationDir1);
       remove(lib);
       // 2) attempt to generate the lib
       compileLib(modelName, compilationDir1);
@@ -397,7 +397,7 @@ generateModelFile(const string& modelName, const string& compilationDir, bool& w
     varExtCommand += " -a " + additionalHeaderList;
   if (withInitFile)
     varExtCommand += " --init";
-  if (packageName != "")
+  if (!packageName.empty())
     varExtCommand += " --package-name " + packageName;
 
   bool doPrintLogs = true;

--- a/dynawo/sources/Models/CMakeLists.txt
+++ b/dynawo/sources/Models/CMakeLists.txt
@@ -41,15 +41,6 @@ add_custom_target(MODEL_FILES_INSTALL
                  )
 
 #
-# Flatten external variable files (in order to process includes)
-#
-add_custom_target(EXTERNAL_VARIABLES_FLATTENING
-                  DEPENDS
-                    MODEL_FILES_INSTALL
-                  COMMENT "Flattening external variables files (processing includes)"
-                 )
-
-#
 # Target used to install Modelica preassembled models files in ddbdir
 # (.so and .desc.xml)
 #
@@ -81,41 +72,18 @@ macro(INSTALL_MODEL_FILE
   # Generate a target name for the model
   string(REPLACE "/" "_" TARGET_NAME "${RELATIVE_MODELICA_MODEL_DIR}/${FILE_TO_INSTALL}")
 
-  # Extract the (short) file extension
-  string(FIND ${FILE_TO_INSTALL} "." SHORT_EXTENSION_INDEX REVERSE)
-  string(SUBSTRING ${FILE_TO_INSTALL} ${SHORT_EXTENSION_INDEX} -1 SHORT_EXTENSION)
-  string(TOLOWER ${SHORT_EXTENSION} SHORT_EXTENSION_LOWER)
-
   set(OUTPUT_FILE_NAME "${FILE_TO_INSTALL}")
   set(OUTPUT_FILE_PATH ${ddbdir}/${RELATIVE_MODELICA_MODEL_DIR}/${OUTPUT_FILE_NAME})
 
-  add_custom_target(${TARGET_NAME}
-    DEPENDS CREATE_DDBDIR
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_TO_INSTALL} ${OUTPUT_FILE_PATH}
+  add_custom_command(
+    OUTPUT ${OUTPUT_FILE_PATH}
+    DEPENDS ${FILE_TO_INSTALL}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_TO_INSTALL} ${OUTPUT_FILE_PATH}
     )
 
-  # Run xmllint on external variable files in order to include possible sub-model external variables
-  if(UNIX AND ${SHORT_EXTENSION_LOWER} STREQUAL ${EXTERNAL_VARIABLES_EXTENSION})
-    set(TARGET_PROCESSING_NAME "${TARGET_NAME}_EXTVAR_FLATTENING")
-    add_custom_target(${TARGET_PROCESSING_NAME}
-      DEPENDS MODEL_FILES_INSTALL
-      COMMENT "Processing external variable files for includes"
-      )
-
-    set(TMP_FILE_PATH ${OUTPUT_FILE_PATH}.tmp)
-    add_custom_command(
-      TARGET ${TARGET_PROCESSING_NAME}
-      PRE_BUILD
-      COMMAND xmllint --nofixup-base-uris --nowarning --xinclude "${OUTPUT_FILE_PATH}" --output "${TMP_FILE_PATH}" 2>&1 || ((echo "*** Failed to include external variable files") && exit 1)
-      COMMAND xmllint --format --noblanks "${TMP_FILE_PATH}" --output "${OUTPUT_FILE_PATH}"
-      COMMAND rm -rf "${TMP_FILE_PATH}"
-      )
-
-    add_dependencies(EXTERNAL_VARIABLES_FLATTENING ${TARGET_PROCESSING_NAME})
-  endif()
+  add_custom_target(${TARGET_NAME} DEPENDS ${OUTPUT_FILE_PATH})
 
   add_dependencies(MODEL_FILES_INSTALL ${TARGET_NAME})
-
 endmacro(INSTALL_MODEL_FILE)
 
 #
@@ -123,143 +91,132 @@ endmacro(INSTALL_MODEL_FILE)
 # file into ddbdir. Automatically adds the dependencies
 # to the main targets.
 #
-
 macro(COMPILE_PREASSEMBLED_MODEL
        PREASSEMBLED_MODEL
      )
   get_filename_component(MODEL_NAME ${PREASSEMBLED_MODEL} NAME_WE)
 
-    #
-    # Builds the preassembled model if .dep file shows
-    # it has been modified
-    #
-    # We have to do a different command for Windows because of the limitation of numbers of characters on a command line...
-    #
-    if (MSVC)
-      add_custom_command(
-        OUTPUT ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        DEPENDS
-            ${PREASSEMBLED_MODEL}
-            MODEL_FILES_INSTALL
-            EXTERNAL_VARIABLES_FLATTENING
-            dynawo_ModelManager
-        COMMAND
-            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/buildChecker.py ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} > ${MODEL_NAME}.log 2>&1 ||
-            (echo "*** [${MODEL_NAME}] Error : for more information see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "@echo off" > ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_INSTALL_DIR=${installdir}" >> wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_DDB_DIR=${ddbdir}" >> wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_SCRIPTS_DIR=${sbindir}" >> wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_RESOURCES_DIR=${sharedir}" >> wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_DICTIONARIES=dictionaries_mapping" >> wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_XSD_DIR=${sharedir}/xsd/" >> wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_ADEPT_INSTALL_DIR=${ADEPT_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_INSTALL_OPENMODELICA=${INSTALL_OPENMODELICA}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_XERCESC_INSTALL_DIR=${XERCESC_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_SUITESPARSE_INSTALL_DIR=${SUITESPARSE_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_SUNDIALS_INSTALL_DIR=${SUNDIALS_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_BOOST_HOME=${BOOST_ROOT}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "set DYNAWO_LIBXML_HOME=${LIBXML_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "${runtime_PATH}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-          ${CMAKE_COMMAND} -E echo "%*" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
-        COMMAND
-            ${CMAKE_COMMAND} -E env
-              cmd /c ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat $<TARGET_FILE:generate-preassembled> --model-list ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} --output-dir ${CMAKE_CURRENT_BINARY_DIR} --remove-model-files true >> ${MODEL_NAME}.log 2>&1 ||
-              (echo "*** [${MODEL_NAME}] Error : for more information please see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
-        COMMENT "Building ${MODEL_NAME}"
-        )
-    else()
-      add_custom_command(
-        OUTPUT ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        DEPENDS
-            ${PREASSEMBLED_MODEL}
-            MODEL_FILES_INSTALL
-            EXTERNAL_VARIABLES_FLATTENING
-            dynawo_ModelManager
-        COMMAND
-            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/buildChecker.py ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} > ${MODEL_NAME}.log 2>&1 ||
-            (echo "*** [${MODEL_NAME}] Error : for more information see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
-        COMMAND
-         ${CMAKE_COMMAND} -E env
-              "${runtime_PATH}"
-              "${runtime_LD_LIBRARY_PATH}"
-              "DYNAWO_INSTALL_DIR=${installdir}"
-              "DYNAWO_DDB_DIR=${ddbdir}"
-              "DYNAWO_SCRIPTS_DIR=${sbindir}"
-              "DYNAWO_RESOURCES_DIR=${sharedir}"
-              "DYNAWO_DICTIONARIES=dictionaries_mapping"
-              "DYNAWO_XSD_DIR=${sharedir}/xsd/"
-              "DYNAWO_ADEPT_INSTALL_DIR=${ADEPT_HOME}"
-              "DYNAWO_INSTALL_OPENMODELICA=${INSTALL_OPENMODELICA}"
-              "DYNAWO_XERCESC_INSTALL_DIR=${XERCESC_HOME}"
-              "DYNAWO_SUITESPARSE_INSTALL_DIR=${SUITESPARSE_HOME}"
-              "DYNAWO_SUNDIALS_INSTALL_DIR=${SUNDIALS_HOME}"
-              "DYNAWO_BOOST_HOME=${BOOST_ROOT}"
-              "DYNAWO_LIBXML_HOME=${LIBXML_HOME}"
-              "DYNAWO_NICSLU_INSTALL_DIR=${NICSLU_HOME}"
-                $<TARGET_FILE:generate-preassembled> --model-list ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} --output-dir ${CMAKE_CURRENT_BINARY_DIR} --remove-model-files true >> ${MODEL_NAME}.log 2>&1 ||
-                (echo "*** [${MODEL_NAME}] Error : for more information please see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
-        COMMENT "Building ${MODEL_NAME}"
-        )
-    endif()
-
-    #
-    # Generates .desc.xml file for the preassembled model
-    #
+  #
+  # Builds the preassembled model if .dep file shows
+  # it has been modified
+  #
+  # We have to do a different command for Windows because of the limitation of numbers of characters on a command line...
+  #
+  if (MSVC)
     add_custom_command(
-        OUTPUT ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION}
-        DEPENDS ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        COMMAND
-            ${CMAKE_COMMAND} -E env
-                "${runtime_PATH}"
-                "${runtime_LD_LIBRARY_PATH}"
-                  $<TARGET_FILE:dumpModel> -m ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} -o ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION}
-        COMMENT "Generating ${MODEL_NAME} description file"
-        )
+      OUTPUT ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      DEPENDS
+        MODEL_FILES_INSTALL
+        ${PREASSEMBLED_MODEL}
+        dynawo_ModelManager
+      COMMAND
+        ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/buildChecker.py ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} > ${MODEL_NAME}.log 2>&1 ||
+        (echo "*** [${MODEL_NAME}] Error : for more information see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "@echo off" > ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_INSTALL_DIR=${installdir}" >> wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_DDB_DIR=${ddbdir}" >> wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_SCRIPTS_DIR=${sbindir}" >> wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_RESOURCES_DIR=${sharedir}" >> wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_DICTIONARIES=dictionaries_mapping" >> wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_XSD_DIR=${sharedir}/xsd/" >> wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_ADEPT_INSTALL_DIR=${ADEPT_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_INSTALL_OPENMODELICA=${INSTALL_OPENMODELICA}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_XERCESC_INSTALL_DIR=${XERCESC_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_SUITESPARSE_INSTALL_DIR=${SUITESPARSE_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_SUNDIALS_INSTALL_DIR=${SUNDIALS_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_BOOST_HOME=${BOOST_ROOT}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "set DYNAWO_LIBXML_HOME=${LIBXML_HOME}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "${runtime_PATH}" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+        ${CMAKE_COMMAND} -E echo "%*" >> ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat
+      COMMAND
+          ${CMAKE_COMMAND} -E env
+            cmd /c ${CMAKE_CURRENT_BINARY_DIR}/wrapper.bat $<TARGET_FILE:generate-preassembled> --model-list ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} --output-dir ${CMAKE_CURRENT_BINARY_DIR} --remove-model-files true >> ${MODEL_NAME}.log 2>&1 ||
+            (echo "*** [${MODEL_NAME}] Error : for more information please see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
+      COMMENT "Building ${MODEL_NAME}"
+      )
+  else()
+    add_custom_command(
+      OUTPUT ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      DEPENDS
+        ${PREASSEMBLED_MODEL}
+        MODEL_FILES_INSTALL
+        dynawo_ModelManager
+      COMMAND
+        test -f ${CMAKE_INSTALL_PREFIX}/${SBINDIR_NAME}/scriptVerifyModelList.py || (echo "Target install was not completed, you need to launch it before compiling a Modelica model. For example with dynawo build-dynawo-core." && exit 1)
+      COMMAND
+        ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/buildChecker.py ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} > ${MODEL_NAME}.log 2>&1 ||
+        (echo "*** [${MODEL_NAME}] Error : for more information see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
+      COMMAND
+        ${CMAKE_COMMAND} -E env
+        "${runtime_PATH}"
+        "${runtime_LD_LIBRARY_PATH}"
+        "DYNAWO_INSTALL_DIR=${installdir}"
+        "DYNAWO_DDB_DIR=${ddbdir}"
+        "DYNAWO_SCRIPTS_DIR=${sbindir}"
+        "DYNAWO_RESOURCES_DIR=${sharedir}"
+        "DYNAWO_DICTIONARIES=dictionaries_mapping"
+        "DYNAWO_XSD_DIR=${sharedir}/xsd/"
+        "DYNAWO_ADEPT_INSTALL_DIR=${ADEPT_HOME}"
+        "DYNAWO_INSTALL_OPENMODELICA=${INSTALL_OPENMODELICA}"
+        "DYNAWO_XERCESC_INSTALL_DIR=${XERCESC_HOME}"
+        "DYNAWO_SUITESPARSE_INSTALL_DIR=${SUITESPARSE_HOME}"
+        "DYNAWO_SUNDIALS_INSTALL_DIR=${SUNDIALS_HOME}"
+        "DYNAWO_BOOST_HOME=${BOOST_ROOT}"
+        "DYNAWO_LIBXML_HOME=${LIBXML_HOME}"
+        "DYNAWO_NICSLU_INSTALL_DIR=${NICSLU_HOME}"
+        $<TARGET_FILE:generate-preassembled> --model-list ${CMAKE_CURRENT_SOURCE_DIR}/${PREASSEMBLED_MODEL} --output-dir ${CMAKE_CURRENT_BINARY_DIR} --remove-model-files true >> ${MODEL_NAME}.log 2>&1 ||
+          (echo "*** [${MODEL_NAME}] Error : for more information please see file ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}.log" && exit 1)
+      COMMENT "Building ${MODEL_NAME}"
+    )
+  endif()
 
-    #
-    # Install built library and generated .desc.xml file into bdddir
-    #
-    add_custom_target(${MODEL_NAME}
-        DEPENDS
-            ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-            ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION}
-            ${MODEL_NAME}${EXTERNAL_VARIABLES_EXTENSION}
-            CREATE_DDBDIR
-        COMMAND
-            ${CMAKE_COMMAND} -E copy ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} ${ddbdir}/
-        COMMAND
-            ${CMAKE_COMMAND} -E copy ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION} ${ddbdir}/
-        )
+  #
+  # Generates .desc.xml file for the preassembled model
+  #
+  add_custom_command(
+    OUTPUT ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION}
+    DEPENDS ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
+    COMMAND
+        ${CMAKE_COMMAND} -E env
+            "${runtime_PATH}"
+            "${runtime_LD_LIBRARY_PATH}"
+              $<TARGET_FILE:dumpModel> -m ${CMAKE_CURRENT_BINARY_DIR}/${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} -o ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION}
+    COMMENT "Generating ${MODEL_NAME} description file"
+    )
 
-    add_custom_target(${MODEL_NAME}${EXTERNAL_VARIABLES_EXTENSION}
-        DEPENDS
-            ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-            CREATE_DDBDIR
-        COMMAND
-            # First echo_append prevents cmake from changing ( to "(" that is an invalid bash command
-            ${CMAKE_COMMAND} -E echo_append && (${CMAKE_COMMAND} -E copy ${MODEL_NAME}${EXTERNAL_VARIABLES_EXTENSION} ${ddbdir}/ || ${CMAKE_COMMAND} -E echo_append This is not an error !) >> ${MODEL_NAME}.log 2>&1
-        COMMENT "Install ${MODEL_NAME}${EXTERNAL_VARIABLES_EXTENSION} external variables description file"
-        )
+  #
+  # Install built library and generated .desc.xml file into bdddir
+  #
+  add_custom_target(${MODEL_NAME}
+      DEPENDS
+        ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
+        ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION}
+      COMMAND
+        ${CMAKE_COMMAND} -E copy ${MODEL_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} ${ddbdir}/
+      COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different ${MODEL_NAME}${DESCRIPTION_XML_EXTENSION} ${ddbdir}/
+      COMMAND
+        # First echo_append prevents cmake from changing ( to "(" that is an invalid bash command
+        ${CMAKE_COMMAND} -E echo_append && (${CMAKE_COMMAND} -E copy_if_different ${MODEL_NAME}${EXTERNAL_VARIABLES_EXTENSION} ${ddbdir}/ || ${CMAKE_COMMAND} -E echo_append This is not an error !) >> ${MODEL_NAME}.log 2>&1
+  )
 
-    add_dependencies(PREASSEMBLED_MODEL_FILES_INSTALL ${MODEL_NAME})
-    add_dependencies(PREASSEMBLED_MODEL_FILES_INSTALL ${MODEL_NAME}${EXTERNAL_VARIABLES_EXTENSION})
+  add_dependencies(PREASSEMBLED_MODEL_FILES_INSTALL ${MODEL_NAME})
 endmacro(COMPILE_PREASSEMBLED_MODEL)
 
 #
@@ -305,6 +262,8 @@ macro(COMPILE_CPP_MODEL
         OUTPUT ${CPP_MODEL}${DESCRIPTION_XML_EXTENSION}
         DEPENDS ${CPP_MODEL}
         COMMAND
+            test -f ${CMAKE_INSTALL_PREFIX}/${LIBDIR_NAME}/$<TARGET_FILE_NAME:dynawo_CPPModelsCommon>  || (echo "Target install was not completed, you need to launch it before compiling a CPP model. For example with dynawo build-dynawo-core." && exit 1)
+        COMMAND
             ${CMAKE_COMMAND} -E env
               "${runtime_PATH}"
               "${runtime_LD_LIBRARY_PATH}"
@@ -316,7 +275,6 @@ macro(COMPILE_CPP_MODEL
         DEPENDS
             ${CPP_MODEL}
             ${CPP_MODEL}${DESCRIPTION_XML_EXTENSION}
-            CREATE_DDBDIR
         COMMAND
             ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${CPP_MODEL}> ${ddbdir}/
         COMMAND

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/Bus.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/Bus.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
 </external_variables>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/InfiniteBus.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/InfiniteBus.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.i.re"/>
   <variable type="continuous" id="terminal.i.im"/>
 </external_variables>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/InfiniteBusWithVariations.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/InfiniteBusWithVariations.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.i.re"/>
   <variable type="continuous" id="terminal.i.im"/>
 </external_variables>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/HVDC/PowerTransferHVDC.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/HVDC/PowerTransferHVDC.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="discrete" id="PRefSet1RawPu"/>
   <variable type="discrete" id="PRefSet2RawPu"/>
   <variable type="discrete" id="running1" defaultValue="true"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/HVDC/PowerTransferHVDCEmulation.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/HVDC/PowerTransferHVDCEmulation.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="discrete" id="PRefSet1RawPu"/>
   <variable type="discrete" id="PRefSet2RawPu"/>
   <variable type="discrete" id="running1" defaultValue="true"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/PLL/PLL.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/PLL/PLL.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="uPu.re"/>
   <variable type="continuous" id="uPu.im"/>
   <variable type="continuous" id="OmegaRefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Transformers/Images/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Transformers/Images/CMakeLists.txt
@@ -18,5 +18,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Transformers/PhaseShifterI.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Transformers/PhaseShifterI.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="iMonitored.value"/>
   <variable id="locked" type="discrete" defaultValue="false"/>
   <variable type="discrete" id="switchOffSignal1.value" defaultValue="false"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Transformers/PhaseShifterP.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Transformers/PhaseShifterP.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="PMonitored.value"/>
   <variable id="locked" type="discrete" defaultValue="false"/>
   <variable type="discrete" id="switchOffSignal1.value" defaultValue="false"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Voltage/Images/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Voltage/Images/CMakeLists.txt
@@ -16,5 +16,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/BaseControls/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/BaseControls/CMakeLists.txt
@@ -26,5 +26,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/CMakeLists.txt
@@ -27,5 +27,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/Utilities/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/Utilities/CMakeLists.txt
@@ -20,5 +20,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/BaseControls/ACEmulation.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/BaseControls/ACEmulation.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="Theta1"/>
   <variable type="continuous" id="Theta2"/>
 </external_variables>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/BaseControls/ACEmulationVariableK.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/BaseControls/ACEmulationVariableK.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="Theta1"/>
   <variable type="continuous" id="Theta2"/>
   <variable type="continuous" id="KACEmulation"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQProp.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQProp.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQPropDangling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQPropDangling.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQPropDanglingDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQPropDanglingDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQPropDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPQProp/HvdcPQPropDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhi.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhi.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhiDangling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhiDangling.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhiDanglingDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhiDanglingDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhiDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPTanPhi/HvdcPTanPhiDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPV.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPV.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPVDangling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPVDangling.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPVDanglingDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPVDanglingDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPVDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/HvdcPV/HvdcPVDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Lines/Line.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Lines/Line.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadAlphaBeta.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadAlphaBeta.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu" optional="true"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadAlphaBetaRestorative.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadAlphaBetaRestorative.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu" optional="true"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu" optional="true"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadZIP.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Loads/LoadZIP.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu" optional="true"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/GeneratorFictitious.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/GeneratorFictitious.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="switchOffSignal1.value" defaultValue="false"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/OmegaRef/GeneratorPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/OmegaRef/GeneratorPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="omegaRefPu.value"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/OmegaRef/GeneratorPV.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/OmegaRef/GeneratorPV.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="omegaRefPu.value"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/OmegaRef/GeneratorSynchronous.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/OmegaRef/GeneratorSynchronous.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="omegaRefPu.value"/>
   <variable type="continuous" id="efdPu.value"/>
   <variable type="continuous" id="PmPu.value"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPQProp.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPQProp.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPQPropDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPQPropDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPV.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPV.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVProp.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVProp.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVRemote.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVRemote.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVRemoteDiagramPQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVRemoteDiagramPQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="N"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/CMakeLists.txt
@@ -19,5 +19,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/WECC/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/WECC/CMakeLists.txt
@@ -23,5 +23,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/WECC/PVCurrentSource.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/WECC/PVCurrentSource.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/WECC/PVVoltageSource.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Photovoltaics/WECC/PVVoltageSource.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Shunts/ShuntBWithSections.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Shunts/ShuntBWithSections.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="section.value"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/InjectorBG.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/InjectorBG.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="BPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/InjectorIDQ.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/InjectorIDQ.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="idPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/InjectorURI.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/InjectorURI.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="urPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPV.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPV.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="URefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVModeHandling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVModeHandling.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="setModeManual"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVProp.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVProp.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="URefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVPropModeHandling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVPropModeHandling.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="setModeManual"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVPropRemote.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVPropRemote.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="URegulatedPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVPropRemoteModeHandling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVPropRemoteModeHandling.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="URegulatedPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVRemote.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVRemote.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="URegulatedPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVRemoteModeHandling.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCPVRemoteModeHandling.extvar
@@ -10,7 +10,7 @@
 
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="URegulatedPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCStandard.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/SVarCStandard.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="discrete" id="setModeManual"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/GeneratorTransformer.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/GeneratorTransformer.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/TransformerFixedRatio.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/TransformerFixedRatio.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal1.V.re"/>
   <variable type="continuous" id="terminal1.V.im"/>
   <variable type="continuous" id="terminal2.V.re"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/CMakeLists.txt
@@ -19,5 +19,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/WECC/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/WECC/CMakeLists.txt
@@ -22,5 +22,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/WECC/WTG4ACurrentSource.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/WECC/WTG4ACurrentSource.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/WECC/WTG4BCurrentSource.extvar
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Wind/WECC/WTG4BCurrentSource.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source suite of
     simulation tools for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.V.re"/>
   <variable type="continuous" id="terminal.V.im"/>
   <variable type="continuous" id="PRefPu"/>

--- a/dynawo/sources/Models/Modelica/Dynawo/Examples/Photovoltaics/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Examples/Photovoltaics/CMakeLists.txt
@@ -19,5 +19,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Examples/Photovoltaics/WECC/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Examples/Photovoltaics/WECC/CMakeLists.txt
@@ -19,5 +19,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Examples/Wind/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Examples/Wind/CMakeLists.txt
@@ -19,5 +19,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/Examples/Wind/WECC/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/Examples/Wind/WECC/CMakeLists.txt
@@ -19,5 +19,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/MathBoolean/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/MathBoolean/CMakeLists.txt
@@ -18,5 +18,5 @@ set(MODEL_FILES
 # Modelica models install
 #
 foreach( MODEL_FILE ${MODEL_FILES} )
-    INSTALL_MODEL_file(${MODEL_FILE})
+    install_model_file(${MODEL_FILE})
 endforeach( MODEL_FILE )

--- a/dynawo/sources/Models/Modelica/PreassembledModels/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/PreassembledModels/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MODELICA_PREASSEMBLED_MODELS
   EventQuadripoleDisconnection.xml
   EventSetPointBoolean.xml
   EventSetPointReal.xml
+  EventSetPointDouble.xml
   EventSetPointDoubleReal.xml
   GeneratorFictitious.xml
   GeneratorPQ.xml
@@ -138,6 +139,8 @@ install(PROGRAMS ${PYTHON_SCRIPTS_PREASSEMBLED_MODELS} DESTINATION ${SBINDIR_NAM
 foreach( FILE ${MODELICA_PREASSEMBLED_MODELS} )
   compile_preassembled_model(${FILE})
 endforeach( FILE )
+
+include(CMakeListsModelsTargets.txt)
 
 if(BUILD_TESTS OR BUILD_TESTS_COVERAGE)
   add_subdirectory(test)

--- a/dynawo/sources/Models/Modelica/PreassembledModels/CMakeListsModelsTargets.txt
+++ b/dynawo/sources/Models/Modelica/PreassembledModels/CMakeListsModelsTargets.txt
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2022, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+#
+# This file is part of Dynawo, an hybrid C++/Modelica open source suite of simulation tools for power systems.
+
+
+# Define utility targets
+
+## Generics
+
+file(GLOB Automatons *Automaton*.xml)
+file(GLOB Basics SetPoint.xml Step.xml)
+file(GLOB Bus Bus.xml)
+file(GLOB Events Event*.xml)
+file(GLOB Generators Generator*.xml)
+file(GLOB GridForming GridForming*.xml)
+file(GLOB Hvdcs Hvdc*.xml *HVDC*.xml)
+file(GLOB InfiniteBus InfiniteBus*.xml)
+file(GLOB Line Line.xml)
+file(GLOB Loads Load*.xml)
+file(GLOB Fault NodeFault.xml)
+file(GLOB PhaseShifters PhaseShifter*.xml)
+file(GLOB Renewable Wind*.xml Photovoltaics*.xml)
+file(GLOB Shunts Shunt*.xml)
+file(GLOB SVarc StaticVarCompensator*.xml)
+file(GLOB TapChangers TapChanger*.xml)
+file(GLOB Transformer TransformerFixedRatio.xml)
+
+## Generators
+add_custom_target(GENERATOR_MODELS)
+
+foreach(generator IN LISTS Generators)
+  get_filename_component(name ${generator} NAME_WE)
+  add_dependencies(GENERATOR_MODELS ${name})
+endforeach()
+
+## Loads
+add_custom_target(LOAD_MODELS)
+
+foreach(load IN LISTS Loads)
+  get_filename_component(name ${load} NAME_WE)
+  add_dependencies(LOAD_MODELS ${name})
+endforeach()
+
+## SMIB
+
+add_custom_target(SMIB_MODELS)
+add_dependencies(SMIB_MODELS InfiniteBus Line TransformerFixedRatio SetPoint NodeFault EventSetPointBoolean)
+
+## DYNAFLOW
+
+file(GLOB DynaFlowAutomatons CurrentLimitAutomaton.xml PIAntiWindUpTable.xml WeightedDifference.xml)
+file(GLOB DynaFlowGenerators *SignalN*.xml VRRemote.xml)
+file(GLOB DynaFlowLoads LoadPQ.xml LoadAlphaBetaRestorative.xml LoadAlphaBeta.xml)
+file(GLOB DynaFlowHvdc HvdcP*.xml PowerTransferHVDCEmulation.xml)
+file(GLOB DynaFlowSVarc StaticVarCompensatorPV*.xml)
+
+add_custom_target(DYNAFLOW_MODELS)
+foreach(item IN LISTS Basics DynaFlowAutomatons DynaFlowGenerators DynaFlowHvdc DynaFlowLoads DynaFlowSVarc Events InfiniteBus Line PhaseShifters Shunts)
+  get_filename_component(name ${item} NAME_WE)
+  add_dependencies(DYNAFLOW_MODELS ${name})
+endforeach()
+
+## DYNASWING
+
+file(GLOB DynaSwingGenerators GeneratorSynchronous*.xml)
+file(GLOB DynaSwingHvdcs HvdcVSC*.xml)
+file(GLOB DynaSwingSVarC StaticVarCompensator.xml StaticVarCompensatorStepURef.xml)
+add_custom_target(DYNASWING_MODELS)
+foreach(item IN LISTS Basics Bus DynaSwingGenerators Events Fault Line Loads GridForming DynaSwingHvdcs InfiniteBus DynaSwingSVarC Renewable Transformer)
+  get_filename_component(name ${item} NAME_WE)
+  add_dependencies(DYNASWING_MODELS ${name})
+endforeach()

--- a/dynawo/sources/Solvers/CMakeLists.txt
+++ b/dynawo/sources/Solvers/CMakeLists.txt
@@ -37,7 +37,9 @@ macro(DESC_SOLVER SOLVER_NAME)
         OUTPUT ${SOLVER_NAME}.desc.xml
         DEPENDS ${SOLVER_NAME} dumpSolver
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND
+      COMMAND
+          test -d ${CMAKE_INSTALL_PREFIX}/${DDBDIR_NAME} || (echo "Target install was not completed, you need to launch it before compiling solvers. For example with dynawo build-dynawo-core." && exit 1)
+      COMMAND
             ${CMAKE_COMMAND} -E env
                 "${runtime_PATH}"
                 "${runtime_LD_LIBRARY_PATH}"
@@ -52,7 +54,6 @@ macro(DESC_SOLVER SOLVER_NAME)
         DEPENDS
             ${SOLVER_NAME}
             ${SOLVER_NAME}.desc.xml
-            CREATE_DDBDIR
         COMMAND
             ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SOLVER_NAME}> ${ddbdir}/
         COMMAND

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/DYNInfiniteBus.extvar
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/DYNInfiniteBus.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.i.re"/>
   <variable type="continuous" id="terminal.i.im"/>
 </external_variables>

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverTRAP/test/jobs/DYNInfiniteBus.extvar
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverTRAP/test/jobs/DYNInfiniteBus.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.i.re"/>
   <variable type="continuous" id="terminal.i.im"/>
 </external_variables>

--- a/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/test/jobs/DYNDerivative.extvar
+++ b/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/test/jobs/DYNDerivative.extvar
@@ -11,6 +11,6 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="x.value"/>
 </external_variables>

--- a/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/test/jobs/DYNInfiniteBus.extvar
+++ b/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/test/jobs/DYNInfiniteBus.extvar
@@ -11,7 +11,7 @@
     This file is part of Dynawo, an hybrid C++/Modelica open source time domain
     simulation tool for power systems.
 -->
-<external_variables xmlns="http://www.rte-france.com/dynawo" xmlns:xi="http://www.w3.org/2001/XInclude">
+<external_variables xmlns="http://www.rte-france.com/dynawo">
   <variable type="continuous" id="terminal.i.re"/>
   <variable type="continuous" id="terminal.i.im"/>
 </external_variables>

--- a/util/envDynawo.sh
+++ b/util/envDynawo.sh
@@ -53,8 +53,10 @@ where [option] can be:"
         build-3rd-party                       build 3rd party softwares
         config-dynawo                         configure Dynawo's compiling environment using CMake
         build-dynawo                          build Dynawo and install preassembled models (core, models cpp, models and solvers)
+        build-dynaflow                        build DynaFlow related models (and core, models cpp and solvers) and install preassembled models (core, models cpp, DynaFlow models and solvers)
+        build-dynaswing                       build DynaSwing related models (and core, models cpp and solvers) and install preassembled models (core, models cpp, DynaSwing models and solvers)
         build-dynawo-core                     build Dynawo without models
-        build-dynawo-lib                      build a specific Dynawo library
+        build-dynawo-target                   build a specific Dynawo target (use help to see all cmake targets)
         build-dynawo-models-cpp               build Dynawo CPP models
         build-dynawo-models                   build Dynawo preassembled models
         build-dynawo-solvers                  build Dynawo solver descriptions
@@ -879,16 +881,16 @@ build_dynawo_core() {
   fi
   if [ "$DYNAWO_CMAKE_GENERATOR" = "Unix Makefiles" ]; then
     cd $DYNAWO_BUILD_DIR
-    make -j $DYNAWO_NB_PROCESSORS_USED && make -j $DYNAWO_NB_PROCESSORS_USED install
+    make -j $DYNAWO_NB_PROCESSORS_USED install
   else
-    cmake --build $DYNAWO_BUILD_DIR $DYNAWO_CMAKE_BUILD_OPTION --config $DYNAWO_BUILD_TYPE && cmake --build $DYNAWO_BUILD_DIR --target install --config $DYNAWO_BUILD_TYPE
+    cmake --build $DYNAWO_BUILD_DIR $DYNAWO_CMAKE_BUILD_OPTION --target install
   fi
   RETURN_CODE=$?
   return ${RETURN_CODE}
 }
 
-# Compile a Dynawo library, use help to see all targets
-build_dynawo_lib() {
+# Compile a Dynawo target, use help to see all targets
+build_dynawo_target() {
   if [ ! -d "$DYNAWO_BUILD_DIR" ]; then
     error_exit "$DYNAWO_BUILD_DIR does not exist."
   fi
@@ -950,6 +952,28 @@ build_dynawo() {
   build_dynawo_solvers
   RETURN_CODE=$?
   return ${RETURN_CODE}
+}
+
+build_dynaX() {
+  config_dynawo || error_exit "Error during config_dynawo."
+  if [ ! -d "$DYNAWO_BUILD_DIR" ]; then
+    error_exit "$DYNAWO_BUILD_DIR does not exist."
+  fi
+  cd $DYNAWO_BUILD_DIR
+  build_dynawo_core || error_exit "Error during build_dynawo_core."
+  build_dynawo_models_cpp || error_exit "Error during build_dynawo_models_cpp."
+  build_dynawo_solvers || error_exit "Error during build_dynawo_solvers."
+  build_dynawo_target $@
+  RETURN_CODE=$?
+  return ${RETURN_CODE}
+}
+
+build_dynaflow() {
+  build_dynaX DYNAFLOW_MODELS || error_exit "Error during build_dynaflow."
+}
+
+build_dynaswing() {
+  build_dynaX DYNASWING_MODELS || error_exit "Error during build_dynaflow."
 }
 
 build_user() {
@@ -1086,7 +1110,7 @@ clean_models() {
     return 0
   fi
   for model in `echo $@`; do
-    rm -rf $DYNAWO_BUILD_DIR/sources/Models/Modelica/P/${model}*
+    rm -rf $DYNAWO_BUILD_DIR/M/M/P/${model}*
   done
 }
 
@@ -1100,7 +1124,7 @@ clean_build_models() {
       error_exit "$model is not a valid model to build."
     fi
   done
-  build_dynawo_lib $@
+  build_dynawo_target $@
 }
 
 list_models() {
@@ -2247,13 +2271,20 @@ case $MODE in
     build_dynawo || error_exit "Error while building Dynawo"
     ;;
 
+  build-dynaflow)
+    build_dynaflow || error_exit "Error while building DynaFlow"
+    ;;
+
+  build-dynaswing)
+    build_dynaswing || error_exit "Error while building DynaSwing"
+    ;;
+
   build-dynawo-core)
     build_dynawo_core || error_exit "Failed to build Dynawo core"
     ;;
 
-  build-dynawo-lib)
-    config_dynawo || error_exit "Error while configuring Dynawo"
-    build_dynawo_lib ${ARGS} || error_exit "Failed to build Dynawo lib"
+  build-dynawo-target)
+    build_dynawo_target ${ARGS} || error_exit "Failed to build Dynawo target"
     ;;
 
   build-dynawo-models)


### PR DESCRIPTION
…ompile only a subpart.

If I want to run `nrt/data/SMIB/SMIB_BasicTestCases/SMIB_1_StepPm/SMIB.jobs`, I can only compile a part of Dynawo models by doing:

``` bash
$> dynawo build-3rd-party # Optionnal if you already have them
$> dynawo config-dynawo && dynawo build-dynawo-core && dynawo build-dynawo-target SMIB_MODELS GeneratorSynchronousFourWindingsProportionalRegulationsStepPm
$> dynawo jobs nrt/data/SMIB/SMIB_BasicTestCases/SMIB_1_StepPm/SMIB.jobs
```
