### PR TITLE
#3417 the number of roots of the bus network model was dependent on the

### DIFF
--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelBus.cpp
@@ -268,10 +268,7 @@ ModelBus::initSize() {
     if (hasConnection_ || hasShortCircuitCapabilities_)
       sizeY_ = 4;
     sizeZ_ = 3;  // numCC, switchOff, state
-    sizeG_ = 0;
-    if (network_->hasConstraints()) {
-      sizeG_ = 2;  // U> Umax or U< Umin
-    }
+    sizeG_ = 2;  // U> Umax or U< Umin
     sizeMode_ = 0;
     sizeCalculatedVar_ = nbCalculatedVariables_;
   }
@@ -736,7 +733,6 @@ ModelBus::evalG(const double& /*t*/) {
 
 void
 ModelBus::setGequations(std::map<int, std::string>& gEquationIndex) {
-  if (!network_->hasConstraints()) return;
   gEquationIndex[0] = "U > UMax localModel:"+id();
   gEquationIndex[1] = "U < UMin localModel:"+id();
 


### PR DESCRIPTION
outputs of the jobs. It should not be the case
closes #3417

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
