### PR TITLE
#3652 Add info when dictionnaries are not the same.

### DIFF
--- a/dynawo/sources/Common/Dictionaries/validateDictionaries.py
+++ b/dynawo/sources/Common/Dictionaries/validateDictionaries.py
@@ -89,6 +89,9 @@ class DictionariesPool:
         if set(dictionary1.messages) != set(dictionary2.messages):
             print("Error: " + str(dictionary1.paths) + " and "
                   + str(dictionary2.paths) + " have not the same entries.")
+            print("Missing entries:")
+            for entry in set(dictionary1.messages).difference(set(dictionary2.messages)):
+                print("  " + entry)
             return False
 
         return True

--- a/dynawo/sources/Common/test/TestValidateDic.cpp
+++ b/dynawo/sources/Common/test/TestValidateDic.cpp
@@ -60,7 +60,7 @@ TEST(Models, TestBuildCheckSum) {
   boost::erase_all(result, "\n");
   ASSERT_EQ(result, "Executing command : " + cmd +
     "Error: ['dic/differentKeys/DifferentKeys_en_GB.dic'] and "
-    "['dic/differentKeys/DifferentKeys_fr_FR.dic'] have not the same entries.");
+    "['dic/differentKeys/DifferentKeys_fr_FR.dic'] have not the same entries.Missing entries:  Key2");
   ssPython.str(std::string());
 
   cmd = pythonCmd + " validateDictionaries.py --inputDir dic/argsCount/";


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
