### PR TITLE
#3419 High RAM usage during compilation of models PhotovoltaicsWeccVo…

### DIFF
--- a/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/factory.py
+++ b/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/factory.py
@@ -3244,6 +3244,7 @@ class Factory:
         if len(all_parameters) >= push_back_threshold:
             self.list_for_defineparameters.append("  };\n")
 
+            self.list_for_defineparameters.append("  parameters.reserve(parameterModelerArray.size());  // with GCC -O3 optimization, pre-allocating the required capacity of the parameters vector prevents excessive RAM usage and out-of-memory errors on some systems")
             self.list_for_defineparameters.append("  for (size_t parameterModelerIndex = 0; parameterModelerIndex < parameterModelerArray.size(); ++parameterModelerIndex)\n")
             self.list_for_defineparameters.append("  {\n")
             self.list_for_defineparameters.append("    parameters.push_back(ParameterModeler(std::get<0>(parameterModelerArray[parameterModelerIndex]), std::get<1>(parameterModelerArray[parameterModelerIndex]), std::get<2>(parameterModelerArray[parameterModelerIndex])));\n")


### PR DESCRIPTION
…ltageSourceA and B

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [x] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
