### PR TITLE
2475 align restoration behaviour at global init

### DIFF
--- a/dynawo/sources/Solvers/Common/DYNSolverImpl.cpp
+++ b/dynawo/sources/Solvers/Common/DYNSolverImpl.cpp
@@ -86,6 +86,7 @@ maximumNumberSlowStepIncrease_(10),
 enableSilentZ_(true),
 optimizeReinitAlgebraicResidualsEvaluations_(true),
 minimumModeChangeTypeForAlgebraicRestoration_(ALGEBRAIC_MODE),
+minimumModeChangeTypeForAlgebraicRestorationInit_(NO_MODE),
 tSolve_(0.)
 { }
 
@@ -353,6 +354,8 @@ Solver::Impl::defineCommonParameters() {
       ParameterSolver("optimizeReinitAlgebraicResidualsEvaluations", VAR_TYPE_BOOL, optional)));
   parameters_.insert(make_pair("minimumModeChangeTypeForAlgebraicRestoration",
       ParameterSolver("minimumModeChangeTypeForAlgebraicRestoration", VAR_TYPE_STRING, optional)));
+  parameters_.insert(make_pair("minimumModeChangeTypeForAlgebraicRestorationInit",
+      ParameterSolver("minimumModeChangeTypeForAlgebraicRestorationInit", VAR_TYPE_STRING, optional)));
 }
 
 bool
@@ -506,6 +509,16 @@ void Solver::Impl::setSolverCommonParameters() {
       minimumModeChangeTypeForAlgebraicRestoration_ = ALGEBRAIC_MODE;
     else if (value == "ALGEBRAIC_J_UPDATE")
       minimumModeChangeTypeForAlgebraicRestoration_ = ALGEBRAIC_J_UPDATE_MODE;
+    else
+      Trace::warn() << DYNLog(IncoherentParamMinimumModeChangeType, value) << Trace::endline;
+  }
+  const ParameterSolver& minimumModeChangeTypeForAlgebraicRestorationInit = findParameter("minimumModeChangeTypeForAlgebraicRestorationInit");
+  if (minimumModeChangeTypeForAlgebraicRestorationInit.hasValue()) {
+    std::string value = minimumModeChangeTypeForAlgebraicRestorationInit.getValue<string>();
+    if (value == "ALGEBRAIC")
+      minimumModeChangeTypeForAlgebraicRestorationInit_ = ALGEBRAIC_MODE;
+    else if (value == "ALGEBRAIC_J_UPDATE")
+      minimumModeChangeTypeForAlgebraicRestorationInit_ = ALGEBRAIC_J_UPDATE_MODE;
     else
       Trace::warn() << DYNLog(IncoherentParamMinimumModeChangeType, value) << Trace::endline;
   }

--- a/dynawo/sources/Solvers/Common/DYNSolverImpl.h
+++ b/dynawo/sources/Solvers/Common/DYNSolverImpl.h
@@ -358,6 +358,8 @@ class Solver::Impl : public Solver, private boost::noncopyable {
   bool enableSilentZ_;  ///< enable the possibility to break discrete variable propagation loop if only silent z are modified
   bool optimizeReinitAlgebraicResidualsEvaluations_;  ///< enable or disable the optimization of the number of algebraic residuals evals during reinit
   modeChangeType_t minimumModeChangeTypeForAlgebraicRestoration_;  ///< parameter to set the minimum mode level at which algebraic restoration will occur
+  modeChangeType_t minimumModeChangeTypeForAlgebraicRestorationInit_;  ///< parameter to set the minimum mode level
+                                                                       ///< at which algebraic restoration will occur at init
 
   stat_t stats_;  ///< execution statistics of the solver
   double tSolve_;  ///< current internal time of the solver

--- a/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
@@ -276,7 +276,7 @@ SolverCommonFixedTimeStep::calculateICCommonModeChange(int& counter, bool& chang
 
   // Maximum number of initialization calculation
   ++counter;
-  if ((modeChangeType < minimumModeChangeTypeForAlgebraicRestoration_)) {
+  if (modeChangeType < minimumModeChangeTypeForAlgebraicRestorationInit_) {
     return true;
   }
   if (counter >= maxNumberUnstableRoots)

--- a/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
@@ -259,6 +259,7 @@ bool
 SolverCommonFixedTimeStep::calculateICCommonModeChange(int& counter, bool& change) {
   // Updating discrete variable values and mode
   model_->evalG(tSolve_, g1_);
+  modeChangeType_t modeChangeType = model_->getModeChangeType();
   if (std::equal(g0_.begin(), g0_.end(), g1_.begin())) {
     return true;
   } else {
@@ -275,6 +276,9 @@ SolverCommonFixedTimeStep::calculateICCommonModeChange(int& counter, bool& chang
 
   // Maximum number of initialization calculation
   ++counter;
+  if ((modeChangeType < minimumModeChangeTypeForAlgebraicRestoration_)) {
+    return true;
+  }
   if (counter >= maxNumberUnstableRoots)
     throw DYNError(Error::SOLVER_ALGO, SolverFixedTimeStepUnstableRoots, solverType());
   return false;


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
- [ ] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
