### PR TITLE
#2721 avoid adept to fail when GeneratorPVTfo is disconnected

### DIFF
--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNDataInterfaceIIDM.cpp
@@ -106,7 +106,6 @@ DataInterfaceIIDM::build(const std::string& iidmFilePath, unsigned int nbVariant
   boost::shared_ptr<DataInterfaceIIDM>  data;
   try {
     stdcxx::Properties properties;
-    properties.set(powsybl::iidm::converter::ImportOptions::THROW_EXCEPTION_IF_EXTENSION_NOT_FOUND, "true");
     powsybl::iidm::converter::ImportOptions options(properties);
 
     std::string extensionsPaths = getMandatoryEnvVar("DYNAWO_LIBIIDM_EXTENSIONS");

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVTfo.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVTfo.mo
@@ -76,12 +76,13 @@ equation
     else
       UStatorPu = UStatorRefPu;
     end if;
+    UStatorPu = ComplexMath.'abs'(uStatorPu);
   else
     terminal.i.im = 0;
+    UStatorPu = 0;
   end if;
 
   uStatorPu = 1 / rTfoPu * (terminal.V - terminal.i * Complex(RTfoPu, XTfoPu) * SystemBase.SnRef / SNom);
-  UStatorPu = ComplexMath.'abs'(uStatorPu);
   iStatorPu = - rTfoPu * terminal.i * SystemBase.SnRef / SNom;
   sStatorPu = uStatorPu * ComplexMath.conj(iStatorPu);
   QStatorPu = sStatorPu.im * SNom / QNomAlt;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVTfoDiagramPQ.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/GeneratorPVTfoDiagramPQ.mo
@@ -91,12 +91,13 @@ equation
     else
       UStatorPu = UStatorRefPu;
     end if;
+    UStatorPu = ComplexMath.'abs'(uStatorPu);
   else
     terminal.i.im = 0;
+    UStatorPu = 0;
   end if;
 
   uStatorPu = 1 / rTfoPu * (terminal.V - terminal.i * Complex(RTfoPu, XTfoPu) * SystemBase.SnRef / SNom);
-  UStatorPu = ComplexMath.'abs'(uStatorPu);
   iStatorPu = - rTfoPu * terminal.i * SystemBase.SnRef / SNom;
   sStatorPu = uStatorPu * ComplexMath.conj(iStatorPu);
   QStatorPu = sStatorPu.im * SNom / QNomAlt;


### PR DESCRIPTION
closes #2721

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
- [ ] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
