### PR TITLE
#3941 replace "== 0" generated by omc by doubleIsZero in discrete eva…

### DIFF
--- a/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/dataContainer.py
+++ b/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/dataContainer.py
@@ -1803,6 +1803,7 @@ class RootObject:
         new_body = []
         i = 0
         double_equality_prtn = re.compile(r'\(data->localData\[0\]->realVars\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/ == data->localData\[0\]->realVars\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/\)')
+        double_equality_parameter_prtn = re.compile(r'\(data->localData\[0\]->realVars\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/ == data->simulationInfo->realParameter\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/\)')
         for line in self.body_for_num_relation:
             line = replace_var_names(line)
             if i == 0 or i == len(self.body_for_num_relation)-1:
@@ -1812,6 +1813,10 @@ class RootObject:
                 line = sub_division_sim(line)
                 line = line.replace('threadData,','')
                 found = re.search(double_equality_prtn, line)
+                if found is not None:
+                    test = "DYN::doubleEquals" + found.group(0).replace (" == ", ",")
+                    line = line.replace(found.group(0), test)
+                found = re.search(double_equality_parameter_prtn, line)
                 if found is not None:
                     test = "DYN::doubleEquals" + found.group(0).replace (" == ", ",")
                     line = line.replace(found.group(0), test)

--- a/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/factory.py
+++ b/dynawo/sources/ModelicaCompiler/Scripts_OMC_1_13_2/factory.py
@@ -2011,11 +2011,21 @@ class Factory:
 
         # print all gout at the end of the function
         nb_zero_crossing = 0;
+        double_equality_prtn = re.compile(r'\(data->localData\[0\]->realVars\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/ == data->localData\[0\]->realVars\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/\)')
+        double_equality_parameter_prtn = re.compile(r'\(data->localData\[0\]->realVars\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/ == data->simulationInfo->realParameter\[[0-9]+\][ ]+\/\*[ \w\$\.()\[\],]*\*\/\)')
         for line in filtered_func:
             if "gout" in line:
                 if "tmp" in line:
                     line = line.replace("tmp", "tmp_zc")
                 line = line.replace("1 : -1;", "ROOT_UP : ROOT_DOWN;")
+                found = re.search(double_equality_prtn, line)
+                if found is not None:
+                    test = "DYN::doubleEquals" + found.group(0).replace (" == ", ",")
+                    line = line.replace(found.group(0), test)
+                found = re.search(double_equality_parameter_prtn, line)
+                if found is not None:
+                    test = "DYN::doubleEquals" + found.group(0).replace (" == ", ",")
+                    line = line.replace(found.group(0), test)
                 self.list_for_setg.append(line)
                 nb_zero_crossing +=1
 


### PR DESCRIPTION
…l methods

closes #3941

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR requires to update dyd or par files of exisiting simulations: the corresponding python was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
