### PR TITLE
3128 delete explicit definition of the empty destructors to enable the compiler to generate implicit inline trivial destructors

### DIFF
--- a/dynawo/sources/API/CRT/CRTImporter.h
+++ b/dynawo/sources/API/CRT/CRTImporter.h
@@ -43,7 +43,7 @@ class Importer {
   /**
    * @brief Destructor
    */
-  virtual ~Importer() {}
+  virtual ~Importer() = default;
 
   /**
    * @brief Import criteria from file

--- a/dynawo/sources/API/CRT/CRTXmlHandler.cpp
+++ b/dynawo/sources/API/CRT/CRTXmlHandler.cpp
@@ -65,9 +65,6 @@ genCriteriaHandler_(parser::ElementName(namespace_uri(), "generatorCriteria")) {
   genCriteriaHandler_.onEnd(lambda::bind(&XmlHandler::addGenCriteria, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {
-}
-
 shared_ptr<CriteriaCollection>
 XmlHandler::getCriteriaCollection() {
   return criteriaCollection_;
@@ -101,8 +98,6 @@ countryHandler_(parser::ElementName(namespace_uri(), "country")) {
   countryHandler_.onEnd(lambda::bind(&CriteriaHandler::addCountry, lambda::ref(*this)));
 }
 
-CriteriaHandler::~CriteriaHandler() {}
-
 void CriteriaHandler::create(attributes_type const & /*attributes*/) {
   criteriaRead_ = CriteriaFactory::newCriteria();
 }
@@ -134,8 +129,6 @@ CriteriaParamsHandler::CriteriaParamsHandler(elementName_type const& root_elemen
   onElement(root_element + namespace_uri()("voltageLevel"), criteriaParamsVoltageLevelHandler_);
   criteriaParamsVoltageLevelHandler_.onEnd(lambda::bind(&CriteriaParamsHandler::addCriteriaParamsVoltageLevel, lambda::ref(*this)));
 }
-
-CriteriaParamsHandler::~CriteriaParamsHandler() {}
 
 void CriteriaParamsHandler::create(attributes_type const & attributes) {
   criteriaParamsRead_ = CriteriaParamsFactory::newCriteriaParams();
@@ -174,8 +167,6 @@ CriteriaParamsVoltageLevelHandler::CriteriaParamsVoltageLevelHandler(elementName
   onStartElement(root_element, lambda::bind(&CriteriaParamsVoltageLevelHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-CriteriaParamsVoltageLevelHandler::~CriteriaParamsVoltageLevelHandler() {}
-
 void CriteriaParamsVoltageLevelHandler::create(attributes_type const & attributes) {
   criteriaParamsVoltageLevelRead_ = shared_ptr<CriteriaParamsVoltageLevel>(new CriteriaParamsVoltageLevel());
   if (attributes.has("uMaxPu"))
@@ -198,8 +189,6 @@ ElementWithIdHandler::ElementWithIdHandler(elementName_type const& root_element)
   onStartElement(root_element, lambda::bind(&ElementWithIdHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-ElementWithIdHandler::~ElementWithIdHandler() {}
-
 void ElementWithIdHandler::create(attributes_type const & attributes) {
   idRead_ = attributes["id"].as_string();
 }
@@ -213,8 +202,6 @@ ElementWithIdHandler::getId() const {
 ComponentHandler::ComponentHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&ComponentHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-ComponentHandler::~ComponentHandler() {}
 
 void ComponentHandler::create(attributes_type const & attributes) {
   idRead_ = attributes["id"].as_string();

--- a/dynawo/sources/API/CRT/CRTXmlHandler.h
+++ b/dynawo/sources/API/CRT/CRTXmlHandler.h
@@ -38,11 +38,6 @@ class ElementWithIdHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ElementWithIdHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~ElementWithIdHandler();
-
-  /**
    * @brief return the id read in xml file
    * @return id build thanks to infos read in xml file
    */
@@ -70,11 +65,6 @@ class ComponentHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit ComponentHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  virtual ~ComponentHandler();
 
   /**
    * @brief return the id read in xml file
@@ -113,11 +103,6 @@ class CriteriaParamsVoltageLevelHandler : public xml::sax::parser::ComposableEle
   explicit CriteriaParamsVoltageLevelHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~CriteriaParamsVoltageLevelHandler();
-
-  /**
    * @brief return the criteria params voltage level read in xml file
    * @return criteria params voltage level object build thanks to infos read in xml file
    */
@@ -145,11 +130,6 @@ class CriteriaParamsHandler : public xml::sax::parser::ComposableElementHandler 
    * @param root_element complete name of the element read by the handler
    */
   explicit CriteriaParamsHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~CriteriaParamsHandler();
 
   /**
    * @brief return the criteria params read in xml file
@@ -185,11 +165,6 @@ class CriteriaHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit CriteriaHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~CriteriaHandler();
 
   /**
    * @brief return the criteria read in xml file
@@ -236,11 +211,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Default constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief Parsed criteria collection getter

--- a/dynawo/sources/API/CRV/CRVExporter.h
+++ b/dynawo/sources/API/CRV/CRVExporter.h
@@ -43,7 +43,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter

--- a/dynawo/sources/API/CRV/CRVImporter.h
+++ b/dynawo/sources/API/CRV/CRVImporter.h
@@ -43,7 +43,7 @@ class Importer {
   /**
    * @brief Destructor
    */
-  virtual ~Importer() {}
+  virtual ~Importer() = default;
 
   /**
    * @brief Import curves's collection from file

--- a/dynawo/sources/API/CRV/CRVXmlHandler.cpp
+++ b/dynawo/sources/API/CRV/CRVXmlHandler.cpp
@@ -56,9 +56,6 @@ curveHandler_(parser::ElementName(namespace_uri(), "curve")) {
   curveHandler_.onEnd(lambda::bind(&XmlHandler::addCurve, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {
-}
-
 shared_ptr<CurvesCollection>
 XmlHandler::getCurvesCollection() {
   return curvesCollection_;
@@ -72,8 +69,6 @@ XmlHandler::addCurve() {
 CurveHandler::CurveHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CurveHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-CurveHandler::~CurveHandler() {}
 
 void CurveHandler::create(attributes_type const & attributes) {
   curveRead_ = CurveFactory::newCurve();

--- a/dynawo/sources/API/CRV/CRVXmlHandler.h
+++ b/dynawo/sources/API/CRV/CRVXmlHandler.h
@@ -45,11 +45,6 @@ class CurveHandler : public xml::sax::parser::ComposableElementHandler {
   explicit CurveHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~CurveHandler();
-
-  /**
    * @brief return the curve read in xml file
    * @return curve object build thanks to infos read in xml file
    */
@@ -79,11 +74,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Default constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief Parsed curves collection getter

--- a/dynawo/sources/API/CSTR/CSTRExporter.h
+++ b/dynawo/sources/API/CSTR/CSTRExporter.h
@@ -44,7 +44,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter

--- a/dynawo/sources/API/DYD/DYDBlackBoxModel.cpp
+++ b/dynawo/sources/API/DYD/DYDBlackBoxModel.cpp
@@ -27,8 +27,6 @@ namespace dynamicdata {
 
 BlackBoxModel::BlackBoxModel(const string& id) : Model(id, Model::BLACK_BOX_MODEL) {}
 
-BlackBoxModel::~BlackBoxModel() {}
-
 const std::string&
 BlackBoxModel::getLib() const {
   return lib_;

--- a/dynawo/sources/API/DYD/DYDBlackBoxModel.h
+++ b/dynawo/sources/API/DYD/DYDBlackBoxModel.h
@@ -46,7 +46,7 @@ class BlackBoxModel : public Model {
   /**
    * @brief Destructor
    */
-  virtual ~BlackBoxModel();
+  virtual ~BlackBoxModel() = default;
 
   /**
    * @brief Model library getter

--- a/dynawo/sources/API/DYD/DYDExporter.h
+++ b/dynawo/sources/API/DYD/DYDExporter.h
@@ -42,7 +42,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter

--- a/dynawo/sources/API/DYD/DYDImporter.h
+++ b/dynawo/sources/API/DYD/DYDImporter.h
@@ -44,7 +44,7 @@ class Importer {
   /**
    * @brief Destructor
    */
-  virtual ~Importer() {}
+  virtual ~Importer() = default;
 
   /**
    * @brief Import dynamic models collection from files

--- a/dynawo/sources/API/DYD/DYDModel.cpp
+++ b/dynawo/sources/API/DYD/DYDModel.cpp
@@ -37,8 +37,6 @@ namespace dynamicdata {
 
 Model::Model(const string& id, ModelType type) : id_(IdentifiableFactory::newIdentifiable(id)), type_(type) {}
 
-Model::~Model() {}
-
 const string&
 Model::getId() const {
   return id_->get();

--- a/dynawo/sources/API/DYD/DYDModel.h
+++ b/dynawo/sources/API/DYD/DYDModel.h
@@ -54,7 +54,7 @@ class Model {
   /**
    * @brief Destructor
    */
-  virtual ~Model();
+  virtual ~Model() = default;
 
   /**
    * @brief Model id getter

--- a/dynawo/sources/API/DYD/DYDModelTemplate.cpp
+++ b/dynawo/sources/API/DYD/DYDModelTemplate.cpp
@@ -56,8 +56,6 @@ namespace dynamicdata {
 
 ModelTemplate::ModelTemplate(const string& id) : Model(id, Model::MODEL_TEMPLATE), useAliasing_(true), generateCalculatedVariables_(true) {}
 
-ModelTemplate::~ModelTemplate() {}
-
 void
 ModelTemplate::setCompilationOptions(bool useAliasing, bool generateCalculatedVariables) {
   useAliasing_ = useAliasing;

--- a/dynawo/sources/API/DYD/DYDModelTemplate.h
+++ b/dynawo/sources/API/DYD/DYDModelTemplate.h
@@ -51,7 +51,7 @@ class ModelTemplate : public Model {
   /**
    * @brief Destructor
    */
-  virtual ~ModelTemplate();
+  virtual ~ModelTemplate() = default;
 
   /**
    * @brief Set compilation options

--- a/dynawo/sources/API/DYD/DYDModelTemplateExpansion.cpp
+++ b/dynawo/sources/API/DYD/DYDModelTemplateExpansion.cpp
@@ -29,8 +29,6 @@ namespace dynamicdata {
 
 ModelTemplateExpansion::ModelTemplateExpansion(const string& id) : Model(id, Model::MODEL_TEMPLATE_EXPANSION) {}
 
-ModelTemplateExpansion::~ModelTemplateExpansion() {}
-
 const std::string&
 ModelTemplateExpansion::getTemplateId() const {
   return templateId_;

--- a/dynawo/sources/API/DYD/DYDModelTemplateExpansion.h
+++ b/dynawo/sources/API/DYD/DYDModelTemplateExpansion.h
@@ -47,7 +47,7 @@ class ModelTemplateExpansion : public Model {
   /**
    * @brief Destructor
    */
-  virtual ~ModelTemplateExpansion();
+  virtual ~ModelTemplateExpansion() = default;
 
   /**
    * @brief Template Model getter

--- a/dynawo/sources/API/DYD/DYDModelicaModel.cpp
+++ b/dynawo/sources/API/DYD/DYDModelicaModel.cpp
@@ -49,8 +49,6 @@ namespace dynamicdata {
 
 ModelicaModel::ModelicaModel(const string& id) : Model(id, Model::MODELICA_MODEL), useAliasing_(true), generateCalculatedVariables_(true) {}
 
-ModelicaModel::~ModelicaModel() {}
-
 const string&
 ModelicaModel::getStaticId() const {
   return staticId_;

--- a/dynawo/sources/API/DYD/DYDModelicaModel.h
+++ b/dynawo/sources/API/DYD/DYDModelicaModel.h
@@ -54,7 +54,7 @@ class ModelicaModel : public Model {
   /**
    * @brief Destructor
    */
-  virtual ~ModelicaModel();
+  virtual ~ModelicaModel() = default;
 
   /**
    * @brief Network Identifiable device modeled getter

--- a/dynawo/sources/API/DYD/DYDStaticRef.h
+++ b/dynawo/sources/API/DYD/DYDStaticRef.h
@@ -35,7 +35,7 @@ class StaticRef {
   /**
    * @brief StaticRef constructor
    */
-  StaticRef() {}
+  StaticRef() = default;
   /**
    * @brief StaticRef constructor
    *

--- a/dynawo/sources/API/DYD/DYDXmlHandler.cpp
+++ b/dynawo/sources/API/DYD/DYDXmlHandler.cpp
@@ -97,8 +97,6 @@ macroStaticReferenceHandler_(parser::ElementName(namespace_uri(), "macroStaticRe
   macroStaticReferenceHandler_.onEnd(lambda::bind(&XmlHandler::addMacroStaticReference, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {}
-
 boost::shared_ptr<DynamicModelsCollection>
 XmlHandler::getDynamicModelsCollection() {
   return dynamicModelsCollection_;
@@ -170,8 +168,6 @@ unitDynamicModelHandler_(parser::ElementName(namespace_uri(), "unitDynamicModel"
   macroStaticRefHandler_.onEnd(lambda::bind(&ModelicaModelHandler::addMacroStaticRef, lambda::ref(*this)));
   unitDynamicModelHandler_.onEnd(lambda::bind(&ModelicaModelHandler::addUnitDynamicModel, lambda::ref(*this)));
 }
-
-ModelicaModelHandler::~ModelicaModelHandler() {}
 
 void
 ModelicaModelHandler::create(attributes_type const& attributes) {
@@ -250,8 +246,6 @@ unitDynamicModelHandler_(parser::ElementName(namespace_uri(), "unitDynamicModel"
   unitDynamicModelHandler_.onEnd(lambda::bind(&ModelTemplateHandler::addUnitDynamicModel, lambda::ref(*this)));
 }
 
-ModelTemplateHandler::~ModelTemplateHandler() {}
-
 void
 ModelTemplateHandler::create(attributes_type const& attributes) {
   modelTemplate_ = ModelTemplateFactory::newModel(attributes["id"]);
@@ -314,8 +308,6 @@ macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")) {
   macroStaticRefHandler_.onEnd(lambda::bind(&BlackBoxModelHandler::addMacroStaticRef, lambda::ref(*this)));
 }
 
-BlackBoxModelHandler::~BlackBoxModelHandler() {}
-
 void
 BlackBoxModelHandler::create(attributes_type const& attributes) {
   blackBoxModel_ = BlackBoxModelFactory::newModel(attributes["id"]);
@@ -359,8 +351,6 @@ macroStaticRefHandler_(parser::ElementName(namespace_uri(), "macroStaticRef")) {
   macroStaticRefHandler_.onEnd(lambda::bind(&ModelTemplateExpansionHandler::addMacroStaticRef, lambda::ref(*this)));
 }
 
-ModelTemplateExpansionHandler::~ModelTemplateExpansionHandler() {}
-
 void
 ModelTemplateExpansionHandler::create(attributes_type const& attributes) {
   modelTemplateExpansion_ = ModelTemplateExpansionFactory::newModel(attributes["id"]);
@@ -396,8 +386,6 @@ ConnectHandler::ConnectHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&ConnectHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-ConnectHandler::~ConnectHandler() {}
-
 void
 ConnectHandler::create(attributes_type const& attributes) {
   connector_.id1 = attributes["id1"].as_string();
@@ -414,8 +402,6 @@ ConnectHandler::get() const {
 MacroConnectHandler::MacroConnectHandler(const elementName_type& root_element) {
   onStartElement(root_element, lambda::bind(&MacroConnectHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-MacroConnectHandler::~MacroConnectHandler() {}
 
 void
 MacroConnectHandler::create(attributes_type const& attributes) {
@@ -447,8 +433,6 @@ macroInitConnectionHandler_(parser::ElementName(namespace_uri(), "initConnect"))
   macroInitConnectionHandler_.onEnd(lambda::bind(&MacroConnectorHandler::addInitConnect, lambda::ref(*this)));
 }
 
-MacroConnectorHandler::~MacroConnectorHandler() {}
-
 void
 MacroConnectorHandler::create(attributes_type const & attributes) {
   macroConnector_ = MacroConnectorFactory::newMacroConnector(attributes["id"]);
@@ -475,8 +459,6 @@ MacroConnectionHandler::MacroConnectionHandler(elementName_type const& root_elem
   onStartElement(root_element, lambda::bind(&MacroConnectionHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-MacroConnectionHandler::~MacroConnectionHandler() {}
-
 void
 MacroConnectionHandler::create(attributes_type const& attributes) {
   macroConnection_.var1 = attributes["var1"].as_string();
@@ -492,8 +474,6 @@ StaticRefHandler::StaticRefHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&StaticRefHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-StaticRefHandler::~StaticRefHandler() {}
-
 void
 StaticRefHandler::create(attributes_type const& attributes) {
   staticRef_.var = attributes["var"].as_string();
@@ -508,8 +488,6 @@ StaticRefHandler::get() const {
 MacroStaticRefHandler::MacroStaticRefHandler(const elementName_type& root_element) {
   onStartElement(root_element, lambda::bind(&MacroStaticRefHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-MacroStaticRefHandler::~MacroStaticRefHandler() {}
 
 void
 MacroStaticRefHandler::create(attributes_type const& attributes) {
@@ -530,8 +508,6 @@ staticRefHandler_(parser::ElementName(namespace_uri(), "staticRef")) {
   staticRefHandler_.onEnd(lambda::bind(&MacroStaticReferenceHandler::addStaticRef, lambda::ref(*this)));
 }
 
-MacroStaticReferenceHandler::~MacroStaticReferenceHandler() {}
-
 void
 MacroStaticReferenceHandler::create(attributes_type const & attributes) {
   macroStaticReference_ = MacroStaticReferenceFactory::newMacroStaticReference(attributes["id"]);
@@ -551,8 +527,6 @@ MacroStaticReferenceHandler::get() const {
 UnitDynamicModelHandler::UnitDynamicModelHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&UnitDynamicModelHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-UnitDynamicModelHandler::~UnitDynamicModelHandler() {}
 
 void
 UnitDynamicModelHandler::create(attributes_type const& attributes) {

--- a/dynawo/sources/API/DYD/DYDXmlHandler.h
+++ b/dynawo/sources/API/DYD/DYDXmlHandler.h
@@ -83,11 +83,6 @@ class UnitDynamicModelHandler : public xml::sax::parser::ComposableElementHandle
   explicit UnitDynamicModelHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~UnitDynamicModelHandler();
-
-  /**
    * @brief return the unit dynamic model read in xml file
    * @return unit dynamic model object build thanks to infos read in xml file
    */
@@ -115,11 +110,6 @@ class StaticRefHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit StaticRefHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~StaticRefHandler();
 
   /**
    * @brief return the static ref read in xml file
@@ -151,11 +141,6 @@ class MacroStaticRefHandler : public xml::sax::parser::ComposableElementHandler 
   explicit MacroStaticRefHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~MacroStaticRefHandler();
-
-  /**
    * return the macroStaticRef read in xml file
    * @return the MacroStaticRef object build thanks to infos read in xml file
    */
@@ -183,11 +168,6 @@ class MacroStaticReferenceHandler : public xml::sax::parser::ComposableElementHa
    * @param root_element complete name of the element read by the handler
    */
   explicit MacroStaticReferenceHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~MacroStaticReferenceHandler();
 
   /**
    * return the macroStaticReference read in xml file
@@ -225,11 +205,6 @@ class ConnectHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ConnectHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~ConnectHandler();
-
-  /**
    * @brief return the connector read in xml file
    * @return connector object build thanks to infos read in xml file
    */
@@ -258,11 +233,6 @@ class MacroConnectHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit MacroConnectHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~MacroConnectHandler();
 
   /**
    * return the macro connect read in xml file
@@ -294,11 +264,6 @@ class MacroConnectionHandler : public xml::sax::parser::ComposableElementHandler
   explicit MacroConnectionHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~MacroConnectionHandler();
-
-  /**
    * return the macro connection read in xml file
    * @return macro connection object build thanks to infos read in xml file
    */
@@ -326,11 +291,6 @@ class MacroConnectorHandler : public xml::sax::parser::ComposableElementHandler 
    * @param root_element complete name of the element read by the handler
    */
   explicit MacroConnectorHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~MacroConnectorHandler();
 
   /**
    * return the macro connector read in xml file
@@ -372,11 +332,6 @@ class ModelicaModelHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit ModelicaModelHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~ModelicaModelHandler();
 
   /**
    * @brief return the modelica model read in xml file
@@ -444,11 +399,6 @@ class ModelTemplateHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ModelTemplateHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~ModelTemplateHandler();
-
-  /**
    * @brief return the model template read in xml file
    * @return model template object build thanks to infos read in xml file
    */
@@ -514,11 +464,6 @@ class BlackBoxModelHandler : public xml::sax::parser::ComposableElementHandler {
   explicit BlackBoxModelHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~BlackBoxModelHandler();
-
-  /**
    * @brief add a static reference to the black box model
    */
   void addStaticRef();
@@ -558,11 +503,6 @@ class ModelTemplateExpansionHandler : public xml::sax::parser::ComposableElement
    * @param root_element complete name of the element read by the handler
    */
   explicit ModelTemplateExpansionHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~ModelTemplateExpansionHandler();
 
   /**
    * @brief add a static reference to the model template expansion
@@ -606,11 +546,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Default constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief Parsed parameters set collection getter

--- a/dynawo/sources/API/EXTVAR/EXTVARExporter.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARExporter.h
@@ -41,7 +41,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter

--- a/dynawo/sources/API/EXTVAR/EXTVARImporter.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARImporter.h
@@ -41,7 +41,7 @@ class Importer {
   /**
    * @brief Destructor
    */
-  virtual ~Importer() {}
+  virtual ~Importer() = default;
 
   /**
    * @brief Import external (i.e. C++-connected) variables

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.cpp
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.cpp
@@ -55,8 +55,6 @@ variablesHandler_(parser::ElementName(namespace_uri(), "variable")) {
   variablesHandler_.onEnd(lambda::bind(&XmlHandler::addVariable, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {}
-
 boost::shared_ptr<VariablesCollection>
 XmlHandler::getVariablesCollection() {
   return variablesCollection_;
@@ -76,8 +74,6 @@ VariableHandler::get() const {
 VariableHandler::VariableHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&VariableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-VariableHandler::~VariableHandler() {}
 
 void
 VariableHandler::create(attributes_type const& attributes) {

--- a/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.h
+++ b/dynawo/sources/API/EXTVAR/EXTVARXmlHandler.h
@@ -41,11 +41,6 @@ class VariableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit VariableHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~VariableHandler();
-
-  /**
    * @brief Variable getter
    * @return the Variable object
    */
@@ -74,11 +69,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Default constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief Parsed parameters set collection getter

--- a/dynawo/sources/API/FSV/FSVXmlHandler.cpp
+++ b/dynawo/sources/API/FSV/FSVXmlHandler.cpp
@@ -56,9 +56,6 @@ XmlHandler::XmlHandler() :
   finalStateValueHandler_.onEnd(lambda::bind(&XmlHandler::addFinalStateValue, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {
-}
-
 shared_ptr<FinalStateValuesCollection>
 XmlHandler::getFinalStateValuesCollection() {
   return finalStateValuesCollection_;
@@ -71,9 +68,6 @@ XmlHandler::addFinalStateValue() {
 
 FinalStateValueHandler::FinalStateValueHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&FinalStateValueHandler::create, lambda::ref(*this), lambda_args::arg2));
-}
-
-FinalStateValueHandler::~FinalStateValueHandler() {
 }
 
 void

--- a/dynawo/sources/API/FSV/FSVXmlHandler.h
+++ b/dynawo/sources/API/FSV/FSVXmlHandler.h
@@ -47,7 +47,7 @@ class FinalStateValueHandler : public xml::sax::parser::ComposableElementHandler
   /**
    * @brief Destructor
    */
-  virtual ~FinalStateValueHandler();
+  virtual ~FinalStateValueHandler() = default;
 
   /**
    * @brief return the final state value read in xml file
@@ -79,11 +79,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Default constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief Parsed final state values collection getter

--- a/dynawo/sources/API/JOB/JOBImporter.h
+++ b/dynawo/sources/API/JOB/JOBImporter.h
@@ -43,7 +43,7 @@ class Importer {
   /**
    * @brief Destructor
    */
-  virtual ~Importer() {}
+  virtual ~Importer() = default;
 
   /**
    * @brief Import job's collection from file

--- a/dynawo/sources/API/JOB/JOBJobEntry.cpp
+++ b/dynawo/sources/API/JOB/JOBJobEntry.cpp
@@ -21,10 +21,6 @@
 
 namespace job {
 
-JobEntry::JobEntry() {}
-
-JobEntry::~JobEntry() {}
-
 JobEntry::JobEntry(const JobEntry& other) :
     modelerEntry_(DYN::clone(other.modelerEntry_)),
     solverEntry_(DYN::clone(other.solverEntry_)),

--- a/dynawo/sources/API/JOB/JOBJobEntry.h
+++ b/dynawo/sources/API/JOB/JOBJobEntry.h
@@ -113,10 +113,10 @@ class JobEntry {
   /**
    * @brief Default constructor
    */
-  JobEntry();
+  JobEntry() = default;
 
   /// @brief Destructor
-  ~JobEntry();
+  ~JobEntry() = default;
 
   /**
    * @brief Copy assignment operator

--- a/dynawo/sources/API/JOB/JOBLogsEntry.cpp
+++ b/dynawo/sources/API/JOB/JOBLogsEntry.cpp
@@ -23,10 +23,6 @@
 
 namespace job {
 
-LogsEntry::~LogsEntry() {}
-
-LogsEntry::LogsEntry() {}
-
 LogsEntry::LogsEntry(const LogsEntry& other) {
   copy(other);
 }

--- a/dynawo/sources/API/JOB/JOBLogsEntry.h
+++ b/dynawo/sources/API/JOB/JOBLogsEntry.h
@@ -35,10 +35,10 @@ namespace job {
 class LogsEntry {
  public:
   /// @brief Destructor
-  ~LogsEntry();
+  ~LogsEntry() = default;
 
   /// @brief Constructor
-  LogsEntry();
+  LogsEntry() = default;
 
   /**
    * @brief Copy constructor

--- a/dynawo/sources/API/JOB/JOBModelerEntry.cpp
+++ b/dynawo/sources/API/JOB/JOBModelerEntry.cpp
@@ -22,10 +22,6 @@
 
 namespace job {
 
-ModelerEntry::ModelerEntry() {}
-
-ModelerEntry::~ModelerEntry() {}
-
 ModelerEntry::ModelerEntry(const ModelerEntry& other):
     compileDir_(other.compileDir_),
     preCompiledModelsDirEntry_(DYN::clone(other.preCompiledModelsDirEntry_)),

--- a/dynawo/sources/API/JOB/JOBModelerEntry.h
+++ b/dynawo/sources/API/JOB/JOBModelerEntry.h
@@ -113,7 +113,7 @@ class ModelerEntry {
   /**
    * @brief Default constructor
    */
-  ModelerEntry();
+  ModelerEntry() = default;
 
   /**
    * @brief Copy constructor
@@ -129,7 +129,7 @@ class ModelerEntry {
   ModelerEntry& operator=(const ModelerEntry& other);
 
   /// @brief Destructor
-  ~ModelerEntry();
+  ~ModelerEntry() = default;
 
  private:
   std::string compileDir_;                                            ///< Compiling directory for the simulation

--- a/dynawo/sources/API/JOB/JOBOutputsEntry.cpp
+++ b/dynawo/sources/API/JOB/JOBOutputsEntry.cpp
@@ -23,10 +23,6 @@
 
 namespace job {
 
-OutputsEntry::~OutputsEntry() {}
-
-OutputsEntry::OutputsEntry() {}
-
 OutputsEntry::OutputsEntry(const OutputsEntry& other) {
   copy(other);
 }

--- a/dynawo/sources/API/JOB/JOBOutputsEntry.h
+++ b/dynawo/sources/API/JOB/JOBOutputsEntry.h
@@ -43,10 +43,10 @@ namespace job {
 class OutputsEntry {
  public:
   /// @brief Destructor
-  ~OutputsEntry();
+  ~OutputsEntry() = default;
 
   /// @brief Default constructor
-  OutputsEntry();
+  OutputsEntry() = default;
 
   /**
    * @brief Copy constructor

--- a/dynawo/sources/API/JOB/JOBXmlHandler.cpp
+++ b/dynawo/sources/API/JOB/JOBXmlHandler.cpp
@@ -71,9 +71,6 @@ jobHandler_(parser::ElementName(namespace_uri(), "job")) {
   jobHandler_.onEnd(lambda::bind(&XmlHandler::addJob, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {
-}
-
 void
 XmlHandler::addJob() {
   jobsCollection_->addJob(jobHandler_.get());
@@ -104,8 +101,6 @@ localInitHandler_(parser::ElementName(namespace_uri(), "localInit")) {
   outputsHandler_.onEnd(lambda::bind(&JobHandler::addOutputs, lambda::ref(*this)));
   localInitHandler_.onEnd(lambda::bind(&JobHandler::addLocalInit, lambda::ref(*this)));
 }
-
-JobHandler::~JobHandler() {}
 
 void
 JobHandler::addSolver() {
@@ -147,8 +142,6 @@ SolverHandler::SolverHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&SolverHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-SolverHandler::~SolverHandler() {}
-
 void
 SolverHandler::create(attributes_type const & attributes) {
   solver_ = shared_ptr<SolverEntry>(new SolverEntry());
@@ -182,8 +175,6 @@ modelicaModelsHandler_(parser::ElementName(namespace_uri(), "modelicaModels")) {
   preCompiledModelsHandler_.onEnd(lambda::bind(&ModelerHandler::addPreCompiledModels, lambda::ref(*this)));
   modelicaModelsHandler_.onEnd(lambda::bind(&ModelerHandler::addModelicaModel, lambda::ref(*this)));
 }
-
-ModelerHandler::~ModelerHandler() {}
 
 void
 ModelerHandler::addNetwork() {
@@ -225,8 +216,6 @@ CriteriaFileHandler::CriteriaFileHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CriteriaFileHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-CriteriaFileHandler::~CriteriaFileHandler() {}
-
 void
 CriteriaFileHandler::create(attributes_type const& attributes) {
   criteriaFile_ = attributes["criteriaFile"].as_string();
@@ -244,8 +233,6 @@ criteriaFileHandler_(parser::ElementName(namespace_uri(), "criteria")) {
 
   criteriaFileHandler_.onEnd(lambda::bind(&SimulationHandler::addCriteriaFile, lambda::ref(*this)));
 }
-
-SimulationHandler::~SimulationHandler() {}
 
 void
 SimulationHandler::create(attributes_type const& attributes) {
@@ -306,8 +293,6 @@ logsHandler_(parser::ElementName(namespace_uri(), "logs")) {
   lostEquipmentsHandler_.onEnd(lambda::bind(&OutputsHandler::addLostEquipments, lambda::ref(*this)));
   logsHandler_.onEnd(lambda::bind(&OutputsHandler::addLog, lambda::ref(*this)));
 }
-
-OutputsHandler::~OutputsHandler() {}
 
 void
 OutputsHandler::addInitValuesEntry() {
@@ -374,8 +359,6 @@ LocalInitHandler::LocalInitHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&LocalInitHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-LocalInitHandler::~LocalInitHandler() {}
-
 void
 LocalInitHandler::create(attributes_type const& attributes) {
   localInit_ = shared_ptr<LocalInitEntry>(new LocalInitEntry());
@@ -391,8 +374,6 @@ LocalInitHandler::get() const {
 InitValuesHandler::InitValuesHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&InitValuesHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-InitValuesHandler::~InitValuesHandler() {}
 
 void
 InitValuesHandler::create(attributes_type const& attributes) {
@@ -410,8 +391,6 @@ FinalValuesHandler::FinalValuesHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&FinalValuesHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-FinalValuesHandler::~FinalValuesHandler() {}
-
 void
 FinalValuesHandler::create(attributes_type const& /*attributes*/) {
   finalValuesEntry_ = shared_ptr<FinalValuesEntry>(new FinalValuesEntry());
@@ -427,8 +406,6 @@ ConstraintsHandler::ConstraintsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&ConstraintsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-ConstraintsHandler::~ConstraintsHandler() {}
-
 void
 ConstraintsHandler::create(attributes_type const& attributes) {
   constraints_ = shared_ptr<ConstraintsEntry>(new ConstraintsEntry());
@@ -443,8 +420,6 @@ ConstraintsHandler::get() const {
 TimelineHandler::TimelineHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&TimelineHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-TimelineHandler::~TimelineHandler() {}
 
 void
 TimelineHandler::create(attributes_type const& attributes) {
@@ -467,8 +442,6 @@ TimetableHandler::TimetableHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&TimetableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-TimetableHandler::~TimetableHandler() {}
-
 void
 TimetableHandler::create(attributes_type const& attributes) {
   timetable_ = shared_ptr<TimetableEntry>(new TimetableEntry());
@@ -483,8 +456,6 @@ TimetableHandler::get() const {
 FinalStateHandler::FinalStateHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&FinalStateHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-FinalStateHandler::~FinalStateHandler() {}
 
 void
 FinalStateHandler::create(attributes_type const& attributes) {
@@ -504,8 +475,6 @@ FinalStateHandler::get() const {
 CurvesHandler::CurvesHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&CurvesHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-CurvesHandler::~CurvesHandler() {}
 
 void
 CurvesHandler::create(attributes_type const& attributes) {
@@ -530,9 +499,6 @@ FinalStateValuesHandler::FinalStateValuesHandler(elementName_type const& root_el
                               lambda_args::arg2));
 }
 
-
-FinalStateValuesHandler::~FinalStateValuesHandler() {}
-
 void FinalStateValuesHandler::create(attributes_type const& attributes) {
   finalStateValues_ = shared_ptr<FinalStateValuesEntry>(new FinalStateValuesEntry());
   finalStateValues_->setInputFile(attributes["inputFile"]);
@@ -544,8 +510,6 @@ shared_ptr<FinalStateValuesEntry> FinalStateValuesHandler::get() const { return 
 LostEquipmentsHandler::LostEquipmentsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&LostEquipmentsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-LostEquipmentsHandler::~LostEquipmentsHandler() {}
 
 void
 LostEquipmentsHandler::create(attributes_type const& /*attributes*/) {
@@ -567,8 +531,6 @@ appenderHandler_(parser::ElementName(namespace_uri(), "appender")) {
   appenderHandler_.onEnd(lambda::bind(&LogsHandler::addAppender, lambda::ref(*this)));
 }
 
-LogsHandler::~LogsHandler() {}
-
 void
 LogsHandler::addAppender() {
   logs_->addAppenderEntry(appenderHandler_.get());
@@ -587,8 +549,6 @@ LogsHandler::get() const {
 AppenderHandler::AppenderHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&AppenderHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-AppenderHandler::~AppenderHandler() {}
 
 void
 AppenderHandler::create(attributes_type const& attributes) {
@@ -620,8 +580,6 @@ NetworkHandler::NetworkHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&NetworkHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-NetworkHandler::~NetworkHandler() {}
-
 void
 NetworkHandler::create(attributes_type const& attributes) {
   network_ = shared_ptr<NetworkEntry>(new NetworkEntry());
@@ -641,8 +599,6 @@ DynModelsHandler::DynModelsHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&DynModelsHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-DynModelsHandler::~DynModelsHandler() {}
-
 void
 DynModelsHandler::create(attributes_type const& attributes) {
   dynModels_ = shared_ptr<DynModelsEntry>(new DynModelsEntry());
@@ -657,8 +613,6 @@ DynModelsHandler::get() const {
 InitialStateHandler::InitialStateHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&InitialStateHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-InitialStateHandler::~InitialStateHandler() {}
 
 void
 InitialStateHandler::create(attributes_type const& attributes) {
@@ -679,8 +633,6 @@ directoryHandler_(parser::ElementName(namespace_uri(), "directory")) {
 
   directoryHandler_.onEnd(lambda::bind(&ModelsDirHandler::addDirectory, lambda::ref(*this)));
 }
-
-ModelsDirHandler::~ModelsDirHandler() {}
 
 void
 ModelsDirHandler::create(attributes_type const& attributes) {
@@ -705,8 +657,6 @@ DirectoryHandler::DirectoryHandler(elementName_type const& root_element) {
   dir_.isRecursive = false;
   onStartElement(root_element, lambda::bind(&DirectoryHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-DirectoryHandler::~DirectoryHandler() {}
 
 void
 DirectoryHandler::create(attributes_type const& attributes) {

--- a/dynawo/sources/API/JOB/JOBXmlHandler.h
+++ b/dynawo/sources/API/JOB/JOBXmlHandler.h
@@ -65,11 +65,6 @@ class AppenderHandler : public xml::sax::parser::ComposableElementHandler {
   explicit AppenderHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~AppenderHandler();
-
-  /**
    * @brief return the appender read in xml file
    * @return appender object build thanks to infos read in xml file
    */
@@ -99,11 +94,6 @@ class DirectoryHandler : public xml::sax::parser::ComposableElementHandler {
   explicit DirectoryHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~DirectoryHandler();
-
-  /**
    * @brief return the directory read in xml file
    * @return directory object build thanks to infos read in xml file
    */
@@ -131,11 +121,6 @@ class ModelsDirHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit ModelsDirHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~ModelsDirHandler();
 
   /**
    * @brief add a directory to the list of directory
@@ -173,11 +158,6 @@ class InitialStateHandler : public xml::sax::parser::ComposableElementHandler {
   explicit InitialStateHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~InitialStateHandler();
-
-  /**
    * @brief get the initial state element read in xml file
    * @return initial state object build thanks to infos read in xml file
    */
@@ -205,11 +185,6 @@ class DynModelsHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit DynModelsHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~DynModelsHandler();
 
   /**
    * @brief get the dynModels objects read in xml file
@@ -241,11 +216,6 @@ class NetworkHandler : public xml::sax::parser::ComposableElementHandler {
   explicit NetworkHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~NetworkHandler();
-
-  /**
    * @brief return the network entry element read in xml file
    * @return network entry object builds thanks to infos read in xml file
    */
@@ -273,11 +243,6 @@ class InitValuesHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit InitValuesHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~InitValuesHandler();
 
   /**
    * @brief return the init values entry read in xml file
@@ -309,11 +274,6 @@ class FinalValuesHandler : public xml::sax::parser::ComposableElementHandler {
   explicit FinalValuesHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~FinalValuesHandler();
-
-  /**
    * @brief return the final values entry read in xml file
    * @return final values entry object build thanks to infos read in xml file
    */
@@ -341,11 +301,6 @@ class ConstraintsHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit ConstraintsHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~ConstraintsHandler();
 
   /**
    * @brief return the constraints entry read in xml file
@@ -377,11 +332,6 @@ class TimelineHandler : public xml::sax::parser::ComposableElementHandler {
   explicit TimelineHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~TimelineHandler();
-
-  /**
    * @brief return the timeline entry read in xml file
    * @return timeline entry object build thanks to infos read in xml file
    */
@@ -409,11 +359,6 @@ class TimetableHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit TimetableHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~TimetableHandler();
 
   /**
    * @brief return the timetable entry read in xml file
@@ -445,11 +390,6 @@ class FinalStateHandler : public xml::sax::parser::ComposableElementHandler {
   explicit FinalStateHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~FinalStateHandler();
-
-  /**
    * @brief return the final state entry read in xml file
    * @return final state entry object build thanks to infos read in xml file
    */
@@ -477,11 +417,6 @@ class CurvesHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit CurvesHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~CurvesHandler();
 
   /**
    * @brief return the curves entry read in xml file
@@ -513,11 +448,6 @@ class FinalStateValuesHandler : public xml::sax::parser::ComposableElementHandle
   explicit FinalStateValuesHandler(elementName_type const& root_element);
 
   /**
-   * @brief default destructor
-   */
-  ~FinalStateValuesHandler();
-
-  /**
    * @brief return the final state values entry read in xml file
    * @return Final state values entry object built from the info read in xml file
    */
@@ -547,11 +477,6 @@ class LostEquipmentsHandler : public xml::sax::parser::ComposableElementHandler 
   explicit LostEquipmentsHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~LostEquipmentsHandler();
-
-  /**
    * @brief return the lostEquipments entry read in xml file
    * @return curves entry object build thanks to infos read in xml file
    */
@@ -579,11 +504,6 @@ class LogsHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit LogsHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~LogsHandler();
 
   /**
    * @brief return the logs entry read in xml file
@@ -619,11 +539,6 @@ class OutputsHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit OutputsHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~OutputsHandler();
 
   /**
    * @brief return the outputs entry read in xml file
@@ -715,11 +630,6 @@ class CriteriaFileHandler : public xml::sax::parser::ComposableElementHandler {
   explicit CriteriaFileHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~CriteriaFileHandler();
-
-  /**
    * @brief return the simulation entry read in xml file
    * @return simulation entry object build thanks to infos read in xml file
    */
@@ -747,11 +657,6 @@ class SimulationHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit SimulationHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~SimulationHandler();
 
   /**
    * @brief return the simulation entry read in xml file
@@ -787,11 +692,6 @@ class ModelerHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit ModelerHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~ModelerHandler();
 
   /**
    * @brief return the modeler entry read in xml file
@@ -853,11 +753,6 @@ class SolverHandler : public xml::sax::parser::ComposableElementHandler {
   explicit SolverHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~SolverHandler();
-
-  /**
    * @brief return the solver entry read in xml file
    * @return solver entry object build thanks to infos read in xml file
    */
@@ -887,11 +782,6 @@ class LocalInitHandler : public xml::sax::parser::ComposableElementHandler {
   explicit LocalInitHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~LocalInitHandler();
-
-  /**
    * @brief return the local init entry read in xml file
    * @return local init entry object build thanks to infos read in xml file
    */
@@ -919,11 +809,6 @@ class JobHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit JobHandler(elementName_type const& root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~JobHandler();
 
   /**
    * @brief return the job read in xml file
@@ -985,11 +870,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief add a job to the jobs list

--- a/dynawo/sources/API/LEQ/LEQExporter.h
+++ b/dynawo/sources/API/LEQ/LEQExporter.h
@@ -45,7 +45,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter

--- a/dynawo/sources/API/LEQ/LEQLostEquipment.h
+++ b/dynawo/sources/API/LEQ/LEQLostEquipment.h
@@ -32,7 +32,7 @@ class LostEquipment {
   /**
    * @brief Constructor
    */
-  LostEquipment() {}
+  LostEquipment() = default;
 
   /**
    * @brief Constructor

--- a/dynawo/sources/API/PAR/PARExporter.h
+++ b/dynawo/sources/API/PAR/PARExporter.h
@@ -42,7 +42,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter

--- a/dynawo/sources/API/PAR/PARImporter.h
+++ b/dynawo/sources/API/PAR/PARImporter.h
@@ -42,7 +42,7 @@ class Importer {
   /**
    * @brief Destructor
    */
-  virtual ~Importer() {}
+  virtual ~Importer() = default;
 
   /**
    * @brief Import parameters' set collection from file

--- a/dynawo/sources/API/PAR/PARXmlHandler.cpp
+++ b/dynawo/sources/API/PAR/PARXmlHandler.cpp
@@ -68,9 +68,6 @@ macroParameterSetHandler_(parser::ElementName(namespace_uri(), "macroParameterSe
   macroParameterSetHandler_.onEnd(lambda::bind(&XmlHandler::addMacroParameterSet, lambda::ref(*this)));
 }
 
-XmlHandler::~XmlHandler() {
-}
-
 shared_ptr<ParametersSetCollection>
 XmlHandler::getParametersSetCollection() {
   return parametersSetCollection_;
@@ -103,8 +100,6 @@ macroParSetHandler_(parser::ElementName(namespace_uri(), "macroParSet")) {
   parTableHandler_.onEnd(lambda::bind(&SetHandler::addTable, lambda::ref(*this)));
   macroParSetHandler_.onEnd(lambda::bind(&SetHandler::addMacroParSet, lambda::ref(*this)));
 }
-
-SetHandler::~SetHandler() {}
 
 void
 SetHandler::create(attributes_type const & attributes) {
@@ -162,8 +157,6 @@ parInTableHandler_(parser::ElementName(namespace_uri(), "par")) {
   parInTableHandler_.onEnd(lambda::bind(&ParTableHandler::addPar, lambda::ref(*this)));
 }
 
-ParTableHandler::~ParTableHandler() {}
-
 void
 ParTableHandler::create(attributes_type const & attributes) {
   pars_.clear();
@@ -185,8 +178,6 @@ ParInTableHandler::ParInTableHandler(elementName_type const & root_element) {
   onStartElement(root_element, lambda::bind(&ParInTableHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
 
-ParInTableHandler::~ParInTableHandler() {}
-
 void
 ParInTableHandler::create(attributes_type const & attributes) {
   par_.value = attributes["value"].as_string();
@@ -202,8 +193,6 @@ ParInTableHandler::get() const {
 ParHandler::ParHandler(elementName_type const & root_element) {
   onStartElement(root_element, lambda::bind(&ParHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-ParHandler::~ParHandler() {}
 
 void
 ParHandler::create(attributes_type const & attributes) {
@@ -232,8 +221,6 @@ ParHandler::get() const {
 RefHandler::RefHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&RefHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-RefHandler::~RefHandler() {}
 
 void RefHandler::create(attributes_type const & attributes) {
   Reference::OriginData origData;
@@ -271,8 +258,6 @@ parHandler_(parser::ElementName(namespace_uri(), "par")) {
   parHandler_.onEnd(lambda::bind(&MacroParameterSetHandler::addParameter, lambda::ref(*this)));
 }
 
-MacroParameterSetHandler::~MacroParameterSetHandler() {}
-
 void
 MacroParameterSetHandler::create(attributes_type const & attributes) {
   macroParameterSet_ = shared_ptr<MacroParameterSet>(new MacroParameterSet(attributes["id"].as_string()));
@@ -296,8 +281,6 @@ MacroParameterSetHandler::get() const {
 MacroParSetHandler::MacroParSetHandler(elementName_type const& root_element) {
   onStartElement(root_element, lambda::bind(&MacroParSetHandler::create, lambda::ref(*this), lambda_args::arg2));
 }
-
-MacroParSetHandler::~MacroParSetHandler() {}
 
 void
 MacroParSetHandler::create(attributes_type const & attributes) {

--- a/dynawo/sources/API/PAR/PARXmlHandler.h
+++ b/dynawo/sources/API/PAR/PARXmlHandler.h
@@ -57,11 +57,6 @@ class ParInTableHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ParInTableHandler(elementName_type const & root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~ParInTableHandler();
-
-  /**
    * @brief return the parameter in xml file
    * @return parameter object build thanks to infos read in xml file
    */
@@ -89,11 +84,6 @@ class ParTableHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit ParTableHandler(elementName_type const & root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~ParTableHandler();
 
   /**
    * @brief get the type of the current parTable
@@ -165,11 +155,6 @@ class ParHandler : public xml::sax::parser::ComposableElementHandler {
   explicit ParHandler(elementName_type const & root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~ParHandler();
-
-  /**
    * @brief return the parameter read in xml file
    * @return parameter object build thanks to infos read in xml file
    */
@@ -197,11 +182,6 @@ class RefHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit RefHandler(elementName_type const & root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~RefHandler();
 
   /**
    * @brief return the reference read in xml file
@@ -233,11 +213,6 @@ class MacroParSetHandler : public xml::sax::parser::ComposableElementHandler {
   explicit MacroParSetHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~MacroParSetHandler();
-
-  /**
    * @brief return the macroParSet read in xml file
    * @return reference object build thanks to infos read in xml file
    */
@@ -265,11 +240,6 @@ class SetHandler : public xml::sax::parser::ComposableElementHandler {
    * @param root_element complete name of the element read by the handler
    */
   explicit SetHandler(elementName_type const & root_element);
-
-  /**
-   * @brief Destructor
-   */
-  ~SetHandler();
 
   /**
    * @brief return the set of parameters read in xml file
@@ -325,11 +295,6 @@ class MacroParameterSetHandler : public xml::sax::parser::ComposableElementHandl
   explicit MacroParameterSetHandler(elementName_type const& root_element);
 
   /**
-   * @brief Destructor
-   */
-  ~MacroParameterSetHandler();
-
-  /**
    * @brief return the macroParameterSet read in xml file
    * @return reference object build thanks to infos read in xml file
    */
@@ -372,11 +337,6 @@ class XmlHandler : public xml::sax::parser::ComposableDocumentHandler {
    * @brief Default constructor
    */
   XmlHandler();
-
-  /**
-   * @brief Destructor
-   */
-  ~XmlHandler();
 
   /**
    * @brief Parsed parameters set collection getter

--- a/dynawo/sources/API/TL/TLExporter.h
+++ b/dynawo/sources/API/TL/TLExporter.h
@@ -49,7 +49,7 @@ class Exporter {
   /**
    * @brief Destructor
    */
-  virtual ~Exporter() {}
+  virtual ~Exporter() = default;
 
   /**
    * @brief Export method for this exporter


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [x] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
