### PR TITLE
#2246 Display of the 5 components that failed the most the cr…

### DIFF
--- a/dynawo/sources/Common/Dictionaries/DYNTimeline_en_GB.dic
+++ b/dynawo/sources/Common/Dictionaries/DYNTimeline_en_GB.dic
@@ -137,3 +137,11 @@ LoadSheddingStarted   =                 LOADS : shedding
 TerminateInModel          =             Simulation stopped : model %1% terminated simulation : %2%
 CriteriaNotChecked        =             Simulation stopped : one criteria is not respected
 SignalReceived            =             Simulation stopped : one interrupt signal was received
+//-------------  Criteria not checked  --------------------------------------
+BusUnderVoltage             =           node: %1% has a voltage %2% kV (%3% pu) < %4% kV (%5% pu) (criteria id: %6%)
+BusAboveVoltage             =           node: %1% has a voltage %2% kV (%3% pu) > %4% kV (%5% pu) (criteria id: %6%)
+SourceUnderPower            =           node: %1% has a load power %2%MW < %3%MW (criteria id: %4%)
+SourceAbovePower            =           node: %1% has a load power %2%MW > %3%MW (criteria id: %4%)
+SourcePowerTakenIntoAccount =           power of %1% %2% was added into the total power sum (criteria id: %3%, power=%4%, V=%5%)
+SourcePowerAboveMax         =           total load power = %1%MW > %2%MW (criteria id: %3%)
+SourcePowerBelowMin         =           total load power = %1%MW < %2%MW (criteria id: %3%)

--- a/dynawo/sources/Modeler/DataInterface/DYNCriteria.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNCriteria.cpp
@@ -25,6 +25,35 @@ Criteria::Criteria(const boost::shared_ptr<criteria::CriteriaParams>& params) :
 
 Criteria::~Criteria() {}
 
+void
+Criteria::printAllFailingCriteriaIntoLog(std::multimap<double, std::shared_ptr<FailingCriteria> >& distanceToFailingCriteriaMap,
+                                          const boost::shared_ptr<timeline::Timeline>& timeline,
+                                          double currentTime) const {
+  // print all failing nodes into logs
+  for (std::multimap<double, std::shared_ptr<FailingCriteria> >::const_reverse_iterator failingCriteriaIt = distanceToFailingCriteriaMap.crbegin();
+        failingCriteriaIt != distanceToFailingCriteriaMap.crend();
+        ++failingCriteriaIt) {
+    failingCriteriaIt->second->printOneFailingCriteriaIntoLog();
+  }
+
+  // print the 5 worst nodes in the timeline
+  if (timeline != nullptr) {
+    constexpr size_t failingCriteriaNumber = 5;
+    const size_t maxFailingCritArraySize = std::min(failingCriteriaNumber, distanceToFailingCriteriaMap.size());
+    std::multimap<double, std::shared_ptr<FailingCriteria> >::const_reverse_iterator worstFailingCriteriaBound = distanceToFailingCriteriaMap.crbegin();
+    std::advance(worstFailingCriteriaBound, maxFailingCritArraySize);
+    for (std::multimap<double, std::shared_ptr<FailingCriteria> >::const_reverse_iterator failingCriteriaIt = distanceToFailingCriteriaMap.crbegin();
+          failingCriteriaIt != worstFailingCriteriaBound;
+          ++failingCriteriaIt) {
+      failingCriteriaIt->second->printOneFailingCriteriaIntoTimeline(timeline, currentTime);
+    }
+  }
+}
+
+Criteria::FailingCriteria::FailingCriteria(Bound bound, std::string nodeId, const std::string& criteriaId) :
+  bound_(bound),
+  nodeId_(nodeId),
+  criteriaId_(criteriaId) {}
 
 BusCriteria::BusCriteria(const boost::shared_ptr<criteria::CriteriaParams>& params) :
             Criteria(params) {}
@@ -32,11 +61,12 @@ BusCriteria::BusCriteria(const boost::shared_ptr<criteria::CriteriaParams>& para
 BusCriteria::~BusCriteria() {}
 
 bool
-BusCriteria::checkCriteria(double t, bool finalStep) {
+BusCriteria::checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline) {
   failingCriteria_.clear();
   assert(params_->getType() != criteria::CriteriaParams::SUM);
   if (!finalStep && params_->getScope() == criteria::CriteriaParams::FINAL)
     return true;
+  std::multimap<double, std::shared_ptr<FailingCriteria> > distanceToBusFailingCriteriaMap;
   for (std::vector<boost::shared_ptr<BusInterface> >::const_iterator it = buses_.begin(), itEnd = buses_.end();
       it != itEnd; ++it) {
     double v = (*it)->getStateVarV();
@@ -46,19 +76,34 @@ BusCriteria::checkCriteria(double t, bool finalStep) {
     const criteria::CriteriaParamsVoltageLevel& vl = params_->getVoltageLevels()[0];
     double vNom = (*it)->getVNom();
     if (vl.hasUMaxPu() && v > vl.getUMaxPu()*vNom) {
+      std::shared_ptr<FailingCriteria> busFailingCriteria(new BusFailingCriteria(Bound::MAX,
+                                                                                  (*it)->getID(),
+                                                                                  v,
+                                                                                  v/vNom,
+                                                                                  vl.getUMaxPu()*vNom,
+                                                                                  vl.getUMaxPu(),
+                                                                                  params_->getId()));
+      distanceToBusFailingCriteriaMap.insert({busFailingCriteria->getDistance(), busFailingCriteria});
       Message mess = DYNLog(BusAboveVoltage, (*it)->getID(), v, v/vNom, vl.getUMaxPu()*vNom, vl.getUMaxPu(), params_->getId());
-      Trace::info() << mess << Trace::endline;
       failingCriteria_.push_back(std::make_pair(t, mess.str()));
-      return false;
     }
     if (vl.hasUMinPu() && v < vl.getUMinPu()*vNom) {
+      std::shared_ptr<FailingCriteria> busFailingCriteria(new BusFailingCriteria(Bound::MIN,
+                                                                                  (*it)->getID(),
+                                                                                  v,
+                                                                                  v/vNom,
+                                                                                  vl.getUMinPu()*vNom,
+                                                                                  vl.getUMinPu(),
+                                                                                  params_->getId()));
+      distanceToBusFailingCriteriaMap.insert({busFailingCriteria->getDistance(), busFailingCriteria});
       Message mess = DYNLog(BusUnderVoltage, (*it)->getID(), v, v/vNom, vl.getUMinPu()*vNom, vl.getUMinPu(), params_->getId());
-      Trace::info() << mess << Trace::endline;
       failingCriteria_.push_back(std::make_pair(t, mess.str()));
-      return false;
     }
   }
-  return true;
+  if (!distanceToBusFailingCriteriaMap.empty()) {
+    printAllFailingCriteriaIntoLog(distanceToBusFailingCriteriaMap, timeline, t);
+  }
+  return distanceToBusFailingCriteriaMap.empty();
 }
 
 bool
@@ -94,22 +139,73 @@ BusCriteria::addBus(const boost::shared_ptr<BusInterface>& bus) {
   buses_.push_back(bus);
 }
 
+BusCriteria::BusFailingCriteria::BusFailingCriteria(Bound bound,
+                                                    std::string busId,
+                                                    double v,
+                                                    double vPu,
+                                                    double vBound,
+                                                    double vBoundPu,
+                                                    const std::string& criteriaId) :
+  FailingCriteria(bound, busId, criteriaId),
+  v_(v),
+  vPu_(vPu),
+  vBound_(vBound),
+  vBoundPu_(vBoundPu) {}
+
+void
+BusCriteria::BusFailingCriteria::printOneFailingCriteriaIntoLog() const {
+  switch (bound_) {
+    case DYN::Criteria::Bound::MAX:
+      {
+        Trace::debug() << DYNLog(BusAboveVoltage, nodeId_, v_, vPu_, vBound_, vBoundPu_, criteriaId_) << Trace::endline;
+      }
+      break;
+    case DYN::Criteria::Bound::MIN:
+      {
+        Trace::debug() << DYNLog(BusUnderVoltage, nodeId_, v_, vPu_, vBound_, vBoundPu_, criteriaId_) << Trace::endline;
+      }
+      break;
+  }
+}
+
+void
+BusCriteria::BusFailingCriteria::printOneFailingCriteriaIntoTimeline(const boost::shared_ptr<timeline::Timeline>& timeline,
+                                                                      double currentTime) const {
+  if (timeline != nullptr) {
+    const std::string name = "Simulation";
+    switch (bound_) {
+    case DYN::Criteria::Bound::MAX:
+      {
+        MessageTimeline messageTimeline = DYNTimeline(BusAboveVoltage, nodeId_, v_, vPu_, vBound_, vBoundPu_, criteriaId_);
+        timeline->addEvent(currentTime, name, messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+      break;
+    case DYN::Criteria::Bound::MIN:
+      {
+        MessageTimeline messageTimeline = DYNTimeline(BusUnderVoltage, nodeId_, v_, vPu_, vBound_, vBoundPu_, criteriaId_);
+        timeline->addEvent(currentTime, name, messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+      break;
+    }
+  }
+}
+
 LoadCriteria::LoadCriteria(const boost::shared_ptr<criteria::CriteriaParams>& params) :
                 Criteria(params) {}
 
 LoadCriteria::~LoadCriteria() {}
 
 bool
-LoadCriteria::checkCriteria(double t, bool finalStep) {
+LoadCriteria::checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline) {
   failingCriteria_.clear();
   if (!finalStep && params_->getScope() == criteria::CriteriaParams::FINAL)
     return true;
   double sum = 0.;
-#ifdef _DEBUG_
-  std::vector<boost::shared_ptr<LoadInterface> > sourcesAddedIntoSum;
-#endif
+  std::multimap<double, boost::shared_ptr<LoadInterface> > loadToSourcesAddedIntoSumMap;
   bool atLeastOneEligibleLoadWasFound = false;
   boost::unordered_set<std::string> alreadySummed;
+  bool isCriteriaOk = true;
+  std::multimap<double, std::shared_ptr<FailingCriteria> > distanceToLoadFailingCriteriaMap;
   for (std::vector<criteria::CriteriaParamsVoltageLevel>::const_iterator itVl = params_->getVoltageLevels().begin(),
       itVlEnd = params_->getVoltageLevels().end();
       itVl != itVlEnd; ++itVl) {
@@ -125,21 +221,29 @@ LoadCriteria::checkCriteria(double t, bool finalStep) {
       }
       if (params_->getType() == criteria::CriteriaParams::LOCAL_VALUE) {
         if (params_->hasPMax() && p > params_->getPMax()) {
+          std::shared_ptr<FailingCriteria> loadFailingCriteria(new LoadFailingCriteria(Bound::MAX,
+                                                                (*it)->getID(),
+                                                                p,
+                                                                params_->getPMax(),
+                                                                params_->getId()));
+          distanceToLoadFailingCriteriaMap.insert({loadFailingCriteria->getDistance(), loadFailingCriteria});
           Message mess = DYNLog(SourceAbovePower, (*it)->getID(), p, params_->getPMax(), params_->getId());
-          Trace::info() << mess << Trace::endline;
           failingCriteria_.push_back(std::make_pair(t, mess.str()));
-          return false;
+          isCriteriaOk &= false;
         }
         if (params_->hasPMin() && p < params_->getPMin()) {
+          std::shared_ptr<FailingCriteria> loadFailingCriteria(new LoadFailingCriteria(Bound::MIN,
+                                                                (*it)->getID(),
+                                                                p,
+                                                                params_->getPMin(),
+                                                                params_->getId()));
+          distanceToLoadFailingCriteriaMap.insert({loadFailingCriteria->getDistance(), loadFailingCriteria});
           Message mess = DYNLog(SourceUnderPower, (*it)->getID(), p, params_->getPMin(), params_->getId());
-          Trace::info() << mess << Trace::endline;
           failingCriteria_.push_back(std::make_pair(t, mess.str()));
-          return false;
+          isCriteriaOk &= false;
         }
       } else {
-#ifdef _DEBUG_
-        sourcesAddedIntoSum.push_back(*it);
-#endif
+        loadToSourcesAddedIntoSumMap.insert({p, *it});
         if (alreadySummed.find((*it)->getID()) != alreadySummed.end()) continue;
         alreadySummed.insert((*it)->getID());
         sum+=p;
@@ -148,34 +252,48 @@ LoadCriteria::checkCriteria(double t, bool finalStep) {
     }
   }
 
-  if (atLeastOneEligibleLoadWasFound && params_->getType() == criteria::CriteriaParams::SUM) {
+  if (params_->getType() == criteria::CriteriaParams::LOCAL_VALUE && !isCriteriaOk) {
+    printAllFailingCriteriaIntoLog(distanceToLoadFailingCriteriaMap, timeline, t);
+  } else if (params_->getType() == criteria::CriteriaParams::SUM && atLeastOneEligibleLoadWasFound) {
     if (params_->hasPMax() && sum > params_->getPMax()) {
-#ifdef _DEBUG_
-  for (size_t i = 0; i < sourcesAddedIntoSum.size(); ++i) {
-    Trace::info() << DYNLog(SourcePowerTakenIntoAccount, "load", sourcesAddedIntoSum[i]->getID(), params_->getId(),
-        sourcesAddedIntoSum[i]->getP(), sourcesAddedIntoSum[i]->getBusInterface()->getStateVarV()) << Trace::endline;
-  }
-#endif
-      Message mess = DYNLog(SourcePowerAboveMax, sum, params_->getPMax(), params_->getId());
-      Trace::info() << mess << Trace::endline;
-      failingCriteria_.push_back(std::make_pair(t, mess.str()));
-      return false;
+      for (std::multimap<double, boost::shared_ptr<LoadInterface> >::const_reverse_iterator loadIt = loadToSourcesAddedIntoSumMap.crbegin();
+            loadIt != loadToSourcesAddedIntoSumMap.crend();
+            ++loadIt) {
+        Trace::debug() << DYNLog(SourcePowerTakenIntoAccount, "load", loadIt->second->getID(), params_->getId(),
+            loadIt->second->getP(), loadIt->second->getBusInterface()->getStateVarV()) << Trace::endline;
+      }
+
+      if (timeline != nullptr) {
+        MessageTimeline messageTimeline = DYNTimeline(SourcePowerAboveMax, sum, params_->getPMax(), params_->getId());
+        timeline->addEvent(t, "Simulation", messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+
+      Message messageLog = DYNLog(SourcePowerAboveMax, sum, params_->getPMax(), params_->getId());
+      Trace::info() << messageLog << Trace::endline;
+      failingCriteria_.push_back(std::make_pair(t, messageLog.str()));
+      isCriteriaOk &= false;
     }
     if (params_->hasPMin() && sum < params_->getPMin()) {
-#ifdef _DEBUG_
-  for (size_t i = 0; i < sourcesAddedIntoSum.size(); ++i) {
-    Trace::info() << DYNLog(SourcePowerTakenIntoAccount, "load", sourcesAddedIntoSum[i]->getID(), params_->getId(),
-        sourcesAddedIntoSum[i]->getP(), sourcesAddedIntoSum[i]->getBusInterface()->getStateVarV()) << Trace::endline;
-  }
-#endif
-      Message mess = DYNLog(SourcePowerBelowMin, sum, params_->getPMin(), params_->getId());
-      Trace::info() << mess << Trace::endline;
-      failingCriteria_.push_back(std::make_pair(t, mess.str()));
-      return false;
+      for (std::multimap<double, boost::shared_ptr<LoadInterface> >::const_iterator loadIt = loadToSourcesAddedIntoSumMap.cbegin();
+            loadIt != loadToSourcesAddedIntoSumMap.cend();
+            ++loadIt) {
+        Trace::debug() << DYNLog(SourcePowerTakenIntoAccount, "load", loadIt->second->getID(), params_->getId(),
+            loadIt->second->getP(), loadIt->second->getBusInterface()->getStateVarV()) << Trace::endline;
+      }
+
+      if (timeline != nullptr) {
+        MessageTimeline messageTimeline = DYNTimeline(SourcePowerBelowMin, sum, params_->getPMin(), params_->getId());
+        timeline->addEvent(t, "Simulation", messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+
+      Message messageLog = DYNLog(SourcePowerBelowMin, sum, params_->getPMin(), params_->getId());
+      Trace::info() << messageLog << Trace::endline;
+      failingCriteria_.push_back(std::make_pair(t, messageLog.str()));
+      isCriteriaOk &= false;
     }
   }
 
-  return true;
+  return isCriteriaOk;
 }
 
 bool
@@ -203,22 +321,69 @@ LoadCriteria::addLoad(const boost::shared_ptr<LoadInterface>& load) {
   }
 }
 
+LoadCriteria::LoadFailingCriteria::LoadFailingCriteria(Bound bound,
+                                                        std::string loadId,
+                                                        double p,
+                                                        double pBound,
+                                                        const std::string& criteriaId) :
+  FailingCriteria(bound, loadId, criteriaId),
+  p_(p),
+  pBound_(pBound) {}
+
+void
+LoadCriteria::LoadFailingCriteria::printOneFailingCriteriaIntoLog() const {
+  switch (bound_) {
+    case DYN::Criteria::Bound::MAX:
+      {
+        Trace::debug() << DYNTimeline(SourceAbovePower, nodeId_, p_, pBound_, criteriaId_) << Trace::endline;
+      }
+      break;
+    case DYN::Criteria::Bound::MIN:
+      {
+        Trace::debug() << DYNTimeline(SourceUnderPower, nodeId_, p_, pBound_, criteriaId_) << Trace::endline;
+      }
+      break;
+  }
+}
+
+void
+LoadCriteria::LoadFailingCriteria::printOneFailingCriteriaIntoTimeline(const boost::shared_ptr<timeline::Timeline>& timeline,
+                                                                      double currentTime) const {
+  if (timeline != nullptr) {
+    const std::string name = "Simulation";
+    switch (bound_) {
+    case DYN::Criteria::Bound::MAX:
+      {
+        MessageTimeline messageTimeline = DYNTimeline(SourceAbovePower, nodeId_, p_, pBound_, criteriaId_);
+        timeline->addEvent(currentTime, name, messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+      break;
+    case DYN::Criteria::Bound::MIN:
+      {
+        MessageTimeline messageTimeline = DYNTimeline(SourceUnderPower, nodeId_, p_, pBound_, criteriaId_);
+        timeline->addEvent(currentTime, name, messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+      break;
+    }
+  }
+}
+
 GeneratorCriteria::GeneratorCriteria(const boost::shared_ptr<criteria::CriteriaParams>& params) :
                 Criteria(params) {}
 
 GeneratorCriteria::~GeneratorCriteria() {}
 
 bool
-GeneratorCriteria::checkCriteria(double t, bool finalStep) {
+GeneratorCriteria::checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline) {
   failingCriteria_.clear();
   if (!finalStep && params_->getScope() == criteria::CriteriaParams::FINAL)
     return true;
   double sum = 0.;
-#ifdef _DEBUG_
-  std::vector<boost::shared_ptr<GeneratorInterface> > sourcesAddedIntoSum;
-#endif
+  std::multimap<double, boost::shared_ptr<GeneratorInterface> > generatorToSourcesAddedIntoSumMap;
   bool atLeastOneEligibleGeneratorWasFound = false;
   boost::unordered_set<std::string> alreadySummed;
+  bool isCriteriaOk = true;
+  std::multimap<double, std::shared_ptr<FailingCriteria> > distanceToGeneratorFailingCriteriaMap;
   for (std::vector<criteria::CriteriaParamsVoltageLevel>::const_iterator itVl = params_->getVoltageLevels().begin(),
       itVlEnd = params_->getVoltageLevels().end();
       itVl != itVlEnd; ++itVl) {
@@ -234,21 +399,29 @@ GeneratorCriteria::checkCriteria(double t, bool finalStep) {
       }
       if (params_->getType() == criteria::CriteriaParams::LOCAL_VALUE) {
         if (params_->hasPMax() && p > params_->getPMax()) {
+          std::shared_ptr<FailingCriteria> generatorFailingCriteria(new LoadCriteria::LoadFailingCriteria(Bound::MAX,
+                                                                                                          (*it)->getID(),
+                                                                                                          p,
+                                                                                                          params_->getPMax(),
+                                                                                                          params_->getId()));
+          distanceToGeneratorFailingCriteriaMap.insert({generatorFailingCriteria->getDistance(), generatorFailingCriteria});
           Message mess = DYNLog(SourceAbovePower, (*it)->getID(), p, params_->getPMax(), params_->getId());
-          Trace::info() << mess << Trace::endline;
           failingCriteria_.push_back(std::make_pair(t, mess.str()));
-          return false;
+          isCriteriaOk &= false;
         }
         if (params_->hasPMin() && p < params_->getPMin()) {
+          std::shared_ptr<FailingCriteria> generatorFailingCriteria(new LoadCriteria::LoadFailingCriteria(Bound::MIN,
+                                                                                                          (*it)->getID(),
+                                                                                                          p,
+                                                                                                          params_->getPMin(),
+                                                                                                          params_->getId()));
+          distanceToGeneratorFailingCriteriaMap.insert({generatorFailingCriteria->getDistance(), generatorFailingCriteria});
           Message mess = DYNLog(SourceUnderPower, (*it)->getID(), p, params_->getPMin(), params_->getId());
-          Trace::info() << mess << Trace::endline;
           failingCriteria_.push_back(std::make_pair(t, mess.str()));
-          return false;
+          isCriteriaOk &= false;
         }
       } else {
-#ifdef _DEBUG_
-        sourcesAddedIntoSum.push_back(*it);
-#endif
+        generatorToSourcesAddedIntoSumMap.insert({p, *it});
         if (alreadySummed.find((*it)->getID()) != alreadySummed.end()) continue;
         alreadySummed.insert((*it)->getID());
         sum+=p;
@@ -257,34 +430,48 @@ GeneratorCriteria::checkCriteria(double t, bool finalStep) {
     }
   }
 
-  if (atLeastOneEligibleGeneratorWasFound && params_->getType() == criteria::CriteriaParams::SUM) {
+  if (params_->getType() == criteria::CriteriaParams::LOCAL_VALUE && !isCriteriaOk) {
+    printAllFailingCriteriaIntoLog(distanceToGeneratorFailingCriteriaMap, timeline, t);
+  } else if (params_->getType() == criteria::CriteriaParams::SUM && atLeastOneEligibleGeneratorWasFound) {
     if (params_->hasPMax() && sum > params_->getPMax()) {
-#ifdef _DEBUG_
-  for (size_t i = 0; i < sourcesAddedIntoSum.size(); ++i) {
-    Trace::info() << DYNLog(SourcePowerTakenIntoAccount, "generator", sourcesAddedIntoSum[i]->getID(), params_->getId(),
-        sourcesAddedIntoSum[i]->getP(), sourcesAddedIntoSum[i]->getBusInterface()->getStateVarV()) << Trace::endline;
-  }
-#endif
-      Message mess = DYNLog(SourcePowerAboveMax, sum, params_->getPMax(), params_->getId());
-      Trace::info() << mess << Trace::endline;
-      failingCriteria_.push_back(std::make_pair(t, mess.str()));
-      return false;
+      for (std::multimap<double, boost::shared_ptr<GeneratorInterface> >::const_reverse_iterator generatorIt = generatorToSourcesAddedIntoSumMap.crbegin();
+            generatorIt != generatorToSourcesAddedIntoSumMap.crend();
+            ++generatorIt) {
+        Trace::info() << DYNLog(SourcePowerTakenIntoAccount, "generator", generatorIt->second->getID(), params_->getId(),
+          generatorIt->second->getP(), generatorIt->second->getBusInterface()->getStateVarV()) << Trace::endline;
+      }
+
+      if (timeline != nullptr) {
+        MessageTimeline messageTimeline = DYNTimeline(SourcePowerAboveMax, sum, params_->getPMax(), params_->getId());
+        timeline->addEvent(t, "Simulation", messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+
+      Message messageLog = DYNLog(SourcePowerAboveMax, sum, params_->getPMax(), params_->getId());
+      Trace::info() << messageLog << Trace::endline;
+      failingCriteria_.push_back(std::make_pair(t, messageLog.str()));
+      isCriteriaOk &= false;
     }
     if (params_->hasPMin() && sum < params_->getPMin()) {
-#ifdef _DEBUG_
-  for (size_t i = 0; i < sourcesAddedIntoSum.size(); ++i) {
-    Trace::info() << DYNLog(SourcePowerTakenIntoAccount, "generator", sourcesAddedIntoSum[i]->getID(), params_->getId(),
-        sourcesAddedIntoSum[i]->getP(), sourcesAddedIntoSum[i]->getBusInterface()->getStateVarV()) << Trace::endline;
-  }
-#endif
+      for (std::multimap<double, boost::shared_ptr<GeneratorInterface> >::const_iterator generatorIt = generatorToSourcesAddedIntoSumMap.cbegin();
+            generatorIt != generatorToSourcesAddedIntoSumMap.cend();
+            ++generatorIt) {
+        Trace::debug() << DYNLog(SourcePowerTakenIntoAccount, "generator", generatorIt->second->getID(), params_->getId(),
+            generatorIt->second->getP(), generatorIt->second->getBusInterface()->getStateVarV()) << Trace::endline;
+      }
+
+      if (timeline != nullptr) {
+        MessageTimeline messageTimeline = DYNTimeline(SourcePowerBelowMin, sum, params_->getPMin(), params_->getId());
+        timeline->addEvent(t, "Simulation", messageTimeline.str(), messageTimeline.priority(), messageTimeline.getKey());
+      }
+
       Message mess = DYNLog(SourcePowerBelowMin, sum, params_->getPMin(), params_->getId());
       Trace::info() << mess << Trace::endline;
       failingCriteria_.push_back(std::make_pair(t, mess.str()));
-      return false;
+      isCriteriaOk &= false;
     }
   }
 
-  return true;
+  return isCriteriaOk;
 }
 
 bool

--- a/dynawo/sources/Modeler/DataInterface/DYNCriteria.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNCriteria.h
@@ -19,6 +19,8 @@
 #include "DYNBusInterface.h"
 #include "DYNLoadInterface.h"
 #include "DYNGeneratorInterface.h"
+#include "TLTimeline.h"
+#include <map>
 
 namespace DYN {
 
@@ -42,10 +44,11 @@ class Criteria {
    * @brief returns true if the criteria is respected, false otherwise
    * @param t current time of the simulation
    * @param finalStep true if this is the final step of the simulation
+   * @param timeline timeline
    *
    * @return true if the criteria is respected, false otherwise
    */
-  virtual bool checkCriteria(double t, bool finalStep) = 0;
+  virtual bool checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline = nullptr) = 0;
 
   /**
    * @brief returns the list of failing criteria
@@ -55,6 +58,67 @@ class Criteria {
   const std::vector<std::pair<double, std::string> >& getFailingCriteria() const {return failingCriteria_;}
 
  protected:
+  /**
+   * @brief Crossed bound for a failing criteria
+   */
+  enum class Bound {
+    MAX = 0,  ///< Upper bound
+    MIN       ///< Lower bound
+  };
+  /**
+   * @brief structure containing information about a failing criteria and related methods
+   */
+  class FailingCriteria {
+   public:
+    /**
+     * @brief constructor
+     * @param bound Crossed bound for a failing criteria
+     * @param nodeId Node id
+     * @param criteriaId Criteria id
+     */
+    FailingCriteria(Bound bound, std::string nodeId, const std::string& criteriaId);
+
+    /**
+     * @brief Destructor
+     */
+    virtual ~FailingCriteria() = default;
+
+    /**
+     * @brief return the distance between the current value tested and the threshold
+     * @return the distance between the current value tested and the threshold
+     */
+    virtual double getDistance() const = 0;
+
+    /**
+     * @brief print the failing criteria log in the log file
+     */
+    virtual void printOneFailingCriteriaIntoLog() const = 0;
+
+    /**
+     * @brief print the failing criteria log in the timeline file
+     * @param timeline timeline
+     * @param currentTime current simulation time
+     */
+    virtual void printOneFailingCriteriaIntoTimeline(const boost::shared_ptr<timeline::Timeline>& timeline,
+                                                      double currentTime) const = 0;
+
+   protected:
+    Bound bound_;                   // Crossed bound : min or max
+    std::string nodeId_;            // node id
+    const std::string criteriaId_;  // criteria id
+  };
+
+  /**
+   * @brief print all the failing criteria in the log file and the timeline file
+   * @param distanceToFailingCriteriaMap map which contains the distance between a specific value and the crossed
+   *                                      criteria bound and the related FailingCriteria object
+   * @param timeline timeline
+   * @param currentTime current simulation time
+   */
+  void printAllFailingCriteriaIntoLog(std::multimap<double, std::shared_ptr<FailingCriteria> >& distanceToFailingCriteriaMap,
+                                      const boost::shared_ptr<timeline::Timeline>& timeline,
+                                      double currentTime) const;
+
   const boost::shared_ptr<criteria::CriteriaParams>& params_;  ///< parameters of this criteria
   std::vector<std::pair<double, std::string> > failingCriteria_;  ///< keeps the ids of the failing criteria
 };
@@ -86,10 +150,11 @@ class BusCriteria : public Criteria {
    * @brief returns true if the criteria is respected, false otherwise
    * @param t current time of the simulation
    * @param finalStep true if this is the final step of the simulation
+   * @param timeline timeline
    *
    * @return true if the criteria is respected, false otherwise
    */
-  bool checkCriteria(double t, bool finalStep);
+  bool checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline = nullptr);
 
   /**
    * @brief add a bus to the criteria
@@ -102,6 +167,55 @@ class BusCriteria : public Criteria {
    * @return true if no bus was added
    */
   bool empty() const {return buses_.empty();}
+
+  /**
+   * @brief structure containing information about a failing criteria on a bus and related methods
+   */
+  class BusFailingCriteria : public FailingCriteria {
+   public:
+    /**
+     * @brief Constructor
+     * @param bound Crossed bound for a failing criteria
+     * @param busId bud id
+     * @param v voltage in kV
+     * @param vPu voltage in pu
+     * @param vBound voltage bound in kV
+     * @param vBoundPu voltage bound in pu
+     * @param criteriaId criteria id
+     */
+    BusFailingCriteria(Bound bound,
+                        std::string busId,
+                        double v,
+                        double vPu,
+                        double vBound,
+                        double vBoundPu,
+                        const std::string& criteriaId);
+
+    /**
+     * @brief return the distance between the voltage in pu and the crossed criteria bound
+     * @return the distance between the voltage in pu and the crossed criteria bound
+     */
+    double getDistance() const override { return std::abs(vPu_ - vBoundPu_); }
+
+    /**
+     * @brief print the failing criteria log in the log file
+     */
+    void printOneFailingCriteriaIntoLog() const override;
+
+    /**
+     * @brief print the failing criteria log in the timeline file
+     * @param timeline timeline
+     * @param currentTime current simulation time
+     */
+    void printOneFailingCriteriaIntoTimeline(const boost::shared_ptr<timeline::Timeline>& timeline,
+                                              double currentTime) const override;
+
+   private:
+    double v_;                      // bus voltage in kV
+    double vPu_;                    // bus voltage in pu
+    double vBound_;                 // bus voltage limit in kV
+    double vBoundPu_;               // bus voltage limit in pu
+  };
 
  private:
   std::vector<boost::shared_ptr<BusInterface> > buses_;  ///< buses of this criteria
@@ -135,10 +249,11 @@ class LoadCriteria : public Criteria {
    * @brief returns true if the criteria is respected, false otherwise
    * @param t current time of the simulation
    * @param finalStep true if this is the final step of the simulation
+   * @param timeline timeline
    *
    * @return true if the criteria is respected, false otherwise
    */
-  bool checkCriteria(double t, bool finalStep);
+  bool checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline = nullptr);
 
   /**
    * @brief add a load to the criteria
@@ -151,6 +266,49 @@ class LoadCriteria : public Criteria {
    * @return true if no load was added
    */
   bool empty() const {return loads_.empty();}
+
+  /**
+   * @brief structure containing information about a failing criteria on a load and related methods
+   */
+  class LoadFailingCriteria : public FailingCriteria {
+   public:
+    /**
+     * @brief Constructor
+     * @param bound Crossed bound for a failing criteria
+     * @param loadId load id
+     * @param p load power in MW
+     * @param pBound load power bound in MW
+     * @param criteriaId criteria id
+     */
+    LoadFailingCriteria(Bound bound,
+                        std::string loadId,
+                        double p,
+                        double pBound,
+                        const std::string& criteriaId);
+
+    /**
+     * @brief return the distance between the load power in MW and the crossed criteria bound
+     * @return the distance between the load power in MW and the crossed criteria bound
+     */
+    double getDistance() const override { return std::abs(p_ - pBound_); }
+
+     /**
+     * @brief print the failing criteria log in the log file
+     */
+    void printOneFailingCriteriaIntoLog() const override;
+
+    /**
+     * @brief print the failing criteria log in the timeline file
+     * @param timeline timeline
+     * @param currentTime current simulation time
+     */
+    void printOneFailingCriteriaIntoTimeline(const boost::shared_ptr<timeline::Timeline>& timeline,
+                                              double currentTime) const override;
+
+   private:
+    double p_;                      // load power in MW
+    double pBound_;                 // load power limit in MW
+  };
 
  private:
   std::vector<boost::shared_ptr<LoadInterface> > loads_;  ///< loads of this criteria
@@ -184,10 +342,11 @@ class GeneratorCriteria : public Criteria {
    * @brief returns true if the criteria is respected, false otherwise
    * @param t current time of the simulation
    * @param finalStep true if this is the final step of the simulation
+   * @param timeline timeline
    *
    * @return true if the criteria is respected, false otherwise
    */
-  bool checkCriteria(double t, bool finalStep);
+  bool checkCriteria(double t, bool finalStep, const boost::shared_ptr<timeline::Timeline>& timeline = nullptr);
 
   /**
    * @brief add a generator to the criteria

--- a/dynawo/sources/Modeler/DataInterface/DYNDataInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNDataInterface.h
@@ -27,6 +27,7 @@
 #include "CRTCriteriaCollection.h"
 #include "LEQLostEquipmentsCollection.h"
 #include "DYNServiceManagerInterface.h"
+#include "TLTimeline.h"
 
 namespace DYN {
 class NetworkInterface;
@@ -214,6 +215,12 @@ class DataInterface {
   * @return do we need to instantiate the network
   */
   virtual bool instantiateNetwork() const = 0;
+
+  /**
+   * @brief Setter for timeline
+   * @param timeline timeline output
+   */
+  virtual void setTimeline(const boost::shared_ptr<timeline::Timeline>& timeline) = 0;
 };  ///< Class for data interface
 
 #ifdef __clang__

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNDataInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNDataInterfaceIIDM.cpp
@@ -1437,7 +1437,7 @@ DataInterfaceIIDM::checkCriteria(double t, bool finalStep) {
   bool criteriaOk = true;
   for (std::vector<boost::shared_ptr<Criteria> >::const_iterator it = criteria_.begin(), itEnd = criteria_.end();
       it != itEnd; ++it) {
-    criteriaOk &= (*it)->checkCriteria(t, finalStep);
+    criteriaOk &= (*it)->checkCriteria(t, finalStep, timeline_);
   }
 #ifdef _DEBUG_
   for (map<string, shared_ptr<ComponentInterface> >::iterator iter = components_.begin(); iter != components_.end(); ++iter) {
@@ -1469,6 +1469,11 @@ DataInterfaceIIDM::getStaticParameterIntValue(const std::string& staticID, const
 bool
 DataInterfaceIIDM::getStaticParameterBoolValue(const std::string& staticID, const std::string& refOrigName) {
   return findComponent(staticID)->getStaticParameterValue<bool>(refOrigName);
+}
+
+void
+DataInterfaceIIDM::setTimeline(const boost::shared_ptr<timeline::Timeline>& timeline) {
+  timeline_ = timeline;
 }
 
 void

--- a/dynawo/sources/Modeler/DataInterface/IIDM/DYNDataInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/IIDM/DYNDataInterfaceIIDM.h
@@ -432,6 +432,12 @@ class DataInterfaceIIDM : public DataInterfaceImpl {
   void configureGeneratorCriteria(const boost::shared_ptr<criteria::CriteriaCollection>& criteria);
 
   /**
+   * @brief Setter for timeline
+   * @param timeline timeline output
+   */
+  void setTimeline(const boost::shared_ptr<timeline::Timeline>& timeline);
+
+  /**
    * @brief Copy data interface info
    *
    * This does NOT copy criteria and IIDM network
@@ -469,6 +475,7 @@ class DataInterfaceIIDM : public DataInterfaceImpl {
   std::map<std::string, boost::shared_ptr<GeneratorInterface> > generatorComponents_;  ///< map of generators by name
   std::map<std::string, std::vector<boost::shared_ptr<CalculatedBusInterfaceIIDM> > > calculatedBusComponents_;  ///< calculatedBus per voltageLevel
   std::vector<boost::shared_ptr<Criteria> > criteria_;  ///< table of criteria to check
+  boost::shared_ptr<timeline::Timeline> timeline_;  ///< instance of the timeline where events are stored
   boost::shared_ptr<ServiceManagerInterfaceIIDM> serviceManager_;  ///< Service manager
 };  ///< Generic data interface for IIDM format files
 }  // namespace DYN

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.cpp
@@ -1153,7 +1153,7 @@ DataInterfaceIIDM::checkCriteria(double t, bool finalStep) {
   bool criteriaOk = true;
   for (std::vector<boost::shared_ptr<Criteria> >::const_iterator it = criteria_.begin(), itEnd = criteria_.end();
       it != itEnd; ++it) {
-    criteriaOk &= (*it)->checkCriteria(t, finalStep);
+    criteriaOk &= (*it)->checkCriteria(t, finalStep, timeline_);
   }
 #ifdef _DEBUG_
   for (boost::unordered_map<string, shared_ptr<ComponentInterface> >::iterator iter = components_.begin(); iter != components_.end(); ++iter) {
@@ -1185,6 +1185,11 @@ DataInterfaceIIDM::getStaticParameterIntValue(const std::string& staticID, const
 bool
 DataInterfaceIIDM::getStaticParameterBoolValue(const std::string& staticID, const std::string& refOrigName) {
   return findComponent(staticID)->getStaticParameterValue<bool>(refOrigName);
+}
+
+void
+DataInterfaceIIDM::setTimeline(const boost::shared_ptr<timeline::Timeline>& timeline) {
+  timeline_ = timeline;
 }
 
 void

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.h
@@ -452,14 +452,21 @@ class DataInterfaceIIDM : public DataInterfaceImpl {
    */
   static void loadExtensions(const std::vector<std::string>& paths);
 
+  /**
+   * @brief Setter for timeline
+   * @param timeline timeline output
+   */
+  void setTimeline(const boost::shared_ptr<timeline::Timeline>& timeline);
+
  private:
-  boost::shared_ptr<powsybl::iidm::Network> networkIIDM_;                                              ///< instance of the IIDM network
-  boost::shared_ptr<NetworkInterfaceIIDM> network_;                                                    ///< instance of the network interface
-  boost::unordered_map<std::string, boost::shared_ptr<ComponentInterface> > components_;               ///< map of components
+  boost::shared_ptr<powsybl::iidm::Network> networkIIDM_;                                          ///< instance of the IIDM network
+  boost::shared_ptr<NetworkInterfaceIIDM> network_;                                                ///< instance of the network interface
+  boost::unordered_map<std::string, boost::shared_ptr<ComponentInterface> > components_;           ///< map of components
   boost::unordered_map<std::string, boost::shared_ptr<VoltageLevelInterface> > voltageLevels_;     ///< map of voltageLevel by name
   boost::unordered_map<std::string, boost::shared_ptr<BusInterface> > busComponents_;              ///< map of bus by name
-  boost::unordered_map<std::string, boost::shared_ptr<LoadInterfaceIIDM> > loadComponents_;            ///< map of loads by name
-  std::vector<boost::shared_ptr<Criteria> > criteria_;                                                 ///< table of criteria to check
+  boost::unordered_map<std::string, boost::shared_ptr<LoadInterfaceIIDM> > loadComponents_;        ///< map of loads by name
+  std::vector<boost::shared_ptr<Criteria> > criteria_;                                             ///< table of criteria to check
+  boost::shared_ptr<timeline::Timeline> timeline_;                                                 ///< instance of the timeline where events are stored
   boost::unordered_map<std::string, boost::shared_ptr<GeneratorInterface> > generatorComponents_;  ///< map of generators by name
   boost::unordered_map<std::string, std::vector<boost::shared_ptr<CalculatedBusInterfaceIIDM> > > calculatedBusComponents_;  ///< calculatedBus per voltageLevel
   boost::shared_ptr<ServiceManagerInterfaceIIDM> serviceManager_;  ///< Service manager

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/test/CMakeLists.txt
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(${MODULE_NAME} ${MODULE_SOURCES})
 target_link_libraries(${MODULE_NAME}
   dynawo_API_PAR
   dynawo_API_CRT
+  dynawo_API_TL
   dynawo_ModelerCommon
   dynawo_DataInterfaceIIDM
   dynawo_DataInterface

--- a/dynawo/sources/Simulation/DYNSimulation.cpp
+++ b/dynawo/sources/Simulation/DYNSimulation.cpp
@@ -596,6 +596,8 @@ Simulation::loadDynamicData() {
 
   data_->importStaticParameters();  // Import static model's parameters' values into DataInterface, these values are useful for referece parameters.
 
+  data_->setTimeline(timeline_);
+
   dyd_->setDataInterface(data_);
 
   dyd_->initFromDydFiles(dydFiles_);


### PR DESCRIPTION
…iteria in the timeline in descending order and dump of all the info in the logs in DEBUG severity level

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [x] unit tests and non regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
- [ ] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
