### PR TITLE
#3783 Equality conditions with zero on voltage removed and, if necessary, replaced

### DIFF
--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/Bus.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/Bus.mo
@@ -26,14 +26,11 @@ model Bus "Bus"
 
 equation
   terminal.i = Complex(0);
-  if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-    UPu = 0;
-  else
-    UPu = ComplexMath.'abs'(terminal.V);
-  end if;
+  UPu = ComplexMath.'abs'(terminal.V);
   UPhase = ComplexMath.arg(terminal.V);
   U = UPu * UNom;
 
-  annotation(preferredView = "text",
+  annotation(
+    preferredView = "text",
     Documentation(info = "<html><head></head><body>The bus model doesn't provide any new equation to the system. It is present into the library for convenience purpose to build network tests.</body></html>"));
 end Bus;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/BusWithInit.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Buses/BusWithInit.mo
@@ -30,15 +30,10 @@ model BusWithInit "Bus with init"
 
 equation
   terminal.i = Complex(0);
-  if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-    UPu = 0;
-  else
-    UPu = ComplexMath.'abs'(terminal.V);
-  end if;
+  UPu = ComplexMath.'abs'(terminal.V);
   UPhase = ComplexMath.arg(terminal.V);
   UPhaseDeg = UPhase * 180.0 / Constants.pi;
   U = UPu * UNom;
 
   annotation(preferredView = "text");
-
 end BusWithInit;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/BaseClasses/BaseHvdcPDangling.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/HVDC/BaseClasses/BaseHvdcPDangling.mo
@@ -28,11 +28,7 @@ equation
   //Connected side
   if runningSide1 then
     P1Pu = if P1RefPu > PMaxPu then PMaxPu elseif P1RefPu < -PMaxPu then -PMaxPu else P1RefPu;
-    if ((terminal1.V.re == 0) and (terminal1.V.im == 0)) then
-      U1Pu = 0;
-    else
-      U1Pu = ComplexMath.'abs'(terminal1.V);
-    end if;
+    U1Pu = ComplexMath.'abs'(terminal1.V);
   else
     P1Pu = 0;
     U1Pu = 0;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/BaseClasses/BaseGeneratorSimplified.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Machines/BaseClasses/BaseGeneratorSimplified.mo
@@ -37,11 +37,7 @@ equation
   SGenPu = -terminal.V * ComplexMath.conj(terminal.i);
 
   if running then
-    if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-      UPu = 0.;
-    else
-      UPu = ComplexMath.'abs'(terminal.V);
-    end if;
+    UPu = ComplexMath.'abs'(terminal.V);
   else
     UPu = 0.;
   end if;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Shunts/ShuntB.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Shunts/ShuntB.mo
@@ -16,14 +16,15 @@ model ShuntB "Shunt element with constant susceptance, reactive power depends on
   extends AdditionalIcons.Shunt;
   extends Dynawo.Electrical.Controls.Basics.SwitchOff.SwitchOffShunt;
 
+  parameter Types.PerUnit BPu "Susceptance in pu (base SnRef), negative values for capacitive consumption (over-excited), positive values for inductive consumption (under-excited)";
+
   Dynawo.Connectors.ACPower terminal(V(re(start = u0Pu.re), im(start = u0Pu.im)), i(re(start = i0Pu.re), im(start = i0Pu.im))) "Connector used to connect the shunt to the grid" annotation(
   Placement(visible = true, transformation(origin = {0, 98}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  Types.VoltageModulePu UPu(start = ComplexMath.'abs'(u0Pu)) "Voltage amplitude at shunt terminal in pu (base UNom)";
+
   Types.ActivePowerPu PPu(start = s0Pu.re) "Active power at shunt terminal in pu (base SnRef, receptor convention)";
   Types.ReactivePowerPu QPu(start = s0Pu.im) "Reactive power at shunt terminal in pu (base SnRef, receptor convention)";
   Types.ComplexApparentPowerPu SPu(re(start = s0Pu.re), im(start = s0Pu.im)) "Apparent power at shunt terminal in pu (base SnRef, receptor convention)";
-
-  parameter Types.PerUnit BPu "Susceptance in pu (base SnRef), negative values for capacitive consumption (over-excited), positive values for inductive consumption (under-excited)";
+  Types.VoltageModulePu UPu(start = ComplexMath.'abs'(u0Pu)) "Voltage amplitude at shunt terminal in pu (base UNom)";
 
   parameter Types.ComplexVoltagePu u0Pu "Start value of complex voltage at shunt terminal in pu (base UNom)";
   parameter Types.ComplexApparentPowerPu s0Pu "Start value of apparent power at shunt terminal in pu (base SnRef, receptor convention)";
@@ -32,17 +33,14 @@ model ShuntB "Shunt element with constant susceptance, reactive power depends on
 equation
   SPu = Complex(PPu, QPu);
   SPu = terminal.V * ComplexMath.conj(terminal.i);
-  if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-    UPu = 0;
-  else
-    UPu = ComplexMath.'abs'(terminal.V);
-  end if;
 
   if running then
-    QPu = BPu * UPu^2;
+    QPu = BPu * UPu ^ 2;
     PPu = 0;
+    UPu = ComplexMath.'abs'(terminal.V);
   else
     terminal.i = Complex(0);
+    UPu = 0;
   end if;
 
   annotation(preferredView = "text");

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Shunts/ShuntBWithSections.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Shunts/ShuntBWithSections.mo
@@ -16,20 +16,21 @@ model ShuntBWithSections "Shunt element with voltage-dependent reactive power an
   extends AdditionalIcons.Shunt;
   extends Dynawo.Electrical.Controls.Basics.SwitchOff.SwitchOffShunt;
 
+  parameter String TableBPuName "Name of the table to calculate BPu from the section of the shunt";
+  parameter String TableBPuFile "File containing the table to calculate BPu from the section of the shunt";
+
   Dynawo.Connectors.ACPower terminal(V(re(start = u0Pu.re), im(start = u0Pu.im)), i(re(start = i0Pu.re), im(start = i0Pu.im))) "Connector used to connect the shunt to the grid";
   discrete Modelica.Blocks.Interfaces.RealInput section(start = section0) "Section position of the shunt";
 
-  parameter Real section0 "Initial section of the shunt";
-  parameter String TableBPuName "Name of the table to calculate BPu from the section of the shunt";
-  parameter String TableBPuFile "File containing the table to calculate BPu from the section of the shunt";
-  Modelica.Blocks.Tables.CombiTable1D tableBPu(tableOnFile = true, tableName = TableBPuName, fileName = TableBPuFile) "Table to get BPu from the section of the shunt";
-
-  Types.VoltageModulePu UPu(start = ComplexMath.'abs'(u0Pu)) "Voltage amplitude at shunt terminal in pu (base UNom)";
+  Types.PerUnit BPu(start = - s0Pu.im / ComplexMath.'abs'(u0Pu)^2) "Variable susceptance of the shunt in pu (base SnRef, UNom)";
   Types.ActivePowerPu PPu(start = 0) "Active power at shunt terminal in pu (base SnRef, receptor convention)";
   Types.ReactivePowerPu QPu(start = s0Pu.im) "Reactive power at shunt terminal in pu (base SnRef, receptor convention)";
   Types.ComplexApparentPowerPu SPu(re(start = 0), im(start = s0Pu.im)) "Apparent power at shunt terminal in pu (base SnRef, receptor convention)";
-  Types.PerUnit BPu(start = - s0Pu.im / ComplexMath.'abs'(u0Pu)^2) "Variable susceptance of the shunt in pu (base SnRef, UNom)";
+  Types.VoltageModulePu UPu(start = ComplexMath.'abs'(u0Pu)) "Voltage amplitude at shunt terminal in pu (base UNom)";
 
+  Modelica.Blocks.Tables.CombiTable1D tableBPu(tableOnFile = true, tableName = TableBPuName, fileName = TableBPuFile) "Table to get BPu from the section of the shunt";
+
+  parameter Real section0 "Initial section of the shunt";
   parameter Types.ComplexVoltagePu u0Pu "Start value of complex voltage at shunt terminal in pu (base UNom)";
   parameter Types.ComplexApparentPowerPu s0Pu "Start value of apparent power at shunt terminal in pu (base SnRef, receptor convention)";
   parameter Types.ComplexCurrentPu i0Pu "Start value of complex current at shunt terminal in pu (base UNom, SnRef, receptor convention)";
@@ -37,19 +38,16 @@ model ShuntBWithSections "Shunt element with voltage-dependent reactive power an
 equation
   section = tableBPu.u[1];
   BPu = tableBPu.y[1];
-  if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-    UPu = 0;
-  else
-    UPu = ComplexMath.'abs'(terminal.V);
-  end if;
   SPu = Complex(PPu, QPu);
   SPu = terminal.V * ComplexMath.conj(terminal.i);
 
   if running then
-    QPu = - BPu * UPu ^ 2;
+    QPu = -BPu * UPu ^ 2;
     PPu = 0;
+    UPu = ComplexMath.'abs'(terminal.V);
   else
     terminal.i = Complex(0);
+    UPu = 0;
   end if;
 
   annotation(preferredView = "text");

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/Converter.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Sources/Converter.mo
@@ -138,14 +138,9 @@ equation
     PFilterPu = udFilterPu * idPccPu + uqFilterPu * iqPccPu;
     QFilterPu = uqFilterPu * idPccPu - udFilterPu * iqPccPu;
 
-    /* Phase calculation */
+    /* Phase and amplitude calculation */
     UPhase = Modelica.ComplexMath.arg(terminal.V);
-    if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-      UPu = 0;
-    else
-      UPu = Modelica.ComplexMath.'abs'(terminal.V);
-    end if;
-
+    UPu = Modelica.ComplexMath.'abs'(terminal.V);
   else
     udPccPu = 0;
     uqPccPu = 0;
@@ -170,7 +165,8 @@ equation
     UPu = 0;
   end if;
 
-  annotation(preferredView = "text",
+  annotation(
+    preferredView = "text",
     Diagram(coordinateSystem(grid = {1, 1}, extent = {{-55, -60}, {64, 60}})),
     Icon(coordinateSystem(grid = {1, 1}, initialScale = 0.1), graphics = {Rectangle(extent = {{-100, 100}, {100, -100}}), Text(origin = {-133, -85.5}, extent = {{-25, 5.5}, {8, -4.5}}, textString = "omegaPu"), Text(origin = {-133, 4.5}, extent = {{-35, 14.5}, {8, -4.5}}, textString = "IdcSourcePu"), Text(origin = {-133, 44.5}, extent = {{-39, 12.5}, {8, -4.5}}, textString = "udConvRefPu"), Text(origin = {-133, 94.5}, extent = {{-17, 5.5}, {8, -4.5}}, textString = "theta"), Text(origin = {-131, -66.5}, extent = {{-43, 16.5}, {8, -4.5}}, textString = "UdcSourceRefPu"), Text(origin = {119, 100.5}, extent = {{-8, 4.5}, {38, -12.5}}, textString = "udFilterPu"), Text(origin = {-133, -35.5}, extent = {{-41, 14.5}, {8, -4.5}}, textString = "uqConvRefPu"), Text(origin = {119, 68.5}, extent = {{-8, 4.5}, {25, -9.5}}, textString = "idPccPu"), Text(origin = {117, 10.5}, extent = {{-8, 4.5}, {38, -16.5}}, textString = "UdcSourcePu"), Text(origin = {118, 37.5}, extent = {{-8, 4.5}, {25, -9.5}}, textString = "idConvPu"), Text(origin = {118, -21.5}, extent = {{-8, 4.5}, {30, -10.5}}, textString = "iqConvPu"), Text(origin = {118, -51.5}, extent = {{-8, 4.5}, {24, -12.5}}, textString = "iqPccPu"), Text(origin = {118, -78.5}, extent = {{-8, 4.5}, {35, -16.5}}, textString = "uqFilterPu"), Text(origin = {17, -107.5}, extent = {{-8, 4.5}, {14, -7.5}}, textString = "ACPower"), Text(origin = {5, 6}, extent = {{-95, 56}, {90, -68}}, textString = "Converter"), Text(origin = {-58, -104.5}, extent = {{-8, 4.5}, {38, -12.5}}, textString = "PFilterPu"), Text(origin = {81, -104.5}, extent = {{-8, 4.5}, {38, -12.5}}, textString = "QFilterPu")}));
 end Converter;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/BaseClasses/BaseSVarC.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/StaticVarCompensators/BaseClasses/BaseSVarC.mo
@@ -56,11 +56,7 @@ equation
   end when;
 
   if running then
-    if ((terminal.V.re == 0) and (terminal.V.im == 0)) then
-      UPu = 0;
-    else
-      UPu = Modelica.ComplexMath.'abs'(terminal.V);
-    end if;
+    UPu = Modelica.ComplexMath.'abs'(terminal.V);
     terminal.i = terminal.V * Complex(0, BPu);
   else
     UPu = 0;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/BaseClasses/BaseTransformer.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/BaseClasses/BaseTransformer.mo
@@ -60,7 +60,7 @@ partial model BaseTransformer "Base model for a general two winding transformer 
 
 equation
   if running then
-    // Kirchoff law
+    // Kirchhoff's laws
     rTfoPu * ComplexMath.conj(rTfoPu) * terminal1.V = ComplexMath.conj(rTfoPu) * terminal2.V + ZPu * terminal1.i;
     terminal1.i = ComplexMath.conj(rTfoPu) * (YPu * terminal2.V - terminal2.i);
   else
@@ -72,21 +72,11 @@ equation
   ISide2 = ComplexMath.'abs'(terminal2.i);
 
   if running then
-  // Variables for display or connection to another model (tap-changer for example)
+    // Variables for display or connection to another model (tap-changer for example)
     P1Pu = ComplexMath.real(terminal1.V * ComplexMath.conj(terminal1.i));
     Q1Pu = ComplexMath.imag(terminal1.V * ComplexMath.conj(terminal1.i));
-
-    if ((terminal1.V.re == 0) and (terminal1.V.im == 0)) then
-      U1Pu = 0;
-    else
-      U1Pu = ComplexMath.'abs'(terminal1.V);
-    end if;
-
-    if ((terminal2.V.re == 0) and (terminal2.V.im == 0)) then
-      U2Pu = 0;
-    else
-      U2Pu = ComplexMath.'abs'(terminal2.V);
-    end if;
+    U1Pu = ComplexMath.'abs'(terminal1.V);
+    U2Pu = ComplexMath.'abs'(terminal2.V);
   else
     P1Pu = 0;
     Q1Pu = 0;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/BaseClasses/BaseTransformerVariableTap.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/BaseClasses/BaseTransformerVariableTap.mo
@@ -30,9 +30,9 @@ partial model BaseTransformerVariableTap "Base class for ideal and classical tra
   discrete Modelica.Blocks.Interfaces.RealInput tap(start = Tap0) "Current transformer tap (between 0 and NbTap - 1)";
 
   // Output connectors
-  Modelica.Blocks.Interfaces.RealOutput U1Pu(start = U10Pu) "Absolute voltage on side 1";
   Modelica.Blocks.Interfaces.RealOutput P1Pu(start = P10Pu) "Active power on side 1";
   Modelica.Blocks.Interfaces.RealOutput Q1Pu(start = Q10Pu) "Reactive power on side 1";
+  Modelica.Blocks.Interfaces.RealOutput U1Pu(start = U10Pu) "Absolute voltage on side 1";
   Modelica.Blocks.Interfaces.RealOutput U2Pu(start = U20Pu) "Voltage amplitude at terminal 2 in pu (base U2Nom)";
 
   // Parameters coming from the initialization process
@@ -41,10 +41,10 @@ partial model BaseTransformerVariableTap "Base class for ideal and classical tra
   parameter Types.ComplexVoltagePu u20Pu "Start value of complex voltage at terminal 2 in pu (base U2Nom)";
   parameter Types.ComplexCurrentPu i20Pu "Start value of complex current at terminal 2 in pu (base U2Nom, SnRef) (receptor convention)";
 
-  parameter Types.VoltageModulePu U10Pu "Start value of voltage amplitude at terminal 1 in pu (base U1Nom)";
-  parameter Types.VoltageModulePu U20Pu "Start value of voltage amplitude at terminal 2 in pu (base U2Nom)";
   parameter Types.ActivePowerPu P10Pu "Start value of active power at terminal 1 in pu (base SnRef) (receptor convention)";
   parameter Types.ReactivePowerPu Q10Pu "Start value of reactive power at terminal 1 in pu (base SnRef) (receptor convention)";
+  parameter Types.VoltageModulePu U10Pu "Start value of voltage amplitude at terminal 1 in pu (base U1Nom)";
+  parameter Types.VoltageModulePu U20Pu "Start value of voltage amplitude at terminal 2 in pu (base U2Nom)";
 
   parameter Integer Tap0 "Start value of transformer tap";
   parameter Types.PerUnit rTfo0Pu "Start value of transformer ratio";
@@ -66,18 +66,8 @@ equation
     // Variables for display or connection to another model (tap-changer for example)
     P1Pu = ComplexMath.real(terminal1.V * ComplexMath.conj(terminal1.i));
     Q1Pu = ComplexMath.imag(terminal1.V * ComplexMath.conj(terminal1.i));
-
-    if ((terminal1.V.re == 0) and (terminal1.V.im == 0)) then
-      U1Pu = 0;
-    else
-      U1Pu = ComplexMath.'abs'(terminal1.V);
-    end if;
-
-    if ((terminal2.V.re == 0) and (terminal2.V.im == 0)) then
-      U2Pu = 0;
-    else
-      U2Pu = ComplexMath.'abs'(terminal2.V);
-    end if;
+    U1Pu = ComplexMath.'abs'(terminal1.V);
+    U2Pu = ComplexMath.'abs'(terminal2.V);
   else
     P1Pu = 0;
     Q1Pu = 0;

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/TransformersFixedTap/NetworkTransformer.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/TransformersFixedTap/NetworkTransformer.mo
@@ -91,26 +91,10 @@ equation
   Q2Pu = ComplexMath.imag(terminal2.V * ComplexMath.conj(terminal2.i));
 
   if running then
-    if ((terminal1.V.re == 0) and (terminal1.V.im == 0)) then
-      U1Pu = 0;
-    else
-      U1Pu = ComplexMath.'abs'(terminal1.V);
-    end if;
-    if ((terminal2.V.re == 0) and (terminal2.V.im == 0)) then
-      U2Pu = 0;
-    else
-      U2Pu = ComplexMath.'abs'(terminal2.V);
-    end if;
-    if ((terminal1.i.re == 0) and (terminal1.i.im == 0)) then
-      I1Pu = 0;
-    else
-      I1Pu = ComplexMath.'abs'(terminal1.i);
-    end if;
-    if ((terminal2.i.re == 0) and (terminal2.i.im == 0)) then
-      I2Pu = 0;
-    else
-      I2Pu = ComplexMath.'abs'(terminal2.i);
-    end if;
+    U1Pu = ComplexMath.'abs'(terminal1.V);
+    U2Pu = ComplexMath.'abs'(terminal2.V);
+    I1Pu = ComplexMath.'abs'(terminal1.i);
+    I2Pu = ComplexMath.'abs'(terminal2.i);
   else
     U1Pu = 0;
     U2Pu = 0;
@@ -121,7 +105,8 @@ equation
   ISide1 = factorPuToASide1 * I1Pu;
   ISide2 = factorPuToASide2 * I2Pu;
 
-  annotation(preferredView = "text",
+  annotation(
+    preferredView = "text",
     Documentation(info = "<html><head></head><body>The transformer has the following equivalent circuit and conventions:<div><br></div><div>
 <p style=\"margin: 0px;\"><br></p>
 <pre style=\"margin-top: 0px; margin-bottom: 0px;\"><span style=\"font-family: 'Courier New'; font-size: 12pt;\">               I1  r                I2</span></pre>

--- a/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/TransformersFixedTap/TransformerFixedRatio.mo
+++ b/dynawo/sources/Models/Modelica/Dynawo/Electrical/Transformers/TransformersFixedTap/TransformerFixedRatio.mo
@@ -28,6 +28,8 @@ model TransformerFixedRatio "Two winding transformer with a fixed ratio"
   extends BaseClasses.TransformerParameters;
   extends AdditionalIcons.Transformer;
 
+  parameter Types.PerUnit rTfoPu "Transformation ratio in pu: U2/U1 in no load conditions";
+
   Dynawo.Connectors.ACPower terminal1 annotation(
     Placement(visible = true, transformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {-100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Dynawo.Connectors.ACPower terminal2 annotation(
@@ -35,8 +37,6 @@ model TransformerFixedRatio "Two winding transformer with a fixed ratio"
 
   Types.CurrentModule ISide1 "Current on side 1 in A (receptor convention)";
   Types.CurrentModule ISide2 "Current on side 2 in A (receptor convention)";
-
-  parameter Types.PerUnit rTfoPu "Transformation ratio in pu: U2/U1 in no load conditions";
 
   Types.ActivePowerPu P1Pu "Active power on side 1 in pu (base SnRef) (receptor convention)";
   Types.ReactivePowerPu Q1Pu "Reactive power on side 1 in pu (base SnRef) (receptor convention)";
@@ -63,23 +63,16 @@ equation
   Q2Pu = ComplexMath.imag(terminal2.V * ComplexMath.conj(terminal2.i));
 
   if running then
-    if ((terminal1.V.re == 0) and (terminal1.V.im == 0)) then
-      U1Pu = 0;
-    else
-      U1Pu = ComplexMath.'abs'(terminal1.V);
-    end if;
-    if ((terminal2.V.re == 0) and (terminal2.V.im == 0)) then
-      U2Pu = 0;
-    else
-      U2Pu = ComplexMath.'abs'(terminal2.V);
-    end if;
+    U1Pu = ComplexMath.'abs'(terminal1.V);
+    U2Pu = ComplexMath.'abs'(terminal2.V);
   else
     U1Pu = 0;
     U2Pu = 0;
   end if;
 
-  annotation(preferredView = "text",
-      Documentation(info = "<html><head></head><body>The transformer has the following equivalent circuit and conventions:<div><br></div><div>
+  annotation(
+    preferredView = "text",
+    Documentation(info = "<html><head></head><body>The transformer has the following equivalent circuit and conventions:<div><br></div><div>
 <p style=\"margin: 0px;\"><br></p>
 <pre style=\"margin-top: 0px; margin-bottom: 0px;\"><span style=\"font-family: 'Courier New'; font-size: 12pt;\">               I1  r                I2</span></pre>
 <pre style=\"margin-top: 0px; margin-bottom: 0px;\"><span style=\"font-family: 'Courier New'; font-size: 12pt;\">    U1,P1,Q1 --&gt;---oo----R+jX-------&lt;-- U2,P2,Q2</span></pre>


### PR DESCRIPTION
Every non-regression test is successful. BaseHvdcP has been preserved as it is (except for style) since the original issue stemmed from its equations. The goal of this pull request is to rely as much as possible on a boolean variable like running.value instead of a comparison of terminal.V to zero.