### PR TITLE
#3895 Connectors and variables distinguished after 3849 PR

### DIFF
--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/BaseClasses_INIT/BaseGeneratorSignalNPQDiagram_INIT.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/BaseClasses_INIT/BaseGeneratorSignalNPQDiagram_INIT.mo
@@ -19,12 +19,13 @@ partial model BaseGeneratorSignalNPQDiagram_INIT "Base initialization model for 
   parameter Types.ComplexCurrentPu iStart0Pu = Complex(0, 0) "Start value of complex current at terminal in pu (base UNom, SnRef) (receptor convention)";
   parameter Types.ActivePowerPu P0Pu "Start value of active power at terminal in pu (base SnRef) (receptor convention)";
   parameter Types.ReactivePowerPu Q0Pu "Start value of reactive power at terminal in pu (base SnRef) (receptor convention)";
-  parameter Dynawo.Connectors.VoltageModulePuConnector U0Pu "Start value of voltage amplitude at terminal in pu (base UNom)";
+  parameter Types.VoltageModulePu U0Pu "Start value of voltage amplitude at terminal in pu (base UNom)";
   parameter Types.Angle UPhase0 "Start value of voltage angle at terminal in rad";
 
   Dynawo.Connectors.ActivePowerPuConnector PGen0Pu "Start value of active power at terminal in pu (base SnRef) (generator convention)";
   Types.ReactivePowerPu QGenRaw0Pu "Start value of reactive power at terminal in pu (base SnRef) (generator convention)";
   Dynawo.Connectors.ReactivePowerPuConnector QGen0Pu "Start value of reactive power at terminal in pu (base SnRef) with limits (generator convention)";
+  Dynawo.Connectors.VoltageModulePuConnector U0PuVar "Start value of voltage amplitude at terminal in pu (base UNom)";
 
   Dynawo.Connectors.ComplexVoltagePuConnector u0Pu "Start value of complex voltage at terminal in pu (base UNom)";
   Types.ComplexApparentPowerPu s0Pu "Start value of complex apparent power at terminal in pu (base SnRef) (receptor convention)";
@@ -48,6 +49,7 @@ partial model BaseGeneratorSignalNPQDiagram_INIT "Base initialization model for 
   QStatus qStatus0(start = QStatus.Standard) "Start voltage regulation status: standard, absorptionMax or generationMax";
 
 equation
+  U0PuVar = U0Pu;
   u0Pu = ComplexMath.fromPolar(U0Pu, UPhase0);
   s0Pu = Complex(P0Pu, Q0Pu);
   s0Pu = u0Pu * ComplexMath.conj(i0Pu);

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/BaseClasses_INIT/BaseGeneratorSignalN_INIT.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/SignalN/BaseClasses_INIT/BaseGeneratorSignalN_INIT.mo
@@ -19,12 +19,13 @@ partial model BaseGeneratorSignalN_INIT "Base initialization model for SignalN g
   parameter Types.ComplexCurrentPu iStart0Pu = Complex(0, 0) "Start value of complex current at terminal in pu (base UNom, SnRef) (receptor convention)";
   parameter Types.ActivePowerPu P0Pu "Start value of active power at terminal in pu (base SnRef) (receptor convention)";
   parameter Types.ReactivePowerPu Q0Pu "Start value of reactive power at terminal in pu (base SnRef) (receptor convention)";
-  parameter Dynawo.Connectors.VoltageModulePuConnector U0Pu "Start value of voltage amplitude at terminal in pu (base UNom)";
+  parameter Types.VoltageModulePu U0Pu "Start value of voltage amplitude at terminal in pu (base UNom)";
   parameter Types.Angle UPhase0 "Start value of voltage angle at terminal in rad";
 
   Dynawo.Connectors.ActivePowerPuConnector PGen0Pu "Start value of active power at terminal in pu (base SnRef) (generator convention)";
   Types.ReactivePowerPu QGenRaw0Pu "Start value of reactive power at terminal in pu (base SnRef) (generator convention)";
   Dynawo.Connectors.ReactivePowerPuConnector QGen0Pu "Start value of reactive power at terminal in pu (base SnRef) with limits (generator convention)";
+  Dynawo.Connectors.VoltageModulePuConnector U0PuVar "Start value of voltage amplitude at terminal in pu (base UNom)";
 
   Dynawo.Connectors.ComplexVoltagePuConnector u0Pu "Start value of complex voltage at terminal in pu (base UNom)";
   Types.ComplexApparentPowerPu s0Pu "Start value of complex apparent power at terminal in pu (base SnRef) (receptor convention)";
@@ -48,6 +49,7 @@ partial model BaseGeneratorSignalN_INIT "Base initialization model for SignalN g
   QStatus qStatus0(start = QStatus.Standard) "Start voltage regulation status: Standard, AbsorptionMax, GenerationMax";
 
 equation
+  U0PuVar = U0Pu;
   u0Pu = ComplexMath.fromPolar(U0Pu, UPhase0);
   s0Pu = Complex(P0Pu, Q0Pu);
   s0Pu = u0Pu * ComplexMath.conj(i0Pu);


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR requires to update dyd or par files of exisiting simulations: the corresponding python was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
