### PR TITLE
#3153 LostEquipmentsCollection::lostEquipments_ vector is turned to a set

### DIFF
--- a/dynawo/sources/API/LEQ/LEQLostEquipmentsCollection.cpp
+++ b/dynawo/sources/API/LEQ/LEQLostEquipmentsCollection.cpp
@@ -30,7 +30,7 @@ namespace lostEquipments {
 void
 LostEquipmentsCollection::addLostEquipment(const string& id, const string& type) {
   shared_ptr<LostEquipment> lostEquipment = LostEquipmentFactory::newLostEquipment(id, type);
-  lostEquipments_.push_back(lostEquipment);
+  lostEquipments_.insert(lostEquipment);
 }
 
 LostEquipmentsCollection::LostEquipmentsCollectionConstIterator

--- a/dynawo/sources/API/LEQ/LEQLostEquipmentsCollection.h
+++ b/dynawo/sources/API/LEQ/LEQLostEquipmentsCollection.h
@@ -25,9 +25,18 @@
 
 #include <boost/shared_ptr.hpp>
 #include <string>
-#include <vector>
+#include <set>
 
 namespace lostEquipments {
+
+struct LostEquipmentComparator {
+  bool operator()(const boost::shared_ptr<LostEquipment>& lostEquipment1,
+                  const boost::shared_ptr<LostEquipment>& lostEquipment2) const {
+    return lostEquipment1->getId() < lostEquipment2->getId();
+  }
+};
+
+using LostEquipmentsSet = std::set<boost::shared_ptr<LostEquipment>, LostEquipmentComparator>;
 
 /**
  * @class LostEquipmentsCollection
@@ -126,7 +135,7 @@ class LostEquipmentsCollection {
     const boost::shared_ptr<LostEquipment>* operator->() const;
 
    private:
-    std::vector<boost::shared_ptr<LostEquipment> >::const_iterator current_;  ///< current vector const iterator
+    LostEquipmentsSet::const_iterator current_;  ///< current vector const iterator
   };
 
   /**
@@ -142,7 +151,7 @@ class LostEquipmentsCollection {
   LostEquipmentsCollectionConstIterator cend() const;
 
  private:
-  std::vector<boost::shared_ptr<LostEquipment> > lostEquipments_;  ///< Vector of the lost equipment objects
+  LostEquipmentsSet lostEquipments_;  ///< set of the lost equipment objects
 };
 
 }  // end of namespace lostEquipments


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [x] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
