### PR TITLE
#3594 Update seaprators in messages to avoid using default separators…

### DIFF
--- a/dynawo/sources/Modeler/Common/DYNCompiler.cpp
+++ b/dynawo/sources/Modeler/Common/DYNCompiler.cpp
@@ -209,9 +209,9 @@ Compiler::compileModelTemplateExpansionDescription(const std::shared_ptr<ModelDe
   string id = DYNLog(CompilingModel, modelTemplateExpansionDescription->getID()).str();
   int l = static_cast<int>(id.size() / 2);
   Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
-  Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
-  Trace::info(Trace::compile()) << "|" << std::setw(50 + l) << id << std::setw(50 - l - 1) << "|" << Trace::endline;
-  Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦" << std::setw(50 + l) << id << std::setw(50 - l - 1) << "¦" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
   Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
   string modelID(modelTemplateExpansionDescription->getID());
   if (compiledModelDescriptions_.find(modelID) != compiledModelDescriptions_.end()) {
@@ -249,9 +249,9 @@ Compiler::compileBlackBoxModelDescription(const std::shared_ptr<ModelDescription
   string id = DYNLog(CompilingModel, blackBoxModelDescription->getID()).str();
   int l = static_cast<int>(id.size() / 2);
   Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
-  Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
-  Trace::info(Trace::compile()) << "|" << std::setw(50 + l) << id << std::setw(50 - l - 1) << "|" << Trace::endline;
-  Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦" << std::setw(50 + l) << id << std::setw(50 - l - 1) << "¦" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
   Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
   string modelID(blackBoxModelDescription->getID());
   if (compiledModelDescriptions_.find(modelID) != compiledModelDescriptions_.end()) {
@@ -315,9 +315,9 @@ Compiler::compileModelicaModelDescription(const std::shared_ptr<ModelDescription
   string id = DYNLog(CompilingModel, modelDescription->getID()).str();
   int l = static_cast<int>(id.size() / 2);
   Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
-  Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
-  Trace::info(Trace::compile()) << "|" << std::setw(50 + l) << id << std::setw(50 - l - 1) << "|" << Trace::endline;
-  Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦" << std::setw(50 + l) << id << std::setw(50 - l - 1) << "¦" << Trace::endline;
+  Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
   Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
 
   // concat models

--- a/dynawo/sources/Modeler/Common/DYNDynamicData.cpp
+++ b/dynawo/sources/Modeler/Common/DYNDynamicData.cpp
@@ -139,9 +139,9 @@ DynamicData::mappingModelicaModels() {
     const string id = "Mapping Modelica Model " + itModelica->first;
     int l = static_cast<int>(id.size() / 2);
     Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
-    Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
-    Trace::info(Trace::compile()) << "|" << setw(50 + l) << id << setw(50 - l - 1) << "|" << Trace::endline;
-    Trace::info(Trace::compile()) << "|                                                                                                  |" << Trace::endline;
+    Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
+    Trace::info(Trace::compile()) << "¦" << setw(50 + l) << id << setw(50 - l - 1) << "¦" << Trace::endline;
+    Trace::info(Trace::compile()) << "¦                                                                                                  ¦" << Trace::endline;
     Trace::info(Trace::compile()) << "====================================================================================================" << Trace::endline;
 
     // search in mapped model library, if already mapped, return.

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
@@ -1094,7 +1094,7 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::string>& xNames = (*it)->xNamesInit();
     for (unsigned int j = 0; j < xNames.size(); ++j) {
-       Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " | " << xNames[j] << Trace::endline;
+       Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " ¦ " << xNames[j] << Trace::endline;
        ++nVar;
     }
   }
@@ -1105,7 +1105,7 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::string>& xNames = (*it)->getCalculatedVarNamesInit();
     for (unsigned int j = 0; j < xNames.size(); ++j) {
-       Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " | " << xNames[j] << Trace::endline;
+       Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " ¦ " << xNames[j] << Trace::endline;
        ++nVar;
     }
   }
@@ -1116,7 +1116,7 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::string>& zNames = (*it)->zNamesInit();
     for (unsigned int j = 0; j < zNames.size(); ++j) {
-      Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " | " << zNames[j] << Trace::endline;
+      Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " ¦ " << zNames[j] << Trace::endline;
       ++nVar;
     }
   }
@@ -1131,9 +1131,9 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::string>& xNames = (*it)->xNames();
     for (unsigned int j = 0; j < xNames.size(); ++j) {
-      std::string varName = (*it)->name() + " | " + xNames[j];
+      std::string varName = (*it)->name() + " ¦ " + xNames[j];
       if (withVariableType) {
-        Trace::debug(Trace::variables()) << nVar << " " << varName << " | " << propertyVar2Str(modelYType[nVar]) << Trace::endline;
+        Trace::debug(Trace::variables()) << nVar << " " << varName << " ¦ " << propertyVar2Str(modelYType[nVar]) << Trace::endline;
       } else {
         Trace::debug(Trace::variables()) << nVar << " " << varName << Trace::endline;
       }
@@ -1143,8 +1143,8 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::pair<std::string, std::pair<std::string, bool > > >& xAlias = (*it)->xAliasesNames();
     for (unsigned int j = 0; j < xAlias.size(); ++j) {
-      Trace::debug(Trace::variables()) << (*it)->name() << " | " << xAlias[j].first << " is an alias of " <<
-          (*it)->name() << " | " << xAlias[j].second.first << " (negated: " << xAlias[j].second.second << ")" << Trace::endline;
+      Trace::debug(Trace::variables()) << (*it)->name() << " ¦ " << xAlias[j].first << " is an alias of " <<
+          (*it)->name() << " ¦ " << xAlias[j].second.first << " (negated: " << xAlias[j].second.second << ")" << Trace::endline;
     }
   }
   nVar = 0;
@@ -1154,7 +1154,7 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::string>& xNames = (*it)->getCalculatedVarNames();
     for (unsigned int j = 0; j < xNames.size(); ++j) {
-      std::string varName = (*it)->name() + " | " + xNames[j];
+      std::string varName = (*it)->name() + " ¦ " + xNames[j];
       Trace::debug(Trace::variables()) << nVar << " " << varName << Trace::endline;
       ++nVar;
     }
@@ -1166,14 +1166,14 @@ void ModelMulti::printVariableNames(bool withVariableType) {
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::string>& zNames = (*it)->zNames();
     for (unsigned int j = 0; j < zNames.size(); ++j) {
-       Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " | " << zNames[j] << Trace::endline;
+       Trace::debug(Trace::variables()) << nVar << " " << (*it)->name() << " ¦ " << zNames[j] << Trace::endline;
        ++nVar;
     }
   }
   for (std::vector<boost::shared_ptr<DYN::SubModel> >::const_iterator it = subModels_.begin(); it != subModels_.end(); ++it) {
     const std::vector<std::pair<std::string, std::pair<std::string, bool > > >& zAlias = (*it)->zAliasesNames();
     for (unsigned int j = 0; j < zAlias.size(); ++j) {
-      Trace::debug(Trace::variables()) << (*it)->name() << " | " << zAlias[j].first << " is an alias of "
+      Trace::debug(Trace::variables()) << (*it)->name() << " ¦ " << zAlias[j].first << " is an alias of "
           << (*it)->name() << "_" << zAlias[j].second.first << " (negated: " << zAlias[j].second.second << ")" << Trace::endline;
     }
   }

--- a/dynawo/sources/Modeler/Common/DYNSubModel.cpp
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.cpp
@@ -1248,7 +1248,7 @@ void
 SubModel::printMessages() {
   std::list<string>::const_iterator iter;
   for (iter = messages_.begin(); iter != messages_.end(); ++iter)
-    Trace::info() << getCurrentTime() << " | " << name() << " : " << *iter << Trace::endline;
+    Trace::info() << getCurrentTime() << " ¦ " << name() << " : " << *iter << Trace::endline;
 
   messages_.clear();
 }

--- a/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
@@ -530,12 +530,12 @@ SolverCommonFixedTimeStep::setDifferentialVariablesIndices() {
 
 void
 SolverCommonFixedTimeStep::printHeaderSpecific(std::stringstream& ss) const {
-  ss << "| iter num   Nonlinear iter   jac eval      time step (h)";
+  ss << "¦ iter num   Nonlinear iter   jac eval      time step (h)";
 }
 
 void
 SolverCommonFixedTimeStep::printSolveSpecific(std::stringstream& msg) const {
-  msg << "| " << setw(8) << stats_.nst_ << " "
+  msg << "¦ " << setw(8) << stats_.nst_ << " "
           << setw(16) << stats_.nni_ << " "
           << setw(10) << stats_.nje_ << " "
           << setw(18) << h_ << " ";

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/TestBasics.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/TestBasics.cpp
@@ -523,7 +523,7 @@ TEST(SimulationTest, testSolverSkipNR) {
   // Solve at t = 2
   solver->solve(tStop, tCurrent);
   std::stringstream msg;
-  msg << "| " << std::setw(8) << 2 << " "
+  msg << "¦ " << std::setw(8) << 2 << " "
           << std::setw(16) << 0 << " "
           << std::setw(10) << 0 << " "
           << std::setw(18) << 1 << " ";
@@ -536,7 +536,7 @@ TEST(SimulationTest, testSolverSkipNR) {
   // Solve at t = 4 -> skipNextNR_ = false
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 4 << " "
+  msg << "¦ " << std::setw(8) << 4 << " "
           << std::setw(16) << 0 << " "
           << std::setw(10) << 0 << " "
           << std::setw(18) << 1 << " ";
@@ -549,7 +549,7 @@ TEST(SimulationTest, testSolverSkipNR) {
   // Solve at t = 6
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 6 << " "
+  msg << "¦ " << std::setw(8) << 6 << " "
           << std::setw(16) << 1 << " "
           << std::setw(10) << 2 << " "
           << std::setw(18) << 1 << " ";
@@ -560,7 +560,7 @@ TEST(SimulationTest, testSolverSkipNR) {
   // Solve at t = 7
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 7 << " "
+  msg << "¦ " << std::setw(8) << 7 << " "
           << std::setw(16) << 1 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";
@@ -597,7 +597,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluations) {
   // Solve at t = 2
   solver->solve(tStop, tCurrent);
   std::stringstream msg;
-  msg << "| " << std::setw(8) << 2 << " "
+  msg << "¦ " << std::setw(8) << 2 << " "
           << std::setw(16) << 0 << " "
           << std::setw(10) << 0 << " "
           << std::setw(18) << 1 << " ";
@@ -613,7 +613,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluations) {
   // Solve at t = 4 -> optimizeAlgebraicResidualsEvaluations = true
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 4 << " "
+  msg << "¦ " << std::setw(8) << 4 << " "
           << std::setw(16) << 1 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";
@@ -629,7 +629,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluations) {
   solver->solve(tStop, tCurrent);
   solver->reinit();
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 6 << " "
+  msg << "¦ " << std::setw(8) << 6 << " "
           << std::setw(16) << 2 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";
@@ -641,7 +641,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluations) {
   // Solve at t = 7
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 7 << " "
+  msg << "¦ " << std::setw(8) << 7 << " "
           << std::setw(16) << 1 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";
@@ -680,7 +680,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluationsAndSkipNR) {
   // Solve at t = 2
   solver->solve(tStop, tCurrent);
   std::stringstream msg;
-  msg << "| " << std::setw(8) << 2 << " "
+  msg << "¦ " << std::setw(8) << 2 << " "
           << std::setw(16) << 0 << " "
           << std::setw(10) << 0 << " "
           << std::setw(18) << 1 << " ";
@@ -697,7 +697,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluationsAndSkipNR) {
   // and optimizeAlgebraicResidualsEvaluations = true
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 4 << " "
+  msg << "¦ " << std::setw(8) << 4 << " "
           << std::setw(16) << 1 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";
@@ -714,7 +714,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluationsAndSkipNR) {
   solver->solve(tStop, tCurrent);
   solver->reinit();
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 6 << " "
+  msg << "¦ " << std::setw(8) << 6 << " "
           << std::setw(16) << 2 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";
@@ -726,7 +726,7 @@ TEST(SimulationTest, testSolverOptimizeAlgebraicResidualsEvaluationsAndSkipNR) {
   // Solve at t = 7
   solver->solve(tStop, tCurrent);
   msg.str(std::string());
-  msg << "| " << std::setw(8) << 7 << " "
+  msg << "¦ " << std::setw(8) << 7 << " "
           << std::setw(16) << 1 << " "
           << std::setw(10) << 1 << " "
           << std::setw(18) << 1 << " ";

--- a/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp
+++ b/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp
@@ -796,7 +796,7 @@ double SolverIDA::getTimeStep() const {
 
 void
 SolverIDA::printHeaderSpecific(std::stringstream& ss) const {
-  ss << "| iter num   order (k)      time step (h)";
+  ss << "¦ iter num   order (k)      time step (h)";
 }
 
 void
@@ -818,7 +818,7 @@ SolverIDA::printSolveSpecific(std::stringstream& msg) const {
   int kused = 0;
   double hused = 0.;
   getLastConf(nst, kused, hused);
-  msg << "| " << setw(8) << nst << " "
+  msg << "¦ " << setw(8) << nst << " "
           << setw(11) << kused << " "
           << setw(18) << hused << " ";
 }


### PR DESCRIPTION
… of log files.

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
