### PR TITLE
#3529 init values v17

### DIFF
--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.cpp
@@ -1264,6 +1264,11 @@ ModelNetwork::defineVariables(vector<boost::shared_ptr<Variable> >& variables) {
 }
 
 void
+ModelNetwork::defineVariablesInit(std::vector<boost::shared_ptr<Variable> >& variables) {
+  defineVariables(variables);
+}
+
+void
 ModelNetwork::defineParameters(vector<ParameterModeler>& parameters) {
   ModelVoltageLevel::defineParameters(parameters);
   ModelLine::defineParameters(parameters);

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
@@ -204,6 +204,11 @@ class ModelNetwork : public ModelCPP, private boost::noncopyable {
   void defineVariables(std::vector<boost::shared_ptr<Variable> >& variables) override;
 
   /**
+   * @copydoc SubModel::defineVariablesInit(std::vector<boost::shared_ptr<Variable> >& variables)
+   */
+  void defineVariablesInit(std::vector<boost::shared_ptr<Variable> >& variables) override;
+
+  /**
    * @brief fill calculated variable and index for one component
    * @param component for which to add calculated variables
    */


### PR DESCRIPTION
them in the init model values
closes #3529

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
