### PR TITLE
#3509 expose kGover in generator interface and fix active power exten…

### DIFF
--- a/dynawo/sources/Modeler/DataInterface/DYNGeneratorInterface.h
+++ b/dynawo/sources/Modeler/DataInterface/DYNGeneratorInterface.h
@@ -200,18 +200,6 @@ class GeneratorInterface : public ComponentInterface, public ReactiveCurvePoints
   virtual double getCoordinatedReactiveControlPercentage() const = 0;
 
   /**
-   * @brief Get the droop parameter
-   * @returns the droop parameter value, or nullopt if the parameter is not found
-   */
-  virtual boost::optional<double> getDroop() const = 0;
-
-  /**
-   * @brief Determines if the generator is participate
-   * @returns true if the generator is participate, false if not, or nullopt if the parameter is not found
-   */
-  virtual boost::optional<bool> isParticipate() const = 0;
-
-  /**
    * @brief Getter for energy source type
    * @returns energy source type
    */

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNBatteryInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNBatteryInterfaceIIDM.cpp
@@ -330,18 +330,6 @@ BatteryInterfaceIIDM::getCoordinatedReactiveControlPercentage() const {
   return 0.;
 }
 
-boost::optional<double>
-BatteryInterfaceIIDM::getDroop() const {
-  // external IIDM extension is irrelevant for batteries
-  return boost::none;
-}
-
-boost::optional<bool>
-BatteryInterfaceIIDM::isParticipate() const {
-  // external IIDM extension is irrelevant for batteries
-  return boost::none;
-}
-
 GeneratorInterface::EnergySource_t
 BatteryInterfaceIIDM::getEnergySource() const {
   return SOURCE_OTHER;

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNBatteryInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNBatteryInterfaceIIDM.h
@@ -183,16 +183,6 @@ class BatteryInterfaceIIDM : public GeneratorInterface, public InjectorInterface
   double getCoordinatedReactiveControlPercentage() const;
 
   /**
-   * @copydoc GeneratorInterface::getDroop() const
-   */
-  boost::optional<double> getDroop() const final;
-
-  /**
-   * @copydoc GeneratorInterface::getDroop() const
-   */
-  boost::optional<bool> isParticipate() const final;
-
-  /**
    * @brief Getter for the generator' country
    * @return the battery country
    */

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorActivePowerControlIIDMExtension.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorActivePowerControlIIDMExtension.h
@@ -41,6 +41,12 @@ class GeneratorActivePowerControlIIDMExtension {
    * @returns true if the generatpr is participate, false if not, or nullopt if the parameter is not found
    */
   virtual boost::optional<bool> isParticipate() const = 0;
+
+  /**
+   * @brief Determines if the extension exists
+   * @returns whether the extension exists
+   */
+  virtual bool exists() const = 0;
 };
 }  // namespace DYN
 

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorInterfaceIIDM.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorInterfaceIIDM.cpp
@@ -358,7 +358,7 @@ GeneratorInterfaceIIDM::getActivePowerControlDroop() const {
     if (activePowerControl_) {
       return activePowerControl_.get().getDroop();
     } else {
-      generatorActivePowerControl_->getDroop().value();
+      return generatorActivePowerControl_->getDroop().value();
     }
   }
   return 0.;

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorInterfaceIIDM.h
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/DYNGeneratorInterfaceIIDM.h
@@ -197,16 +197,6 @@ class GeneratorInterfaceIIDM : public GeneratorInterface, public InjectorInterfa
   double getCoordinatedReactiveControlPercentage() const;
 
   /**
-   * @copydoc GeneratorInterface::getDroop() const
-   */
-  boost::optional<double> getDroop() const final;
-
-  /**
-   * @copydoc GeneratorInterface::isParticipate() const
-   */
-  boost::optional<bool> isParticipate() const final;
-
-  /**
    * @brief Getter for the generator' country
    * @return the generator country
    */

--- a/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/test/TestGeneratorInterface.cpp
+++ b/dynawo/sources/Modeler/DataInterface/PowSyblIIDM/test/TestGeneratorInterface.cpp
@@ -222,9 +222,6 @@ TEST(DataInterfaceTest, Generator_1) {
   ASSERT_DOUBLE_EQUALS_DYNAWO(genItfWithExtensions.getActivePowerControlDroop(), 4.);
   ASSERT_TRUE(genItfWithExtensions.hasCoordinatedReactiveControl());
   ASSERT_DOUBLE_EQUALS_DYNAWO(genItfWithExtensions.getCoordinatedReactiveControlPercentage(), 50.);
-
-  ASSERT_FALSE(genItf.getDroop());
-  ASSERT_FALSE(genItf.isParticipate());
 }  // TEST(DataInterfaceTest, Generator_1)
 
 TEST(DataInterfaceTest, Generator_2) {


### PR DESCRIPTION
…sion

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
