### PR TITLE
#4006 iidmDiff: take into account targetV, targetQ and use relative ta…

### DIFF
--- a/util/nrt_diff/iidmDiff.py
+++ b/util/nrt_diff/iidmDiff.py
@@ -55,6 +55,10 @@ def getOutputIIDMInfo(filename):
                     set_values(child,'p',myObject)
                     set_values(child,'q',myObject)
                     set_values(child,'bus',myObject)
+                    if myObject.type == 'generator' and 'voltageRegulatorOn' in child.attrib and child.attrib['voltageRegulatorOn'] == "true":
+                        set_values(child,'targetV',myObject)
+                    if myObject.type == 'generator':
+                        set_values(child,'targetQ',myObject)
                 elif myObject.type == 'switch':
                     set_values(child,'open',myObject)
                     set_values(child,'node1',myObject)
@@ -120,7 +124,9 @@ def getOutputIIDMInfo(filename):
                     tapChangerId = myId + "_" + tapChangerType
                     tapChangerObject = IIDMobject(tapChangerId)
                     tapChangerObject.type = tapChangerType
-                    set_values(tapChanger,'tapPosition',tapChangerObject)
+                    tapPosition = tapChanger.attrib['tapPosition']
+                    lowTapPosition = tapChanger.attrib['lowTapPosition']
+                    tapChangerObject.values['tapPosition'] = str(float(tapPosition) - float(lowTapPosition))
                     IIDM_objects_byID[tapChangerId] = tapChangerObject
     return IIDM_objects_byID
 


### PR DESCRIPTION
…p instead of absolute one

closes #4006

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR requires to update dyd or par files of exisiting simulations: the corresponding python was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
