### PR TITLE
#3806 TransferFunction : more complete initialization, x_start -> u_start, y_start removed

### DIFF
--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/IEC/IEC61400/BaseControls/WPP/LinearCommunication.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/IEC/IEC61400/BaseControls/WPP/LinearCommunication.mo
@@ -32,7 +32,7 @@ model LinearCommunication "Linear communication module (IEC N°61400-27-1)"
   Modelica.Blocks.Interfaces.RealVectorOutput y[nu] "Connector of Real vector input signal" annotation(
     Placement(visible = true, transformation(extent = {{80, 70}, {120, -70}}, rotation = 0), iconTransformation(extent = {{80, 70}, {120, -70}}, rotation = 0)));
 
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag[nu](each a = {tLag, 1}, each b = {tLead, 1}, x_start = [X0Pu], y_start = X0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag[nu](each a = {tLag, 1}, each b = {tLead, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = X0Pu) annotation(
     Placement(visible = true, transformation(origin = {0, 0}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
 
   //Initial parameter

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/IEC/IEC61400/BaseControls/WPP/WPPPControl2015.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/IEC/IEC61400/BaseControls/WPP/WPPPControl2015.mo
@@ -47,7 +47,7 @@ model WPPPControl2015 "Active power control module for wind power plants (IEC NÂ
     Placement(visible = true, transformation(origin = {110, -90}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.MathBoolean.Or or1(nu = 2) annotation(
     Placement(visible = true, transformation(origin = {110, -40}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tpfv, 1},b = {tpft, 1}, x_start = {-P0Pu*SystemBase.SnRef/SNom}, y_start = -P0Pu * SystemBase.SnRef / SNom) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tpfv, 1},b = {tpft, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = -P0Pu * SystemBase.SnRef / SNom) annotation(
     Placement(visible = true, transformation(origin = {170, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.Continuous.AbsLimRateLimFeedthroughFreeze absLimRateLimFeedthroughFreeze(DyMax = DPRefMaxPu, DyMin = DPRefMinPu, U0 = -P0Pu*SystemBase.SnRef/SNom, Y0 = -P0Pu*SystemBase.SnRef/SNom, YMax = PRefMaxPu, YMin = PRefMinPu, tS = tS) annotation(
     Placement(visible = true, transformation(origin = {204, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/IEC/IEC61400/BaseControls/WPP/WPPQControl2015.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/IEC/IEC61400/BaseControls/WPP/WPPQControl2015.mo
@@ -54,7 +54,7 @@ model WPPQControl2015 "Reactive power control module for wind power plants (IEC 
     Placement(visible = true, transformation(origin = {-290, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.Continuous.AbsLimRateLimFeedthroughFreezeLimDetection absLimRateLimFeedthroughFreezeLimDetection1(DyMax = DXRefMaxPu, DyMin = DXRefMinPu, U0 = XWT0Pu, Y0 = XWT0Pu, YMax = XRefMaxPu, YMin = XRefMinPu, tS = tS) annotation(
     Placement(visible = true, transformation(origin = {326, 100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {txfv, 1}, b = {txft, 1}, x_start = {XWT0Pu}, y_start = XWT0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {txfv, 1}, b = {txft, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = XWT0Pu) annotation(
     Placement(visible = true, transformation(origin = {296, 100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Sources.BooleanConstant booleanConstant(k = false) annotation(
     Placement(visible = true, transformation(origin = {260, 138}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Standard/Generic/GovCt2.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Standard/Generic/GovCt2.mo
@@ -278,9 +278,9 @@ model GovCt2 "Governor type GovCT2"
     Placement(visible = true, transformation(origin = {272, -126}, extent = {{10, -10}, {-10, 10}}, rotation = -90)));
   Modelica.Blocks.Tables.CombiTable1Ds tablePLimFromf(extrapolation = Modelica.Blocks.Types.Extrapolation.LastTwoPoints, smoothness = Modelica.Blocks.Types.Smoothness.LinearSegments, table = PLimFromfPoints, tableOnFile = false, verboseRead = false) annotation(
     Placement(visible = true, transformation(origin = {138, 38}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunctCtB(a = {tB, 1}, b = {tC, 1}, x_start = {initPMechNoLossPu}, y_start = initPMechNoLossPu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunctCtB(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = initPMechNoLossPu) annotation(
     Placement(visible = true, transformation(origin = {254, 106}, extent = {{10, -10}, {-10, 10}}, rotation = -90)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunctSAtSB(a = {tSB, 1}, b = {tSA, 1}, x_start = {initTexPu}, y_start = initTexPu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunctSAtSB(a = {tSB, 1}, b = {tSA, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = initTexPu) annotation(
     Placement(visible = true, transformation(origin = {80, 114}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
 
   // Initial parameters

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Standard/Steam/IEEEG2.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Standard/Steam/IEEEG2.mo
@@ -42,7 +42,7 @@ model IEEEG2 "IEEE governor type IEEEG2"
     Placement(visible = true, transformation(origin = {30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Nonlinear.Limiter limiter(homotopyType = Modelica.Blocks.Types.LimiterHomotopy.NoHomotopy, uMax = PMaxPu, uMin = PMinPu) annotation(
     Placement(visible = true, transformation(origin = {70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {t4 / 2, 1}, b = {-t4, 1}, x_start = {Pm0Pu}, y_start = Pm0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {t4 / 2, 1}, b = {-t4, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Pm0Pu) annotation(
     Placement(visible = true, transformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {t3, 1}, b = {t2, 1}) annotation(
     Placement(visible = true, transformation(origin = {-30, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Standard/Steam/TGov1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/Governors/Standard/Steam/TGov1.mo
@@ -36,7 +36,7 @@ model TGov1 "IEEE governor type TGOV1"
   Modelica.Blocks.Interfaces.RealOutput PmPu(start = Pm0Pu) "Mechanical power in pu (base PNomTurb)" annotation(
     Placement(visible = true, transformation(origin = {150, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {t3, 1}, b = {t2, 1}, x_start = {Pm0Pu}, y_start = Pm0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {t3, 1}, b = {t2, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Pm0Pu) annotation(
     Placement(visible = true, transformation(origin = {70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add add(k2 = -1) annotation(
     Placement(visible = true, transformation(origin = {-90, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/OverExcitationLimiters/Standard/Oel5c.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/OverExcitationLimiters/Standard/Oel5c.mo
@@ -72,7 +72,7 @@ model Oel5c "IEEE (2016) overexcitation limiter type OEL5C model"
     Placement(visible = true, transformation(origin = {-160, -140}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
   Modelica.Blocks.Continuous.FirstOrder firstOrder2(T = tF2, k = KScale2, y_start = KScale2 * Vfe0Pu) annotation(
     Placement(visible = true, transformation(origin = {-210, -100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunctionBypass transferFunction(a = {tBOel, 1}, b = {tCOel, 1}, x_start = {KScale1 * Input0Pu}, y_start = KScale1 * Input0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunctionBypass transferFunction(a = {tBOel, 1}, b = {tCOel, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = KScale1 * Input0Pu) annotation(
     Placement(visible = true, transformation(origin = {-110, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain(k = KIfdt) annotation(
     Placement(visible = true, transformation(origin = {-50, 100}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Simplified/VRNordic.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Simplified/VRNordic.mo
@@ -79,7 +79,7 @@ model VRNordic "Voltage regulator model for the Nordic 32 test system used for v
     Placement(visible = true, transformation(origin = {-270, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Continuous.LimIntegrator timer(outMax = 99, outMin = tOelMin, y_start = tOelMin) annotation(
     Placement(visible = true, transformation(origin = {-150, 40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {tLagTgr, 1}, b = {tLeadTgr, 1}, x_start = {Efd0Pu}, y_start = Efd0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {tLagTgr, 1}, b = {tLeadTgr, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Efd0Pu) annotation(
     Placement(visible = true, transformation(origin = {90, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback dU annotation(
     Placement(visible = true, transformation(origin = {-220, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc1.mo
@@ -59,7 +59,7 @@ partial model BaseAc1 "IEEE excitation system type AC1 base model"
     Placement(visible = true, transformation(origin = {-250, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add3 add3(k2 = -1) annotation(
     Placement(visible = true, transformation(origin = {-190, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB, 1}, b = {tC, 1}, x_start = {Efe0Pu / Ka}, y_start = Efe0Pu / Ka) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Efe0Pu / Ka) annotation(
     Placement(visible = true, transformation(origin = {-30, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback annotation(
     Placement(visible = true, transformation(origin = {-80, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc6.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc6.mo
@@ -61,7 +61,7 @@ partial model BaseAc6 "IEEE excitation system type AC6 base model"
     Placement(visible = true, transformation(origin = {-290, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add3 add3(k2 = -1) annotation(
     Placement(visible = true, transformation(origin = {-230, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tA, 1}, b = {tK, 1}, x_start = {Va0Pu}, y_start = Va0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tA, 1}, b = {tK, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Va0Pu) annotation(
     Placement(visible = true, transformation(origin = {-90, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback annotation(
     Placement(visible = true, transformation(origin = {120, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
@@ -95,7 +95,7 @@ partial model BaseAc6 "IEEE excitation system type AC6 base model"
     Placement(visible = true, transformation(origin = {230, -80}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
   Modelica.Blocks.Nonlinear.Limiter limiter(homotopyType = Modelica.Blocks.Types.LimiterHomotopy.NoHomotopy, uMax = VhMaxPu, uMin = 0) annotation(
     Placement(visible = true, transformation(origin = {190, -80}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tH, 1}, b = {tJ, 1}, x_start = {Vh0Pu}, y_start = Vh0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tH, 1}, b = {tJ, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Vh0Pu) annotation(
     Placement(visible = true, transformation(origin = {150, -80}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain2(k = EfeMaxPu) annotation(
     Placement(visible = true, transformation(origin = {-230, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseDc1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseDc1.mo
@@ -51,7 +51,7 @@ partial model BaseDc1 "IEEE excitation system type DC1 base model"
     Placement(visible = true, transformation(origin = {-210, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback annotation(
     Placement(visible = true, transformation(origin = {-120, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB, 1}, b = {tC, 1}, x_start = {Va0Pu / Ka}, y_start = Va0Pu / Ka) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Va0Pu / Ka) annotation(
     Placement(visible = true, transformation(origin = {-70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedFirstOrder limitedFirstOrder(K = Ka, Y0 = Va0Pu, YMax = VrMaxPu, YMin = VrMinPu, tFilter = tA) annotation(
     Placement(visible = true, transformation(origin = {50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseIEEEX.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseIEEEX.mo
@@ -52,7 +52,7 @@ partial model BaseIEEEX "IEEE excitation system base model"
     Placement(visible = true, transformation(origin = {-170, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback annotation(
     Placement(visible = true, transformation(origin = {-120, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB, 1}, b = {tC, 1}, x_start = {Va0Pu / Ka}, y_start = Va0Pu / Ka) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Va0Pu / Ka) annotation(
     Placement(visible = true, transformation(origin = {-70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedFirstOrder limitedFirstOrder(K = Ka, Y0 = Va0Pu, YMax = VrMaxPu, YMin = VrMinPu, tFilter = tA) annotation(
     Placement(visible = true, transformation(origin = {-30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt1.mo
@@ -57,7 +57,7 @@ partial model BaseSt1 "IEEE excitation system type ST1 base model"
 
   Modelica.Blocks.Continuous.FirstOrder firstOrder(T = tR, y_start = Us0Pu) annotation(
     Placement(visible = true, transformation(origin = {-370, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tB, 1}, b = {tC, 1}, x_start = {Va0Pu / Ka}, y_start = Va0Pu / Ka) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Va0Pu / Ka) annotation(
     Placement(visible = true, transformation(origin = {10, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback annotation(
     Placement(visible = true, transformation(origin = {-200, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
@@ -65,7 +65,7 @@ partial model BaseSt1 "IEEE excitation system type ST1 base model"
     Placement(visible = true, transformation(origin = {90, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Continuous.Derivative derivative(k = Kf, T = tF, x_start = Efd0Pu) annotation(
     Placement(visible = true, transformation(origin = {-150, -40}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB1, 1}, b = {tC1, 1}, x_start = {Va0Pu / Ka}, y_start = Va0Pu / Ka) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB1, 1}, b = {tC1, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Va0Pu / Ka) annotation(
     Placement(visible = true, transformation(origin = {50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Nonlinear.Limiter limiter(homotopyType = Modelica.Blocks.Types.LimiterHomotopy.NoHomotopy, uMax = ViMaxPu, uMin = ViMinPu) annotation(
     Placement(visible = true, transformation(origin = {-150, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt5.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt5.mo
@@ -55,7 +55,7 @@ partial model BaseSt5 "IEEE excitation system type ST5 base model"
 
   Modelica.Blocks.Continuous.FirstOrder firstOrder(T = tR, y_start = Us0Pu) annotation(
     Placement(visible = true, transformation(origin = {-310, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB2, 1}, b = {tC2, 1}, x_start = {Vr0Pu}, y_start = Vr0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB2, 1}, b = {tC2, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Vr0Pu) annotation(
     Placement(visible = true, transformation(origin = {70, 80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain(k = Kc) annotation(
     Placement(visible = true, transformation(origin = {170, 160}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
@@ -85,9 +85,9 @@ partial model BaseSt5 "IEEE excitation system type ST5 base model"
     Placement(visible = true, transformation(origin = {110, 80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedLeadLag limitedLeadLag1(t1 = tUC1, t2 = tUB1, Y0 = Vr0Pu, YMax = VrMaxPu, YMin = VrMinPu) annotation(
     Placement(visible = true, transformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tUB2, 1}, b = {tUC2, 1}, x_start = {Vr0Pu}, y_start = Vr0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tUB2, 1}, b = {tUC2, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Vr0Pu) annotation(
     Placement(visible = true, transformation(origin = {70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction2(a = {tOB2, 1}, b = {tOC2, 1}, x_start = {Vr0Pu}, y_start = Vr0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction2(a = {tOB2, 1}, b = {tOC2, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Vr0Pu) annotation(
     Placement(visible = true, transformation(origin = {70, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedLeadLag limitedLeadLag2(t1 = tOC1, t2 = tOB1, Y0 = Vr0Pu, YMax = VrMaxPu, YMin = VrMinPu) annotation(
     Placement(visible = true, transformation(origin = {110, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt7.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt7.mo
@@ -58,7 +58,7 @@ partial model BaseSt7 "IEEE excitation system type ST7 base model"
 
   Modelica.Blocks.Continuous.FirstOrder firstOrder(T = tR, y_start = Us0Pu) annotation(
     Placement(visible = true, transformation(origin = {-330, -100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tB, 1}, b = {tC, 1}, x_start = {(1 + Kia) * Efd0Pu}, y_start = (1 + Kia) * Efd0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction1(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = (1 + Kia) * Efd0Pu) annotation(
     Placement(visible = true, transformation(origin = {70, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Nonlinear.Limiter limiter(homotopyType = Modelica.Blocks.Types.LimiterHomotopy.NoHomotopy, uMax = VMaxPu, uMin = VMinPu) annotation(
     Placement(visible = true, transformation(origin = {-210, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
@@ -88,7 +88,7 @@ partial model BaseSt7 "IEEE excitation system type ST7 base model"
     Placement(visible = true, transformation(origin = {30, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add3 add3(k3 = -1) annotation(
     Placement(visible = true, transformation(origin = {-130, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tF, 1}, b = {tG, 1}, x_start = {Us0Pu}, y_start = Us0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tF, 1}, b = {tG, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Us0Pu) annotation(
     Placement(visible = true, transformation(origin = {-210, -100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Continuous.FirstOrder firstOrder2(T = tIa, k = Kia, y_start = Kia * Efd0Pu) annotation(
     Placement(visible = true, transformation(origin = {310, -60}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BbSex1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BbSex1.mo
@@ -45,7 +45,7 @@ model BbSex1 "Model of exciter BBSEX1"
 
   Modelica.Blocks.Math.Sum sum1(k = {1, 1, 1, 1, -1}, nin = 5) annotation(
     Placement(visible = true, transformation(origin = {-90, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {t4 , 1}, b = {t3 , 1}, x_start = {Efd0Pu / K}, y_start = Efd0Pu / K) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {t4 , 1}, b = {t3 , 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Efd0Pu / K) annotation(
     Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain1(k =  t2 / t1) annotation(
     Placement(visible = true, transformation(origin = {50, -20}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/ExAc1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/ExAc1.mo
@@ -61,7 +61,7 @@ model ExAc1 "IEEE exciter type EXAC1 model, defined in IEEE 1981 Excitation Syst
 
   Modelica.Blocks.Continuous.FirstOrder firstOrder(T = tR, y_start = Us0Pu) annotation(
     Placement(visible = true, transformation(origin = {-250, -80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {tB, 1}, b = {tC, 1}, x_start = {Vr0Pu / Ka}, y_start = Vr0Pu / Ka) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {tB, 1}, b = {tC, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Vr0Pu / Ka) annotation(
     Placement(visible = true, transformation(origin = {-90, 80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add3 add3(k2 = Ke, k3 = Kd) annotation(
     Placement(visible = true, transformation(origin = {-30, -40}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/SCRX.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/SCRX.mo
@@ -46,7 +46,7 @@ model SCRX "Bus-fed or solid-fed exciter model"
 
   Modelica.Blocks.Math.Sum sum1(k = {1, 1, 1, 1, -1}, nin = 5) annotation(
     Placement(visible = true, transformation(origin = {-170, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB , 1}, b = {tA , 1}, x_start = {Vr0Pu / K}, y_start = Vr0Pu / K) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction transferFunction(a = {tB , 1}, b = {tA , 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Vr0Pu / K) annotation(
     Placement(visible = true, transformation(origin = {-130, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedFirstOrder limitedFirstOrder(K = K, Y0 = Vr0Pu, YMax = VrMaxPu, YMin = VrMinPu, tFilter = tE) annotation(
     Placement(visible = true, transformation(origin = {-90, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/SEXS.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/SEXS.mo
@@ -35,7 +35,7 @@ model SEXS "IEEE Automatic Voltage Regulator type SEXS (Simplified excitation sy
 
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedFirstOrder limitedFirstOrder(tFilter = Te, K = K, YMax = EMax, YMin = EMin, Y0 = Efd0Pu) annotation(
     Placement(visible = true, transformation(origin = {50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {Tb, 1}, b = {Ta, 1}, x_start = {Efd0Pu / K}, y_start = Efd0Pu / K) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {Tb, 1}, b = {Ta, 1}, initType = Modelica.Blocks.Types.Init.SteadyState, u_start = Efd0Pu / K) annotation(
     Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Add3 add3(k2 = -1) annotation(
     Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/REPC/REPCa.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/WECC/REPC/REPCa.mo
@@ -110,7 +110,7 @@ model REPCa "WECC Plant Control type A"
     Placement(visible = true, transformation(origin = {130, 50}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
   Dynawo.Electrical.Controls.WECC.BaseControls.VoltageCheck voltageCheck(UMinPu = VFrz, UMaxPu = 999) annotation(
     Placement(visible = true, transformation(origin = {-230, 94}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {tFv, 1}, b = {tFt, 1}, x_start = {QInj0Pu}, y_start = QInj0Pu) annotation(
+  Dynawo.NonElectrical.Blocks.Continuous.TransferFunction leadLag(a = {tFv, 1}, b = {tFt, 1}, initType = Modelica.Blocks.Types.Init.InitialState, x_start = {QInj0Pu}, y_start = QInj0Pu) annotation(
     Placement(visible = true, transformation(origin = {170, 50}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 
   parameter Types.PerUnit PGen0Pu "Start value of active power at regulated bus in pu (generator convention) (base SNom)";

--- a/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/Continuous/TransferFunction.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/Continuous/TransferFunction.mo
@@ -14,17 +14,23 @@ within Dynawo.NonElectrical.Blocks.Continuous;
 */
 
 block TransferFunction "Linear transfer function"
-  extends Modelica.Blocks.Interfaces.SISO(y(start = y_start));
+  import Modelica.Blocks.Types.Init;
+
+  extends Modelica.Blocks.Interfaces.SISO(y(start = Y0));
 
   parameter Real b[:] = {1} "Numerator coefficients of transfer function (e.g., 2*s+3 is specified as {2,3})";
   parameter Real a[:] = {1} "Denominator coefficients of transfer function (e.g., 5*s+6 is specified as {5,6})";
 
-  output Real x[nx](start = x_start) "State of transfer function from controller canonical form";
+  output Real x[nx](start = X0) "State of transfer function from controller canonical form";
 
-  parameter Real x_start[nx] = zeros(nx) "Initial or guess values of states" annotation(
+  parameter Modelica.Blocks.Types.Init initType = Modelica.Blocks.Types.Init.NoInit "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)" annotation(
     Dialog(group = "Initialization"));
-  parameter Real y_start = 0 "Initial value of output (derivatives of y are zero up to nx-1-th derivative)" annotation(
-    Dialog(group = "Initialization"));
+  parameter Real u_start = 0 "Initial value of input (SteadyState)" annotation(
+    Dialog(enable = initType == Init.SteadyState, group = "Initialization"));
+  parameter Real x_start[nx] = zeros(nx) "Initial or guess values of states (InitialState or InitialOutput)" annotation(
+    Dialog(enable = initType == Init.InitialState or initType == Init.InitialOutput, group = "Initialization"));
+  parameter Real y_start = 0 "Initial value of output (derivatives of y are zero up to nx-1-th derivative) (InitialState or InitialOutput)" annotation(
+    Dialog(enable = initType == Init.InitialState or initType == Init.InitialOutput, group = "Initialization"));
 
 protected
   parameter Integer na = size(a, 1) "Size of denominator of transfer function";
@@ -33,8 +39,10 @@ protected
   parameter Real bb[:] = vector([zeros(max(0,na-nb),1);b]) "Numerator coefficients, padded if necessary by zeroes for highest-order coefficients";
   parameter Real d = bb[1] / a[1] "Ratio of highest-order coefficients of numerator and denominator";
   parameter Real a_end = if a[end] > 100 * Modelica.Constants.eps * sqrt(a*a) then a[end] else 1 "Non-zero value of lowest-order coefficient of denominator";
+  parameter Real X0[nx] = if nx == 0 then {0} elseif initType == Init.SteadyState then cat(1, zeros(nx-1), {u_start / a_end}) elseif initType == Init.InitialState or initType == Init.InitialOutput then x_start else zeros(nx) "Initial or guess values of states";
+  parameter Real Y0 = if initType == Init.SteadyState then u_start * b[end] / a_end elseif initType == Init.InitialState or initType == Init.InitialOutput then y_start else 0 "Initial value of output (derivatives of y are zero up to nx-1-th derivative)";
 
-  Real x_scaled[nx](start = a_end * x_start) "Scaled vector x";
+  Real x_scaled[nx](start = X0 * a_end) "Scaled vector x";
 
 equation
   assert(size(b,1) <= size(a,1), "Transfer function is not proper");
@@ -64,8 +72,7 @@ State variables <strong>x</strong> are defined according to <strong>controller c
 form. Internally, vector <strong>x</strong> is scaled to improve the numerics (the states in versions before version 3.0 of the Modelica Standard Library have been not scaled). This scaling is
 not visible from the outside of this block because the non-scaled vector <strong>x</strong>
 is provided as output signal and the start value is with respect to the non-scaled
-vector <strong>x</strong>.
-Initial values of the states <strong>x</strong> can be set via parameter <strong>x_start</strong>.</p>
+vector <strong>x</strong>.&nbsp;</p>
 
 <p>
 Example:
@@ -77,7 +84,7 @@ results in the following transfer function:
 </p>
 <pre>      2*s + 4
  y = --------- * u
-       s + 3</pre><p>This block differs from the one of the same name in the Modelica Standard Library in one respect : the initial equations are absent since Dynawo ignores them, start values are given for&nbsp;<b>y</b>&nbsp;and for&nbsp;<b>x_scaled</b>&nbsp;instead.</p><p></p>
+       s + 3</pre><p>This block differs from the one of the same name in the Modelica Standard Library in one respect : the initial equations are absent since Dynawo ignores them, start values are given for&nbsp;<b>y</b>&nbsp;and for&nbsp;<b>x_scaled</b>&nbsp;instead.<br><br>Three initialization options are available :</p><p></p><ul><li>NoInit : <b>x</b>, <b>x_scaled</b> and <b>y</b> are initialized at 0;</li><li>SteadyState : the initial values of <b>x</b>, <b>x_scaled</b> and <b>y</b> depend on <b>u_start</b> (a parameter for the initial input value) with the goal of having derivative values equal to 0;</li><li>InitialState or InitialOutput : <b>x</b> and <b>x_scaled</b> are initialized on the basis of <b>x_start</b>, <b>y</b> is initialized at <b>y_start</b>.</li></ul>
 </body></html>"),
     Icon(
         coordinateSystem(preserveAspectRatio=true,

--- a/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/Continuous/TransferFunctionBypass.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/NonElectrical/Blocks/Continuous/TransferFunctionBypass.mo
@@ -14,17 +14,23 @@ within Dynawo.NonElectrical.Blocks.Continuous;
 */
 
 block TransferFunctionBypass "Linear transfer function, bypassed if highest-order coefficient of denominator is zero"
-  extends Modelica.Blocks.Interfaces.SISO(y(start = y_start));
+  import Modelica.Blocks.Types.Init;
+
+  extends Modelica.Blocks.Interfaces.SISO(y(start = Y0));
 
   parameter Real b[:] = {1} "Numerator coefficients of transfer function (e.g., 2*s+3 is specified as {2,3})";
   parameter Real a[:] = {1} "Denominator coefficients of transfer function (e.g., 5*s+6 is specified as {5,6})";
 
-  output Real x[nx](start = x_start) "State of transfer function from controller canonical form";
+  output Real x[nx](start = X0) "State of transfer function from controller canonical form";
 
-  parameter Real x_start[nx] = zeros(nx) "Initial or guess values of states" annotation(
+  parameter Modelica.Blocks.Types.Init initType = Modelica.Blocks.Types.Init.NoInit "Type of initialization (1: no init, 2: steady state, 3: initial state, 4: initial output)" annotation(
     Dialog(group = "Initialization"));
-  parameter Real y_start = 0 "Initial value of output (derivatives of y are zero up to nx-1-th derivative)" annotation(
-    Dialog(group = "Initialization"));
+  parameter Real u_start = 0 "Initial value of input (SteadyState)" annotation(
+    Dialog(enable = initType == Init.SteadyState, group = "Initialization"));
+  parameter Real x_start[nx] = zeros(nx) "Initial or guess values of states (InitialState or InitialOutput)" annotation(
+    Dialog(enable = initType == Init.InitialState or initType == Init.InitialOutput, group = "Initialization"));
+  parameter Real y_start = 0 "Initial value of output (derivatives of y are zero up to nx-1-th derivative) (InitialState or InitialOutput)" annotation(
+    Dialog(enable = initType == Init.InitialState or initType == Init.InitialOutput, group = "Initialization"));
 
 protected
   parameter Integer na = size(a, 1) "Size of denominator of transfer function";
@@ -34,8 +40,10 @@ protected
   parameter Real d = bb[1] / a_one "Ratio of highest-order coefficients of numerator and denominator";
   parameter Real a_one = if a[1] > 100 * Modelica.Constants.eps then a[1] else 1 "Non-zero value of highest-order coefficient of denominator";
   parameter Real a_end = if a[end] > 100 * Modelica.Constants.eps * sqrt(a*a) then a[end] else 1 "Non-zero value of lowest-order coefficient of denominator";
+  parameter Real X0[nx] = if nx == 0 then {0} elseif initType == Init.SteadyState then cat(1, zeros(nx-1), {u_start / a_end}) elseif initType == Init.InitialState or initType == Init.InitialOutput then x_start else zeros(nx) "Initial or guess values of states";
+  parameter Real Y0 = if initType == Init.SteadyState then u_start * b[end] / a_end elseif initType == Init.InitialState or initType == Init.InitialOutput then y_start else 0 "Initial value of output (derivatives of y are zero up to nx-1-th derivative)";
 
-  Real x_scaled[nx](start = a_end * x_start) "Scaled vector x";
+  Real x_scaled[nx](start = X0 * a_end) "Scaled vector x";
 
 equation
   assert(size(b,1) <= size(a,1), "Transfer function is not proper");
@@ -71,8 +79,7 @@ State variables <strong>x</strong> are defined according to <strong>controller c
 form. Internally, vector <strong>x</strong> is scaled to improve the numerics (the states in versions before version 3.0 of the Modelica Standard Library have been not scaled). This scaling is
 not visible from the outside of this block because the non-scaled vector <strong>x</strong>
 is provided as output signal and the start value is with respect to the non-scaled
-vector <strong>x</strong>.
-Initial values of the states <strong>x</strong> can be set via parameter <strong>x_start</strong>.</p>
+vector <strong>x</strong>.</p>
 
 <p>
 Example:
@@ -84,8 +91,7 @@ results in the following transfer function:
 </p>
 <pre>      2*s + 4
  y = --------- * u
-       s + 3</pre><p><span style=\"font-family: 'DejaVu Sans Mono'; font-size: 12px;\">This block differs from the one of the same name in the Modelica Standard Library</span>&nbsp;on two counts :</p><ul><li>If the highest-order component of the denominator is zero, the block returns the input as output;</li><li>The initial equations are absent since Dynawo ignores them, start values are given for&nbsp;<b>y</b>&nbsp;and for&nbsp;<b>x_scaled</b>&nbsp;instead.</li></ul><p></p>
-</body></html>"),
+       s + 3</pre><p><span style=\"font-family: 'DejaVu Sans Mono'; font-size: 12px;\">This block differs from the TransferFunction block in the Modelica Standard Library</span>&nbsp;on two counts :</p><ul><li>If the highest-order component of the denominator is zero, the block returns the input as output;</li><li>The initial equations are absent since Dynawo ignores them, start values are given for&nbsp;<b>y</b>&nbsp;and for&nbsp;<b>x_scaled</b>&nbsp;instead.</li></ul>Three initialization options are available :<div><ul><li>NoInit : <b>x</b>, <b>x_scaled</b> and <b>y</b> are initialized at 0;</li><li>SteadyState : the initial values of <b>x</b>, <b>x_scaled</b> and <b>y</b> depend on <b>u_start</b> (a parameter for the initial input value) with the goal of having derivative values equal to 0;</li><li>InitialState or InitialOutput : <b>x</b> and <b>x_scaled</b> are initialized on the basis of <b>x_start</b>, <b>y</b> is initialized at <b>y_start</b>.</li></ul></div></body></html>"),
     Icon(
         coordinateSystem(preserveAspectRatio=true,
           extent={{-100.0,-100.0},{100.0,100.0}}),


### PR DESCRIPTION
In the first commit, the TransferFunction block is modified in order to assign start values consistent with the different initialization types of the MSL block of the same name. In the second commit, y_start is calculated on the basis of u_start. The non-regression tests are successful for both versions.
