### PR TITLE
#4093 Remove redundant and dangerous error checks inside macros

### DIFF
--- a/dynawo/sources/Common/DYNMacrosMessage.h
+++ b/dynawo/sources/Common/DYNMacrosMessage.h
@@ -48,8 +48,7 @@
  * @param name the name of the model
  * @param key key to find the message
  */
-#define DYNAddTimelineEvent(model, name, key, ...) \
-  if (model->hasTimeline()) model->addEvent(name, DYNTimeline(key, ##__VA_ARGS__))
+#define DYNAddTimelineEvent(model, name, key, ...) model->addEvent(name, DYNTimeline(key, ##__VA_ARGS__))
 
 /**
  * @brief Macro to define a constraint message
@@ -66,8 +65,7 @@
  * @param type model type
  * @param key key to find the message
  */
-#define DYNAddConstraint(model, name, begin, type, key, ...) \
-  if (model->hasConstraints()) model->addConstraint(name, begin, DYNConstraint(key, ##__VA_ARGS__), type)
+#define DYNAddConstraint(model, name, begin, type, key, ...) model->addConstraint(name, begin, DYNConstraint(key, ##__VA_ARGS__), type)
 
 /**
  * @brief Macro to add a constraint and add some structured data to be saved
@@ -80,8 +78,7 @@
  * @param data structure with detailed information
  * @param key key to find the message
  */
-#define DYNAddConstraintWithData(model, name, begin, type, data, key, ...) \
-  if (model->hasConstraints()) model->addConstraint(name, begin, DYNConstraint(key, ##__VA_ARGS__), type, data)
+#define DYNAddConstraintWithData(model, name, begin, type, data, key, ...) model->addConstraint(name, begin, DYNConstraint(key, ##__VA_ARGS__), type, data)
 
 /**
  * @brief Macro description to have a shortcut.

--- a/dynawo/sources/Modeler/Common/DYNSubModel.cpp
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.cpp
@@ -122,11 +122,6 @@ SubModel::setTimeline(const shared_ptr<Timeline>& timeline) {
   timeline_ = timeline;
 }
 
-bool
-SubModel::hasTimeline() const {
-  return timeline_.use_count() > 0;
-}
-
 void
 SubModel::setConstraints(const std::shared_ptr<ConstraintsCollection>& constraints) {
   constraints_ = constraints;

--- a/dynawo/sources/Modeler/Common/DYNSubModel.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.h
@@ -797,13 +797,6 @@ class SubModel {
   void setTimeline(const boost::shared_ptr<timeline::Timeline>& timeline);
 
   /**
-   * @brief determines if contains a timeline
-   *
-   * @returns whether the model has a timeline
-   */
-  bool hasTimeline() const;
-
-  /**
    * @brief set the constraints collection to use during the simulation (where constraints should be added)
    *
    * @param constraints constraints collections to use

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.cpp
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.cpp
@@ -54,63 +54,7 @@ void printLogExecution_(ModelManager * model, const std::string & message) {
 }
 
 void addLogEvent_(ModelManager* model, const MessageTimeline& messageTimeline) {
-  if (!model->hasTimeline()) {
-    return;
-  }
-
   model->addEvent(model->name(), messageTimeline);
-}
-
-void addLogEventRaw2_(ModelManager* model, const char* message1, const char* message2) {
-  if (!model->hasTimeline()) {
-    return;
-  }
-
-  std::stringstream ss("");
-  ss << message1 << message2;
-  const std::string fullMessage = ss.str();
-
-  addLogEvent_(model, (MessageTimeline("", fullMessage)));
-}
-
-void
-addLogEventRaw3_(ModelManager* model, const char* message1, const char* message2,
-        const char* message3) {
-  if (!model->hasTimeline()) {
-    return;
-  }
-
-  std::stringstream ss("");
-  ss << message1 << message2 << message3;
-  const std::string fullMessage = ss.str();
-
-  addLogEvent_(model, (MessageTimeline("", fullMessage)));
-}
-
-void addLogEventRaw4_(ModelManager* model, const char* message1, const char* message2,
-        const char* message3, const char* message4) {
-  if (!model->hasTimeline()) {
-    return;
-  }
-
-  std::stringstream ss("");
-  ss << message1 << message2 << message3 << message4;
-  const std::string fullMessage = ss.str();
-
-  addLogEvent_(model, (MessageTimeline("", fullMessage)));
-}
-
-void addLogEventRaw5_(ModelManager* model, const char* message1, const char* message2,
-        const char* message3, const char* message4, const char* message5) {
-  if (!model->hasTimeline()) {
-    return;
-  }
-
-  std::stringstream ss("");
-  ss << message1 << message2 << message3 << message4 << message5;
-  const std::string fullMessage = ss.str();
-
-  addLogEvent_(model, (MessageTimeline("", fullMessage)));
 }
 
 void addLogConstraintBegin_(ModelManager* model, const Message& message) {

--- a/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
+++ b/dynawo/sources/Modeler/ModelManager/DYNModelManagerCommon.h
@@ -326,23 +326,17 @@ inline modelica_boolean GreaterEq<double>(double a, double b) {
  */
 #define DYNTimelineFromModelica(key, ...) (DYN::MessageTimeline(DYN::KeyTimeline_t::names(DYN::KeyTimeline_t::value(key))), ##__VA_ARGS__ )
 
-#define addLogEvent1(key) if ((this)->getModelManager()->hasTimeline()) \
-  addLogEvent_((this)->getModelManager(), DYNTimelineFromModelica(key))
-#define addLogEvent2(key, arg1) if ((this)->getModelManager()->hasTimeline()) \
-  addLogEvent_((this)->getModelManager(), DYNTimelineFromModelica(key, arg1))
-#define addLogEvent3(key, arg1, arg2) if ((this)->getModelManager()->hasTimeline()) \
-  addLogEvent_((this)->getModelManager(), DYNTimelineFromModelica(key, arg1, arg2))
-#define addLogEvent4(key, arg1, arg2, arg3) if ((this)->getModelManager()->hasTimeline()) \
-  addLogEvent_((this)->getModelManager(), DYNTimelineFromModelica(key, arg1, arg2, arg3))
-#define addLogEvent5(key, arg1, arg2, arg3, arg4) if ((this)->getModelManager()->hasTimeline()) \
-  addLogEvent_((this)->getModelManager(), DYNTimelineFromModelica(key, arg1, arg2, arg3, arg4))
+#define addLogEvent1(key)                             addLogEvent_(this->getModelManager(), DYNTimelineFromModelica(key))
+#define addLogEvent2(key, arg1)                       addLogEvent_(this->getModelManager(), DYNTimelineFromModelica(key, arg1))
+#define addLogEvent3(key, arg1, arg2)                 addLogEvent_(this->getModelManager(), DYNTimelineFromModelica(key, arg1, arg2))
+#define addLogEvent4(key, arg1, arg2, arg3)           addLogEvent_(this->getModelManager(), DYNTimelineFromModelica(key, arg1, arg2, arg3))
+#define addLogEvent5(key, arg1, arg2, arg3, arg4)     addLogEvent_(this->getModelManager(), DYNTimelineFromModelica(key, arg1, arg2, arg3, arg4))
 
-#define addLogEventRaw1(key) if ((this)->getModelManager()->hasTimeline()) \
-  addLogEvent_((this)->getModelManager(), (MessageTimeline("", key)))
-#define addLogEventRaw2(key1, key2) addLogEventRaw2_((this)->getModelManager(), key1, key2)
-#define addLogEventRaw3(key1, key2, key3) addLogEventRaw3_((this)->getModelManager(), key1, key2, key3)
-#define addLogEventRaw4(key1, key2, key3, key4) addLogEventRaw4_((this)->getModelManager(), key1, key2, key3, key4)
-#define addLogEventRaw5(key1, key2, key3, key4, key5) addLogEventRaw5_((this)->getModelManager(), key1, key2, key3, key4, key5)
+#define addLogEventRaw1(msg)                          addLogEvent_(this->getModelManager(), MessageTimeline("", std::string(msg)))
+#define addLogEventRaw2(m1, m2)                       addLogEvent_(this->getModelManager(), MessageTimeline("", std::string(m1)+m2))
+#define addLogEventRaw3(m1, m2, m3)                   addLogEvent_(this->getModelManager(), MessageTimeline("", std::string(m1)+m2+m3))
+#define addLogEventRaw4(m1, m2, m3, m4)               addLogEvent_(this->getModelManager(), MessageTimeline("", std::string(m1)+m2+m3+m4))
+#define addLogEventRaw5(m1, m2, m3, m4, m5)           addLogEvent_(this->getModelManager(), MessageTimeline("", std::string(m1)+m2+m3+m4+m5))
 
 #define printLogToStdOut(message) printLogToStdOut_((this)->getModelManager(), std::string(message))
 #define printLogExecution(message) printLogExecution_((this)->getModelManager(), std::string(message))
@@ -602,44 +596,6 @@ void addLogConstraintEndData_(ModelManager* model, const Message& message, std::
  * @param messageTimeline description of the event
  */
 void addLogEvent_(ModelManager* model, const MessageTimeline& messageTimeline);
-
-/**
- * @brief add a raw event log based on multiple sub-log messages
- * @param model model where the event appears
- * @param message1 the first sub message
- * @param message2 the second sub message
- */
-void addLogEventRaw2_(ModelManager* model, const char* message1, const char* message2);
-
-/**
- * @brief add a raw event log based on multiple sub-log messages
- * @param model model where the event appears
- * @param message1 the first sub message
- * @param message2 the second sub message
- * @param message3 the third sub message
- */
-void addLogEventRaw3_(ModelManager* model, const char* message1, const char* message2, const char* message3);
-
-/**
- * @brief add a raw event log based on multiple sub-log messages
- * @param model model where the event appears
- * @param message1 the first sub message
- * @param message2 the second sub message
- * @param message3 the third sub message
- * @param message4 the fourth sub message
- */
-void addLogEventRaw4_(ModelManager* model, const char* message1, const char* message2, const char* message3, const char* message4);
-
-/**
- * @brief add a raw event log based on multiple sub-log messages
- * @param model model where the event appears
- * @param message1 the first sub message
- * @param message2 the second sub message
- * @param message3 the third sub message
- * @param message4 the fourth sub message
- * @param message5 the fifth sub message
- */
-void addLogEventRaw5_(ModelManager* model, const char* message1, const char* message2, const char* message3, const char* message4, const char* message5);
 
 /**
  * @brief  conversion of a modelica real number to modelica string

--- a/dynawo/sources/Modeler/ModelManager/test/TestCommon.cpp
+++ b/dynawo/sources/Modeler/ModelManager/test/TestCommon.cpp
@@ -55,25 +55,15 @@ TEST(TestModelManager, TestModelManagerCommonLogs) {
   ASSERT_NO_THROW(addLogEvent_(&mm, mess));
   ASSERT_EQ(timeline->getSizeEvents(), 1);
 
-  ASSERT_NO_THROW(addLogEventRaw2_(&mm, "blah.", "blah."));
-  ASSERT_EQ(timeline->getSizeEvents(), 2);
-
-  ASSERT_NO_THROW(addLogEventRaw3_(&mm, "blah.", "blah.", "blah."));
-  ASSERT_EQ(timeline->getSizeEvents(), 3);
-
-  ASSERT_NO_THROW(addLogEventRaw4_(&mm, "blah.", "blah.", "blah.", "blah."));
-  ASSERT_EQ(timeline->getSizeEvents(), 4);
-
-  ASSERT_NO_THROW(addLogEventRaw5_(&mm, "blah.", "blah.", "blah.", "blah.", "blah."));
-  ASSERT_EQ(timeline->getSizeEvents(), 5);
-
   std::shared_ptr<constraints::ConstraintsCollection> constraints = constraints::ConstraintsCollectionFactory::newInstance("MyConstraints");
   mm.setConstraints(constraints);
 
-  ASSERT_THROW(assert_(&mm, mess), MessageError);
-  ASSERT_THROW(throw_(&mm, mess), MessageError);
-  ASSERT_THROW(terminate_(&mm, mess),  DYN::Terminate);
-  ASSERT_EQ(timeline->getSizeEvents(), 6);
+  MessageTimeline mess2("", "Blah");
+
+  ASSERT_THROW(assert_(&mm, mess2), MessageError);
+  ASSERT_THROW(throw_(&mm, mess2), MessageError);
+  ASSERT_THROW(terminate_(&mm, mess2),  DYN::Terminate);
+  ASSERT_EQ(timeline->getSizeEvents(), 2);
 }
 
 TEST(TestModelManager, TestModelManagerCommonStrings) {


### PR DESCRIPTION
- [x] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [x] the corresponding milestone was added in the ticket and in this PR