### PR TITLE
#3880 VariableLimiter from Dynawo in DynaSwing regulations

### DIFF
--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc6.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc6.mo
@@ -69,7 +69,7 @@ partial model BaseAc6 "IEEE excitation system type AC6 base model"
     Placement(visible = true, transformation(origin = {-130, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.NonElectrical.Blocks.NonLinear.LimitedLeadLag limitedLeadLag(Y0 = Va0Pu, YMax = VaMaxPu, YMin = VaMinPu, t1 = tC, t2 = tB) annotation(
     Placement(visible = true, transformation(origin = {-50, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(homotopyType = Modelica.Blocks.Types.VariableLimiterHomotopy.NoHomotopy) annotation(
+  Dynawo.NonElectrical.Blocks.NonLinear.VariableLimiter variableLimiter annotation(
     Placement(visible = true, transformation(origin = {190, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.Electrical.Controls.Machines.VoltageRegulators.Standard.BaseClasses.AcRotatingExciter acRotatingExciter(
     AEx = AEx,

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc7.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseAc7.mo
@@ -107,7 +107,7 @@ partial model BaseAc7 "IEEE exciter type AC7 base model"
     Placement(visible = true, transformation(origin = {150, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Product product annotation(
     Placement(visible = true, transformation(origin = {270, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(homotopyType = Modelica.Blocks.Types.VariableLimiterHomotopy.NoHomotopy) annotation(
+  Dynawo.NonElectrical.Blocks.NonLinear.VariableLimiter variableLimiter annotation(
     Placement(visible = true, transformation(origin = {330, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Sources.Constant const(k = 999) annotation(
     Placement(visible = true, transformation(origin = {270, 40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt1.mo
@@ -79,7 +79,7 @@ partial model BaseSt1 "IEEE excitation system type ST1 base model"
     Placement(visible = true, transformation(origin = {140, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
   Modelica.Blocks.Math.Add3 add3(k3 = -1) annotation(
     Placement(visible = true, transformation(origin = {-310, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(homotopyType = Modelica.Blocks.Types.VariableLimiterHomotopy.NoHomotopy) annotation(
+  Dynawo.NonElectrical.Blocks.NonLinear.VariableLimiter variableLimiter annotation(
     Placement(visible = true, transformation(origin = {390, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain1(k = VrMaxPu) annotation(
     Placement(visible = true, transformation(origin = {250, 100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt5.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt5.mo
@@ -61,7 +61,7 @@ partial model BaseSt5 "IEEE excitation system type ST5 base model"
     Placement(visible = true, transformation(origin = {170, 160}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback1 annotation(
     Placement(visible = true, transformation(origin = {220, 0}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(homotopyType = Modelica.Blocks.Types.VariableLimiterHomotopy.NoHomotopy) annotation(
+  Dynawo.NonElectrical.Blocks.NonLinear.VariableLimiter variableLimiter annotation(
     Placement(visible = true, transformation(origin = {330, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain1(k = VrMaxPu) annotation(
     Placement(visible = true, transformation(origin = {270, 120}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt7.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BaseClasses/BaseSt7.mo
@@ -66,7 +66,7 @@ partial model BaseSt7 "IEEE excitation system type ST7 base model"
     Placement(visible = true, transformation(origin = {-90, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Feedback feedback1 annotation(
     Placement(visible = true, transformation(origin = {-60, -60}, extent = {{-10, -10}, {10, 10}}, rotation = 90)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(homotopyType = Modelica.Blocks.Types.VariableLimiterHomotopy.NoHomotopy) annotation(
+  Dynawo.NonElectrical.Blocks.NonLinear.VariableLimiter variableLimiter annotation(
     Placement(visible = true, transformation(origin = {310, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain1(k = VrMaxPu) annotation(
     Placement(visible = true, transformation(origin = {-90, 100}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BbSex1.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Controls/Machines/VoltageRegulators/Standard/BbSex1.mo
@@ -57,7 +57,7 @@ model BbSex1 "Model of exciter BBSEX1"
     Placement(visible = true, transformation(origin = {50, -60}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
   Modelica.Blocks.Continuous.FirstOrder firstOrder(T = t2, y_start = Efd0Pu) annotation(
     Placement(visible = true, transformation(origin = {90, -60}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-  Modelica.Blocks.Nonlinear.VariableLimiter variableLimiter(homotopyType = Modelica.Blocks.Types.VariableLimiterHomotopy.NoHomotopy) annotation(
+  Dynawo.NonElectrical.Blocks.NonLinear.VariableLimiter variableLimiter annotation(
     Placement(visible = true, transformation(origin = {170, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Math.Gain gain3(k = EfdMaxPu) annotation(
     Placement(visible = true, transformation(origin = {-90, 80}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));


### PR DESCRIPTION
All non-regression tests are successful, the .csv files are almost identical after this change.

Closes [#3880](https://github.com/dynawo/dynawo/issues/3880)