### PR TITLE
#3905 Avoid transient erroneous current calculation when a tap is

### DIFF
--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelPhaseTapChanger.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelPhaseTapChanger.cpp
@@ -80,30 +80,33 @@ bool ModelPhaseTapChanger::getIncreaseTap(bool P1SupP2) const {
 void ModelPhaseTapChanger::evalG(double t, double iValue, bool /*nodeOff*/,
                                  state_g* g, double disable, double locked,
                                  bool tfoClosed) {
+  int currentStepIndex = getCurrentStepIndex();
+  if (getNextStepIndex() != -1)
+    currentStepIndex = getNextStepIndex();
   g[0] = (iValue >= thresholdI_ && !(disable > 0.) && tfoClosed)
              ? ROOT_UP
              : ROOT_DOWN;  // I > IThreshold
   g[1] = (iValue < thresholdI_) ? ROOT_UP : ROOT_DOWN;
 
   g[2] = (moveUp_ && (t - whenUp_ >= getTFirst()) &&
-          getCurrentStepIndex() < getHighStepIndex() && !(locked > 0.) &&
-          getRegulating() && getCurrentStepIndex() == tapRefUp_ && tfoClosed)
+          currentStepIndex < getHighStepIndex() && !(locked > 0.) &&
+          getRegulating() && currentStepIndex == tapRefUp_ && tfoClosed)
              ? ROOT_UP
              : ROOT_DOWN;  // first tap Up
   g[3] = (moveUp_ && (t - whenLastTap_ >= getTNext()) &&
-          getCurrentStepIndex() < getHighStepIndex() && !(locked > 0.) &&
-          getRegulating() && getCurrentStepIndex() != tapRefUp_ && tfoClosed)
+          currentStepIndex < getHighStepIndex() && !(locked > 0.) &&
+          getRegulating() && currentStepIndex != tapRefUp_ && tfoClosed)
              ? ROOT_UP
              : ROOT_DOWN;  // next tap Up
 
   g[4] = (moveDown_ && (t - whenDown_ >= getTFirst()) &&
-          getCurrentStepIndex() > getLowStepIndex() && !(locked > 0.) &&
-          getRegulating() && getCurrentStepIndex() == tapRefDown_ && tfoClosed)
+          currentStepIndex > getLowStepIndex() && !(locked > 0.) &&
+          getRegulating() && currentStepIndex == tapRefDown_ && tfoClosed)
              ? ROOT_UP
              : ROOT_DOWN;  // first tap down
   g[5] = (moveDown_ && (t - whenLastTap_ >= getTNext()) &&
-          getCurrentStepIndex() > getLowStepIndex() && !(locked > 0.) &&
-          getRegulating() && getCurrentStepIndex() != tapRefDown_ && tfoClosed)
+          currentStepIndex > getLowStepIndex() && !(locked > 0.) &&
+          getRegulating() && currentStepIndex != tapRefDown_ && tfoClosed)
              ? ROOT_UP
              : ROOT_DOWN;  // next tap down
 
@@ -113,19 +116,22 @@ void ModelPhaseTapChanger::evalG(double t, double iValue, bool /*nodeOff*/,
 void ModelPhaseTapChanger::evalZ(double t, state_g* g, ModelNetwork* network,
                                  double disable, bool P1SupP2, double locked,
                                  bool tfoClosed) {
+  int currentStepIndex = getCurrentStepIndex();
+  if (getNextStepIndex() != -1)
+    currentStepIndex = getNextStepIndex();
   if (!(disable > 0.) && !(locked > 0.) && tfoClosed) {
     if (g[0] == ROOT_UP && !currentOverThresholdState_) {  // I > IThreshold
       if (getIncreaseTap(P1SupP2)) {
         whenUp_ = t;
         moveUp_ = true;
-        tapRefUp_ = getCurrentStepIndex();
+        tapRefUp_ = currentStepIndex;
         whenDown_ = VALDEF;
         moveDown_ = false;
         tapRefDown_ = getHighStepIndex();
       } else {
         whenDown_ = t;
         moveDown_ = true;
-        tapRefDown_ = getCurrentStepIndex();
+        tapRefDown_ = currentStepIndex;
         whenUp_ = VALDEF;
         moveUp_ = false;
         tapRefUp_ = getLowStepIndex();
@@ -144,13 +150,17 @@ void ModelPhaseTapChanger::evalZ(double t, state_g* g, ModelNetwork* network,
     }
 
     if (g[2] == ROOT_UP || g[3] == ROOT_UP) {  // increase tap
-      setCurrentStepIndex(getCurrentStepIndex() + 1);
+      if (getNextStepIndex() == -1)
+        setNextStepIndex(getCurrentStepIndex());
+      setNextStepIndex(getNextStepIndex() + 1);
       whenLastTap_ = t;
       DYNAddTimelineEvent(network, id(), TapUp, latestIValue_, "A");
     }
 
     if (g[4] == ROOT_UP || g[5] == ROOT_UP) {  // decrease tap
-      setCurrentStepIndex(getCurrentStepIndex() - 1);
+      if (getNextStepIndex() == -1)
+        setNextStepIndex(getCurrentStepIndex());
+      setNextStepIndex(getNextStepIndex() - 1);
       whenLastTap_ = t;
       DYNAddTimelineEvent(network, id(), TapDown, latestIValue_, "A");
     }

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTapChanger.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTapChanger.h
@@ -51,7 +51,8 @@ class ModelTapChanger {
         lowStepIndex_(lowIndex),
         highStepIndex_(0),
         tFirst_(60),
-        tNext_(10) {}
+        tNext_(10),
+        nextStepIndex_(-1) {}
 
   /**
    * @brief destructor
@@ -188,6 +189,29 @@ class ModelTapChanger {
    */
   template <typename T> void dumpInternalVariable(boost::archive::binary_oarchive& os, T value) const;
 
+  /**
+   * @brief set next step index
+   *
+   * @param index next step index
+   */
+  inline void setNextStepIndex(int index) { nextStepIndex_ = index;}
+
+  /**
+   * @brief get next step index
+   *
+   * @return next step index
+   */
+  inline int getNextStepIndex() const {return nextStepIndex_;}
+
+  /**
+   * @brief  update the steps to the next value computed during evalZ
+   */
+  void applyStep() {
+    if (nextStepIndex_ != -1)
+      setCurrentStepIndex(nextStepIndex_);
+    nextStepIndex_ = -1;
+  }
+
  private:
   std::string id_;  ///< id of the tap changer
   std::vector<TapChangerStep>
@@ -200,6 +224,7 @@ class ModelTapChanger {
   double tFirst_;  ///< time to wait before changing of step for the first time
   double tNext_;   ///< time to wait before changing of step if it's not the
                    ///< first time
+  int nextStepIndex_;  ///< new value of the step index at the next timestep (-1 if unmodified)
 };                 // class ModelTapChanger
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelTwoWindingsTransformer.h
@@ -488,10 +488,27 @@ class ModelTwoWindingsTransformer : public NetworkComponent {
   int getCurrentStepIndex() const;
 
   /**
+   * @brief  get the index of the tap used at the next timestep
+   * @return the index of the tap used at the next timestep
+   */
+  int getNextStepIndex() const;
+
+  /**
+   * @brief replace the current step index by the next step index (if modified)
+   */
+  void applyStep();
+
+  /**
    * @brief  set the index of the tap used
    * @param stepIndex index of the tap used
    */
   void setCurrentStepIndex(const int& stepIndex);
+
+  /**
+   * @brief  set the index of the tap used at the next timestep
+   * @param stepIndex index of the tap used at the next timestep
+   */
+  void setNextStepIndex(int stepIndex);
 
   /**
    * @brief  get the current value of the active power at side 1

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestTapChanger.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestTapChanger.cpp
@@ -149,6 +149,9 @@ TEST(ModelsModelNetwork, ModelNetworkPhaseTapChanger) {
   ASSERT_EQ(states[4], ROOT_DOWN);
   ASSERT_EQ(states[5], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, P1SupP2, locked, tfoClosed);
+  ASSERT_EQ(ptc.getCurrentStepIndex(), 0);
+  ASSERT_EQ(ptc.getNextStepIndex(), 1);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 1);
   t = 135.;
   ptc.evalG(t, iValue, nodeOff, &states[0], disable, locked, tfoClosed);
@@ -159,6 +162,9 @@ TEST(ModelsModelNetwork, ModelNetworkPhaseTapChanger) {
   ASSERT_EQ(states[4], ROOT_DOWN);
   ASSERT_EQ(states[5], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, P1SupP2, locked, tfoClosed);
+  ASSERT_EQ(ptc.getCurrentStepIndex(), 1);
+  ASSERT_EQ(ptc.getNextStepIndex(), 2);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
 
   P1SupP2 = false;
@@ -172,6 +178,9 @@ TEST(ModelsModelNetwork, ModelNetworkPhaseTapChanger) {
   ASSERT_EQ(states[5], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, P1SupP2, locked, tfoClosed);
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
+  ASSERT_EQ(ptc.getNextStepIndex(), -1);
+  ptc.applyStep();
+  ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
   iValue = 6.;
   ptc.evalG(t, iValue, nodeOff, &states[0], disable, locked, tfoClosed);
   ASSERT_EQ(states[0], ROOT_UP);
@@ -182,6 +191,9 @@ TEST(ModelsModelNetwork, ModelNetworkPhaseTapChanger) {
   ASSERT_EQ(states[5], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, P1SupP2, locked, tfoClosed);
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
+  ASSERT_EQ(ptc.getNextStepIndex(), -1);
+  ptc.applyStep();
+  ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
   t = 235.;
   ptc.evalG(t, iValue, nodeOff, &states[0], disable, locked, tfoClosed);
   ASSERT_EQ(states[0], ROOT_UP);
@@ -191,6 +203,9 @@ TEST(ModelsModelNetwork, ModelNetworkPhaseTapChanger) {
   ASSERT_EQ(states[4], ROOT_UP);
   ASSERT_EQ(states[5], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, P1SupP2, locked, tfoClosed);
+  ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
+  ASSERT_EQ(ptc.getNextStepIndex(), 1);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 1);
   t = 255.;
   ptc.evalG(t, iValue, nodeOff, &states[0], disable, locked, tfoClosed);
@@ -201,6 +216,9 @@ TEST(ModelsModelNetwork, ModelNetworkPhaseTapChanger) {
   ASSERT_EQ(states[4], ROOT_DOWN);
   ASSERT_EQ(states[5], ROOT_UP);
   ptc.evalZ(t, &states[0], &network, disable, P1SupP2, locked, tfoClosed);
+  ASSERT_EQ(ptc.getCurrentStepIndex(), 1);
+  ASSERT_EQ(ptc.getNextStepIndex(), 0);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 0);
 }
 
@@ -267,6 +285,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_UP);
   ASSERT_EQ(states[3], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 1);
 
   t = 135.;
@@ -276,6 +295,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_UP);
   ASSERT_EQ(states[3], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
 
   deltaUTarget = 1.;
@@ -286,6 +306,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_DOWN);
   ASSERT_EQ(states[3], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
 
   deltaUTarget = -1.;
@@ -296,6 +317,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_DOWN);
   ASSERT_EQ(states[3], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
 
   ptc.setSide("ONE");
@@ -306,6 +328,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_DOWN);
   ASSERT_EQ(states[3], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
   uValue = 11.2;
   ptc.evalG(t, uValue, nodeOff, &states[0], disable, locked, tfoClosed, deltaUTarget);
@@ -314,6 +337,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_DOWN);
   ASSERT_EQ(states[3], ROOT_DOWN);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 2);
   t = 235.;
   ptc.evalG(t, uValue, nodeOff, &states[0], disable, locked, tfoClosed, deltaUTarget);
@@ -322,6 +346,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_DOWN);
   ASSERT_EQ(states[3], ROOT_UP);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 1);
   t = 255.;
   ptc.evalG(t, uValue, nodeOff, &states[0], disable, locked, tfoClosed, deltaUTarget);
@@ -330,6 +355,7 @@ TEST(ModelsModelNetwork, ModelNetworkRatioTapChanger) {
   ASSERT_EQ(states[2], ROOT_DOWN);
   ASSERT_EQ(states[3], ROOT_UP);
   ptc.evalZ(t, &states[0], &network, disable, nodeOff, locked, tfoClosed);
+  ptc.applyStep();
   ASSERT_EQ(ptc.getCurrentStepIndex(), 0);
 }
 }  // namespace DYN


### PR DESCRIPTION
modified (as voltage and current are modified in sequence)

closes #3905

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR requires to update dyd or par files of exisiting simulations: the corresponding python was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
