### PR TITLE
#3263 initialize roots in IDA to ROOT_DOWN to avoid massive modification

### DIFF
--- a/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp
+++ b/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp
@@ -306,8 +306,8 @@ SolverIDA::init(const shared_ptr<Model>& model, const double t0, const double tE
     throw DYNError(Error::SUNDIALS_ERROR, SolverFuncErrorIDA, "IDASetNoInactiveRootWarn");
 
   Solver::Impl::resetStats();
-  g0_.assign(model_->sizeG(), NO_ROOT);
-  g1_.assign(model_->sizeG(), NO_ROOT);
+  g0_.assign(model_->sizeG(), ROOT_DOWN);
+  g1_.assign(model_->sizeG(), ROOT_DOWN);
 
   Trace::debug() << DYNLog(SolverIDAInitOk) << Trace::endline;
 


### PR DESCRIPTION
during the global init

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
