### PR TITLE
#3850 Correctly compute modes obtained during global init to solve again

### DIFF
--- a/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
@@ -262,7 +262,6 @@ bool
 SolverCommonFixedTimeStep::calculateICCommonModeChange(int& counter, bool& change) {
   // Updating discrete variable values and mode
   model_->evalG(tSolve_, g1_);
-  modeChangeType_t modeChangeType = model_->getModeChangeType();
   if (std::equal(g0_.begin(), g0_.end(), g1_.begin())) {
     return true;
   } else {
@@ -273,6 +272,7 @@ SolverCommonFixedTimeStep::calculateICCommonModeChange(int& counter, bool& chang
     change = evalZMode(g0_, g1_, tSolve_);
   }
 
+  const modeChangeType_t modeChangeType = model_->getModeChangeType();
   model_->rotateBuffers();
   state_.reset();
   model_->reinitMode();


### PR DESCRIPTION
if required
closes #3850

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies the parameters or inputs/outputs of a model/solver: the corresponding xsl was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
