### PR TITLE
#3512 ad-hoc, low-level fix

### DIFF
--- a/dynawo/sources/Modeler/DataInterface/DYNComponentInterface.cpp
+++ b/dynawo/sources/Modeler/DataInterface/DYNComponentInterface.cpp
@@ -66,8 +66,17 @@ ComponentInterface::setModelDyn(const shared_ptr<SubModel>& model) {
 void
 ComponentInterface::setReference(const string& componentVar, const string& modelId, const string& modelVar) {
   int index = getComponentVarIndex(componentVar);
-  if (index == -1)
+  if (index == -1) {
+    // quick fix to #3512, encompassing all nrts from dyn and dyn-rte as of 06/2025
+    if ((componentVar == "regulatingMode") && (modelVar == "SVarC_modeHandling_mode_value")) {
+      Trace::warn() << "could not map SVarC_modeHandling_mode_value to regulatingMode on model "
+                    << modelId
+                    << ", probably because standbyAutomaton iidm extension is missing"
+                    << Trace::endline;
+      return;
+    }
     throw DYNError(Error::MODELER, UnknownStateVariable, componentVar, getID());
+  }
   stateVariables_[index].setModelId(modelId);
   stateVariables_[index].setVariableId(modelVar);
 }


### PR DESCRIPTION


- [x ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
