### PR TITLE
#3117 New block combining rate limiter and limited first order, used …

### DIFF
--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Simplified/GoverNordic.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Simplified/GoverNordic.mo
@@ -42,14 +42,6 @@ model GoverNordic "Governor model for the Nordic 32 test system used for voltage
     Placement(visible = true, transformation(origin = {90, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Division flowDivGateOpening annotation(
     Placement(visible = true, transformation(origin = {30, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Math.Feedback feedback annotation(
-    Placement(visible = true, transformation(origin = {80, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Math.Gain gain(k = 5) annotation(
-    Placement(visible = true, transformation(origin = {130, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.Limiter limiter(uMax = 0.1) annotation(
-    Placement(visible = true, transformation(origin = {170, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Continuous.LimIntegrator limIntegrator(outMax = 1, outMin = 0, y_start = Pm0Pu) annotation(
-    Placement(visible = true, transformation(origin = {210, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add govOut annotation(
     Placement(visible = true, transformation(origin = {30, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain govKp(k = Kp) annotation(
@@ -76,6 +68,8 @@ model GoverNordic "Governor model for the Nordic 32 test system used for voltage
     Placement(visible = true, transformation(origin = {-180, 20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain perUnitP(k = SystemBase.SnRef / PNom) annotation(
     Placement(visible = true, transformation(origin = {-250, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Dynawo.NonElectrical.Blocks.NonLinear.LimRateLimFirstOrder limRateLimFirstOrder(DuMax = 0.1, Y0 = Pm0Pu, YMax = 1, YMin = 0, tS = 0.2) annotation(
+    Placement(visible = true, transformation(origin = {70, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
   parameter Types.ActivePowerPu Pm0Pu "Initial mechanical power in pu (base PNom)";
 
@@ -88,16 +82,8 @@ equation
     Line(points = {{-19, 40}, {0, 40}, {0, 54}, {18, 54}}, color = {0, 0, 127}));
   connect(govKi.y, govInt.u) annotation(
     Line(points = {{-59, 40}, {-42, 40}}, color = {0, 0, 127}));
-  connect(limiter.y, limIntegrator.u) annotation(
-    Line(points = {{181, 60}, {198, 60}}, color = {0, 0, 127}));
-  connect(gain.y, limiter.u) annotation(
-    Line(points = {{141, 60}, {158, 60}}, color = {0, 0, 127}));
-  connect(limIntegrator.y, flowDivGateOpening.u2) annotation(
-    Line(points = {{221, 60}, {240, 60}, {240, 0}, {-20, 0}, {-20, -86}, {18, -86}}, color = {0, 0, 127}));
   connect(product.y, PmPu) annotation(
     Line(points = {{261, -100}, {290, -100}}, color = {0, 0, 127}));
-  connect(feedback.y, gain.u) annotation(
-    Line(points = {{89, 60}, {118, 60}}, color = {0, 0, 127}));
   connect(govKp.y, govOut.u1) annotation(
     Line(points = {{-39, 80}, {0, 80}, {0, 66}, {18, 66}}, color = {0, 0, 127}));
   connect(dOmegaPlusDroop.y, govKp.u) annotation(
@@ -118,10 +104,6 @@ equation
     Line(points = {{-199, -20}, {-180, -20}, {-180, 12}}, color = {0, 0, 127}));
   connect(dP.y, dOmegaPlusDroop.u2) annotation(
     Line(points = {{-171, 20}, {-160, 20}, {-160, 34}, {-142, 34}}, color = {0, 0, 127}));
-  connect(govOut.y, feedback.u1) annotation(
-    Line(points = {{42, 60}, {72, 60}}, color = {0, 0, 127}));
-  connect(limIntegrator.y, feedback.u2) annotation(
-    Line(points = {{221, 60}, {240, 60}, {240, 20}, {80, 20}, {80, 52}}, color = {0, 0, 127}));
   connect(dH.y, waterFlow.u) annotation(
     Line(points = {{149, -40}, {177, -40}}, color = {0, 0, 127}));
   connect(waterFlow.y, product.u1) annotation(
@@ -136,8 +118,13 @@ equation
     Line(points = {{-300, -20}, {-262, -20}}, color = {0, 0, 127}));
   connect(perUnitP.y, firstOrder1.u) annotation(
     Line(points = {{-238, -20}, {-222, -20}}, color = {0, 0, 127}));
+  connect(govOut.y, limRateLimFirstOrder.u) annotation(
+    Line(points = {{42, 60}, {58, 60}}, color = {0, 0, 127}));
+  connect(limRateLimFirstOrder.y, flowDivGateOpening.u2) annotation(
+    Line(points = {{82, 60}, {100, 60}, {100, 0}, {-20, 0}, {-20, -86}, {18, -86}}, color = {0, 0, 127}));
 
-  annotation(preferredView = "diagram",
+  annotation(
+    preferredView = "diagram",
     Icon(graphics = {Rectangle(extent = {{-100, 100}, {100, -100}}), Text(origin = {0, 120}, lineColor = {0, 0, 255}, fillColor = {0, 0, 255}, extent = {{-60, 20}, {60, -20}}, textString = "%name"), Text(extent = {{-68, 66}, {68, -66}}, textString = "GOV")}, coordinateSystem(initialScale = 0.1)),
     Documentation(info = "<html><head></head><body>This model implements the speed control of the generator frames in the Nordic 32 test system used for voltage stability studies.<div>It consists of a turbine model (lower part) and a speed controller (upper part).&nbsp;</div></body></html>"),
     Diagram(coordinateSystem(extent = {{-280, -140}, {280, 140}})));

--- a/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/NonLinear/CMakeLists.txt
+++ b/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/NonLinear/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MODEL_FILES
   LimitedLeadLag.mo
   LimiterWithLag.mo
   LimiterWithLag_INIT.mo
+  LimRateLimFirstOrder.mo
   MaxThresholdSwitch.mo
   MinThresholdSwitch.mo
   MultiSwitch.mo

--- a/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/NonLinear/LimRateLimFirstOrder.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/NonLinear/LimRateLimFirstOrder.mo
@@ -1,0 +1,59 @@
+within Dynawo.NonElectrical.Blocks.NonLinear;
+
+/*
+* Copyright (c) 2024, RTE (http://www.rte-france.com)
+* See AUTHORS.txt
+* All rights reserved.
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, you can obtain one at http://mozilla.org/MPL/2.0/.
+* SPDX-License-Identifier: MPL-2.0
+*
+* This file is part of Dynawo, an hybrid C++/Modelica open source suite
+* of simulation tools for power systems.
+*/
+
+block LimRateLimFirstOrder "First-order filter with non-windup limiter and slew rate limiter"
+  extends Modelica.Blocks.Icons.Block;
+
+  parameter Types.PerUnit DuMax "Maximum rising slew rate";
+  parameter Types.PerUnit DuMin = -DuMax "Maximum falling slew rate";
+  parameter Types.Time tS "Integration time step in s";
+  parameter Real YMax "Upper limit of output signal";
+  parameter Real YMin = -YMax "Lower limit of output signal";
+
+  Modelica.Blocks.Interfaces.RealInput u annotation(
+    Placement(visible = true, transformation(origin = {-120, 0}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, 0}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput y(start = Y0) annotation(
+    Placement(visible = true, transformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+
+  Modelica.Blocks.Nonlinear.Limiter limiter(uMax = DuMax, uMin = DuMin) annotation(
+    Placement(visible = true, transformation(origin = {10, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Math.Feedback feedback annotation(
+    Placement(visible = true, transformation(origin = {-80, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Math.Gain gain(k = 1 / tS) annotation(
+    Placement(visible = true, transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Modelica.Blocks.Continuous.LimIntegrator limIntegrator(outMax = YMax, outMin = YMin, y_start = Y0) annotation(
+    Placement(visible = true, transformation(origin = {50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+
+  parameter Types.PerUnit Y0 "Initial value of output";
+
+equation
+  connect(u, feedback.u1) annotation(
+    Line(points = {{-120, 0}, {-94, 0}, {-94, 0}, {-88, 0}}, color = {0, 0, 127}));
+  connect(limIntegrator.y, y) annotation(
+    Line(points = {{62, 0}, {110, 0}}, color = {0, 0, 127}));
+  connect(limIntegrator.y, feedback.u2) annotation(
+    Line(points = {{62, 0}, {80, 0}, {80, -40}, {-80, -40}, {-80, -8}}, color = {0, 0, 127}));
+  connect(feedback.y, gain.u) annotation(
+    Line(points = {{-70, 0}, {-42, 0}}, color = {0, 0, 127}));
+  connect(gain.y, limiter.u) annotation(
+    Line(points = {{-18, 0}, {-2, 0}}, color = {0, 0, 127}));
+  connect(limiter.y, limIntegrator.u) annotation(
+    Line(points = {{22, 0}, {38, 0}}, color = {0, 0, 127}));
+
+  annotation(
+    preferredView = "diagram",
+    Icon(coordinateSystem(grid = {0.1, 0.1}, initialScale = 0.1), graphics = {Line(origin = {0, 1.05741}, points = {{-80, -121.057}, {-40, -121.057}, {42, 118.943}, {80, 118.943}}), Rectangle(lineColor = {0, 0, 127}, fillColor = {255, 255, 255}, fillPattern = FillPattern.Solid, extent = {{-100, 100}, {100, -100}}), Text(origin = {12, 28}, extent = {{-44, 34}, {26, -16}}, textString = "k"), Text(origin = {2, -44}, extent = {{-60, 22}, {60, -22}}, textString = "1 + sT"), Line(origin = {4, 0}, points = {{-86, 0}, {86, 0}})}),
+    Documentation(info = "<html><head></head><body><span style=\"font-size: 12px;\">Block to implement a first order filter:</span><div style=\"font-size: 12px;\"><br></div><div style=\"font-size: 12px;\"><span class=\"Apple-tab-span\" style=\"white-space: pre;\"> </span>y &nbsp; &nbsp; &nbsp; &nbsp; 1</div><div style=\"font-size: 12px;\"><span class=\"Apple-tab-span\" style=\"white-space: pre;\"> </span>- = ---------------</div><div style=\"font-size: 12px;\"><span class=\"Apple-tab-span\" style=\"white-space: pre;\"> </span>u &nbsp; &nbsp; &nbsp;1 + s*tS</div><div style=\"font-size: 12px;\"><br></div><div style=\"font-size: 12px;\">It is required that tS &gt; 0.</div><div style=\"font-size: 12px;\"><br></div><div style=\"font-size: 12px;\">Both the rate of output variation and the output itself are limited.&nbsp;</div></body></html>"));
+end LimRateLimFirstOrder;

--- a/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/NonLinear/package.order
+++ b/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/NonLinear/package.order
@@ -1,5 +1,6 @@
 BaseClasses
 BacklashHysteresis
+ConditionalForward
 DeadBand
 DelayFlag
 FixedBooleanDelay
@@ -11,9 +12,11 @@ LimitedIntegrator
 LimitedLeadLag
 LimiterWithLag
 LimiterWithLag_INIT
+LimRateLimFirstOrder
 MaxThresholdSwitch
 MinThresholdSwitch
 MultiSwitch
+PIAntiWindUpTable
 PulseFixedDuration
 PulseMinimumDuration
 RampLimiter
@@ -21,5 +24,3 @@ StandAloneRampRateLimiter
 SwitchInteger
 VariableDelayFlag
 VariableLimiter
-PIAntiWindUpTable
-ConditionalForward


### PR DESCRIPTION
…in an existing OM test case

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
