### PR TITLE
#3398 [Constraints] when current overload happens, the value dumped is 0 instead of the value before opening

### DIFF
--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelCurrentLimits.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelCurrentLimits.cpp
@@ -135,7 +135,7 @@ ModelCurrentLimits::evalZ(const string& componentName, const double& t, state_g*
 
       if (openingAuthorized_[i] && g[1 + 2 * i] == ROOT_UP) {  // Warning: openingAuthorized_ = false => no associated g
         state = ModelCurrentLimits::COMPONENT_OPEN;
-        if (!DYN::doubleIsZero(lastCurrentValue_ * factorPuToA_)) {
+        if (!DYN::doubleIsZero(lastCurrentValue_)) {
           DYNAddConstraintWithData(network, componentName, true, modelType,
               constraintData(ConstraintData::OverloadOpen, i),
               OverloadOpen, acceptableDurations_[i], side_);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelCurrentLimits.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelCurrentLimits.cpp
@@ -135,9 +135,11 @@ ModelCurrentLimits::evalZ(const string& componentName, const double& t, state_g*
 
       if (openingAuthorized_[i] && g[1 + 2 * i] == ROOT_UP) {  // Warning: openingAuthorized_ = false => no associated g
         state = ModelCurrentLimits::COMPONENT_OPEN;
-        DYNAddConstraintWithData(network, componentName, true, modelType,
-            constraintData(ConstraintData::OverloadOpen, i),
-            OverloadOpen, acceptableDurations_[i], side_);
+        if (!DYN::doubleIsZero(lastCurrentValue_ * factorPuToA_)) {
+          DYNAddConstraintWithData(network, componentName, true, modelType,
+              constraintData(ConstraintData::OverloadOpen, i),
+              OverloadOpen, acceptableDurations_[i], side_);
+        }
         DYNAddTimelineEvent(network, componentName, OverloadOpen, acceptableDurations_[i]);
       }
     }


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [x] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
