### PR TITLE
#4196 Add opt-in invariant switch sparsity and topology-event reclassification

### DIFF
--- a/dynawo/sources/Common/DYNSparseMatrix.cpp
+++ b/dynawo/sources/Common/DYNSparseMatrix.cpp
@@ -92,6 +92,26 @@ SparseMatrix::addTerm(const int row, const double val) {
 }
 
 void
+SparseMatrix::addTermForced(const int row, const double val) {
+  assert(row < nbRow_);
+  // To deal with exploding matrix sizes
+  if (nbTerm_ >= currentMaxTerm_) increaseReserve();
+  ++Ap_[iAp_];
+  Ai_[iAi_] = row;
+  Ax_[iAx_] = val;
+  ++iAi_;
+  ++iAx_;
+  ++nbTerm_;
+  if (std::isnan(val)) {   // right way to check is the value is a NaN value
+    withoutNan_ = false;
+  }
+
+  if (std::isinf(val)) {  // if val is INFINITY
+    withoutInf_ = false;
+  }
+}
+
+void
 SparseMatrix::init(const int nbRow, const int nbCol) {
   free();
 

--- a/dynawo/sources/Common/DYNSparseMatrix.h
+++ b/dynawo/sources/Common/DYNSparseMatrix.h
@@ -109,6 +109,19 @@ class SparseMatrix {
   void addTerm(const int row, const double val);
 
   /**
+   * @brief add a new term in the matrix even if its value is zero
+   *
+   * Used to keep a fixed (superset) sparsity pattern when a Jacobian entry
+   * is numerically zero in the current state but nonzero in another state.
+   * The caller guarantees the entry is structurally meaningful in at least
+   * one state of the model.
+   *
+   * @param row row of the term in the matrix
+   * @param val value to add in the matrix (may be zero)
+   */
+  void addTermForced(const int row, const double val);
+
+  /**
    * @brief print the Frobenius norm of the matrix
    *
    * @return value of the Frobenius norm of the matrix

--- a/dynawo/sources/Common/test/Test.cpp
+++ b/dynawo/sources/Common/test/Test.cpp
@@ -500,6 +500,42 @@ TEST(CommonTest, testSparseMatrix) {
   ASSERT_EQ(1, check_status.info);
 }
 
+TEST(CommonTest, testSparseMatrixAddTermForced) {
+  // structural zeros must be stored, addTerm keeps dropping them
+  SparseMatrix smj;
+  smj.init(3, 3);
+  smj.changeCol();
+  smj.addTermForced(0, 0.0);   // structural zero: stored
+  smj.addTermForced(1, 5.0);   // regular value: stored
+  smj.addTerm(2, 0.0);         // regular addTerm: dropped
+  smj.changeCol();
+  smj.changeCol();
+  ASSERT_EQ(smj.nbElem(), 2);
+  ASSERT_EQ(smj.Ap_[0], 0);
+  ASSERT_EQ(smj.Ap_[1], 2);
+  ASSERT_EQ(smj.Ai_[0], 0);
+  ASSERT_EQ(smj.Ai_[1], 1);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[0], 0.0);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[1], 5.0);
+  ASSERT_EQ(smj.withoutNan(), true);
+  ASSERT_EQ(smj.withoutInf(), true);
+
+  // NaN / Inf tracking is preserved
+  SparseMatrix smj2;
+  smj2.init(2, 2);
+  smj2.changeCol();
+  const double zero = 0.0;
+  smj2.addTermForced(0, 1. / zero);
+  smj2.changeCol();
+  ASSERT_EQ(smj2.withoutInf(), false);
+
+  SparseMatrix smj3;
+  smj3.init(2, 2);
+  smj3.changeCol();
+  smj3.addTermForced(0, nan(""));
+  smj3.changeCol();
+  ASSERT_EQ(smj3.withoutNan(), false);
+}
 
 TEST(CommonTest, testEnumUtils) {
   ASSERT_EQ(modeChangeType2Str(NO_MODE), "No mode change");

--- a/dynawo/sources/Modeler/Common/DYNModel.h
+++ b/dynawo/sources/Modeler/Common/DYNModel.h
@@ -219,6 +219,15 @@ class Model {
   virtual void reinitMode() = 0;
 
   /**
+   * @brief get whether the last mode change was a topology change that left the Jacobian
+   * sparsity pattern invariant, aggregated (OR) over all sub models, with the same set/reset
+   * lifecycle as getModeChangeType()/reinitMode()
+   *
+   * @return @b true if the last mode change was a pattern-invariant topology change
+   */
+  virtual bool getPatternInvariantTopoChange() const = 0;
+
+  /**
    * @brief get the type of z that were modified
    * @return type of z that were modified
    */

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
@@ -68,6 +68,7 @@ sizeY_(0),
 silentZChange_(NO_Z_CHANGE),
 modeChange_(false),
 modeChangeType_(NO_MODE),
+patternInvariantTopoChange_(false),
 offsetFOptional_(0),
 zConnectedLocal_(nullptr),
 silentZInitialized_(false),
@@ -547,6 +548,12 @@ ModelMulti::evalMode(const double t) {
     if (subModel->modeChange()) {
       modeChange_ = true;
     }
+    // Latched on every call and cleared only by reinitMode(): a sub model reports this per
+    // evalModeSub() call rather than against its own high-water mark, so the OR must be
+    // unconditional.
+    if (subModel->getPatternInvariantTopoChange()) {
+      patternInvariantTopoChange_ = true;
+    }
   }
   if (modeChange_) {
     modeChangeType_ = modeChangeType;
@@ -563,6 +570,7 @@ ModelMulti::evalMode(const double t) {
 void
 ModelMulti::reinitMode() {
   modeChangeType_ = NO_MODE;
+  patternInvariantTopoChange_ = false;
   for (const auto& subModel : subModels_) {
     subModel->modeChange(false);
     subModel->setModeChangeType(NO_MODE);

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.h
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.h
@@ -161,6 +161,13 @@ class ModelMulti : public Model, private boost::noncopyable {
   void reinitMode() override;
 
   /**
+   * @copydoc Model::getPatternInvariantTopoChange() const
+   */
+  inline bool getPatternInvariantTopoChange() const override {
+    return patternInvariantTopoChange_;
+  }
+
+  /**
    * @copydoc Model::notifyTimeStep()
    */
   void notifyTimeStep() override;
@@ -613,6 +620,7 @@ class ModelMulti : public Model, private boost::noncopyable {
   zChangeType_t silentZChange_;  ///< @b indicates which types of silent Z has changed
   bool modeChange_;  ///< @b true if one mode has changed
   modeChangeType_t modeChangeType_;  ///< type of mode change
+  bool patternInvariantTopoChange_;  ///< @b true if the last mode change was a pattern-invariant topology change; same lifecycle as modeChangeType_
 
   unsigned int offsetFOptional_;  ///< offset in whole F buffer for optional equations
   std::set<int> numVarsOptional_;  ///< index of optional variables

--- a/dynawo/sources/Modeler/Common/DYNSubModel.h
+++ b/dynawo/sources/Modeler/Common/DYNSubModel.h
@@ -520,6 +520,16 @@ class SubModel {
   }
 
   /**
+   * @brief determine whether the last evalMode() call on this sub model reported a topology
+   * change whose Jacobian sparsity pattern is invariant (as opposed to a plain algebraic
+   * state change)
+   * @return true if it did, false by default
+   */
+  virtual bool getPatternInvariantTopoChange() const {
+    return false;
+  }
+
+  /**
    * @brief Coherence check on data (asserts, min/max values, sanity checks)
    *
    * @param t : time for which to conduct the data coherence check

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.cpp
@@ -133,7 +133,9 @@ calculatedVarBuffer_(NULL),
 isInit_(false) ,
 isInitModel_(false),
 withNodeBreakerTopology_(false),
-deactivateZeroCrossingFunctions_(false) {
+deactivateZeroCrossingFunctions_(false),
+patternInvariantTopology_(false),
+patternInvariantTopoChange_(false) {
   busContainer_.reset(new ModelBusContainer());
 }
 
@@ -1056,14 +1058,25 @@ ModelNetwork::evalMode(const double t) {
    *     1. State or topological change on the network (given by the evalState method)
    *     2. Short-circuit on a bus (given by the evalNodeFault method)
    */
-  bool topoChange = false;
+  bool topoChangeStructural = false;
+  bool topoChangePatternInvariant = false;
   bool stateChange = false;
   modeChangeType_t modeChangeType = NO_MODE;
+
+  patternInvariantTopoChange_ = false;
 
   for (const auto& component : getComponents()) {
     switch (component->evalState(t)) {
     case NetworkComponent::TOPO_CHANGE:
-      topoChange = true;
+      // Voltage-level-internal events (switches, buses, injection connection
+      // changes) keep an invariant Jacobian pattern with superset sparsity;
+      // structural events (line/transformer trips) still need a J update.
+      if (patternInvariantTopology_ && component->hasPatternInvariantTopologyChange()) {
+        topoChangePatternInvariant = true;
+        patternInvariantTopoChange_ = true;
+      } else {
+        topoChangeStructural = true;
+      }
       break;
     case NetworkComponent::STATE_CHANGE:
       stateChange = true;
@@ -1074,9 +1087,9 @@ ModelNetwork::evalMode(const double t) {
   }
 
   // recalculate admittance matrix and reevaluate connectivity
-  if (topoChange) {
+  if (topoChangeStructural) {
     modeChangeType = ALGEBRAIC_J_UPDATE_MODE;
-  } else if (stateChange) {
+  } else if (topoChangePatternInvariant || stateChange) {
     modeChangeType = ALGEBRAIC_MODE;
   }
 
@@ -1248,6 +1261,7 @@ ModelNetwork::defineParameters(vector<ParameterModeler>& parameters) {
   ModelHvdcLink::defineParameters(parameters);
   parameters.push_back(ParameterModeler("startingPointMode", VAR_TYPE_STRING, EXTERNAL_PARAMETER));
   parameters.push_back(ParameterModeler("deactivate_zero_crossing_functions", VAR_TYPE_BOOL, EXTERNAL_PARAMETER));
+  parameters.push_back(ParameterModeler("patternInvariantTopology", VAR_TYPE_BOOL, EXTERNAL_PARAMETER));
 
   for (const auto& component : getComponents()) {
     component->defineNonGenericParameters(parameters);
@@ -1318,6 +1332,10 @@ ModelNetwork::setSubModelParameters() {
   deactivateZeroCrossingFunctions_ = false;
   if (deactivateZeroCrossingFunctions.hasValue())
     deactivateZeroCrossingFunctions_ = deactivateZeroCrossingFunctions.getValue<bool>();
+  const auto& patternInvariantTopology = findParameter("patternInvariantTopology", false);
+  patternInvariantTopology_ = false;
+  if (patternInvariantTopology.hasValue())
+    patternInvariantTopology_ = patternInvariantTopology.getValue<bool>();
   for (const auto& component : getComponents())
     component->setSubModelParameters(parametersDynamic_);
 }

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelNetwork.h
@@ -278,6 +278,34 @@ class ModelNetwork : public ModelCPP, private boost::noncopyable {
   }
 
   /**
+   * @brief get whether the pattern-invariant topology optimization is enabled
+   * @return whether the pattern-invariant topology optimization is enabled
+   */
+  inline bool getPatternInvariantTopology() const {
+    return patternInvariantTopology_;
+  }
+
+  /**
+   * @brief set whether the pattern-invariant topology optimization is enabled
+   *
+   * Exposed for unit tests; production code sets this via the "patternInvariantTopology" parameter.
+   *
+   * @param patternInvariantTopology whether the pattern-invariant topology optimization is enabled
+   */
+  inline void setPatternInvariantTopology(const bool patternInvariantTopology) {
+    patternInvariantTopology_ = patternInvariantTopology;
+  }
+
+  /**
+   * @brief get whether the last evalMode() call downgraded a genuine topology change to ALGEBRAIC_MODE
+   * (superset sparsity), as opposed to a plain algebraic state change
+   * @return whether the last mode change was a pattern-invariant topology change
+   */
+  inline bool getPatternInvariantTopoChange() const override {
+    return patternInvariantTopoChange_;
+  }
+
+  /**
    * @copydoc ModelCPP::initParams()
    */
   void initParams() override;
@@ -410,6 +438,8 @@ class ModelNetwork : public ModelCPP, private boost::noncopyable {
   bool isInitModel_;  ///< whether the current model used is the init one
   bool withNodeBreakerTopology_;  ///< whether at least one voltageLevel has node breaker topology view
   bool deactivateZeroCrossingFunctions_;  ///< whether we use root functions
+  bool patternInvariantTopology_;  ///< invariant switch sparsity + voltage-level topology-event downgrade; param "patternInvariantTopology", default false
+  bool patternInvariantTopoChange_;  ///< @b true if the last evalMode() call downgraded a genuine topology change (reset at the top of each evalMode() call)
 
   std::unique_ptr<ModelBusContainer> busContainer_;  ///< all network buses
   std::vector<std::shared_ptr<ModelVoltageLevel> > vLevelComponents_;  ///< all voltage level components

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelSwitch.cpp
@@ -280,38 +280,73 @@ ModelSwitch::close() {
 
 void
 ModelSwitch::evalJt(const double /*cj*/, const int rowOffset, SparseMatrix& jt) {
-  // Column for node current / real part of the voltage (i depending on re(V))
-  // --------------------------------------------------------------------------
+  // The superset form is used outside initialization only.
+  //
+  // SolverKINSubModel, which solves for the switch currents, hands this Jacobian to KLU
+  // unchanged, so during initialization KLU would be asked to factorise a matrix carrying
+  // explicit zeros in pivot positions. On a near-singular initial state that solve can return
+  // NaN without raising. isInitModel() covers the switch-current solve and getIsInitProcess()
+  // the rest of the initialization phase, where the network is solved as an ordinary submodel.
+  //
+  // The exclusion is free: the superset holds the pattern steady across topology events, and
+  // initialization runs once, before any event.
+  if (network_->getPatternInvariantTopology() && !network_->isInitModel() && !network_->getIsInitProcess()) {
+    // Superset sparsity: both columns always hold the same three entries
+    // (bus1, bus2, self) in fixed order so the pattern is invariant across
+    // switch states. Inactive entries hold structural zeros (addTermForced).
+    //   closed, normal       : ur1 - ur2 = 0  -> bus coupling entries active
+    //   closed, loop-breaking: irsw - 1  = 0  -> self entry active
+    //   open (or bus1 off)   : irsw      = 0  -> self entry active
+    const bool busCoupling = (getConnectionState() == CLOSED && !modelBus1_->getSwitchOff() && !inLoop_);
 
-  // Switching column
-  jt.changeCol();
+    // Column for the real part
+    jt.changeCol();
+    jt.addTermForced(modelBus1_->urYNum() + rowOffset, busCoupling ? +1. : 0.);
+    jt.addTermForced(modelBus2_->urYNum() + rowOffset, busCoupling ? -1. : 0.);
+    jt.addTermForced(irYNum_ + rowOffset, busCoupling ? 0. : +1.);
 
-  if (getConnectionState() == CLOSED && !modelBus1_->getSwitchOff()) {  // Close switch
-    if (inLoop_) {  // Switch breaking a loop : irsw - 1 = 0
+    // Column for the imaginary part
+    jt.changeCol();
+    jt.addTermForced(modelBus1_->uiYNum() + rowOffset, busCoupling ? +1. : 0.);
+    jt.addTermForced(modelBus2_->uiYNum() + rowOffset, busCoupling ? -1. : 0.);
+    jt.addTermForced(iiYNum_ + rowOffset, busCoupling ? 0. : +1.);
+  } else {
+    // Default state-dependent sparsity: entries emitted only for the active equation form,
+    // so the pattern changes when the switch state changes.
+
+    // Column for node current / real part of the voltage (i depending on re(V))
+    // --------------------------------------------------------------------------
+
+    // Switching column
+    jt.changeCol();
+
+    if (getConnectionState() == CLOSED && !modelBus1_->getSwitchOff()) {  // Close switch
+      if (inLoop_) {  // Switch breaking a loop : irsw - 1 = 0
+        jt.addTerm(irYNum_ + rowOffset, +1);
+      } else {  // "Normal" case : ur1 - ur2 = 0
+        jt.addTerm(modelBus1_->urYNum() + rowOffset, +1.);
+        jt.addTerm(modelBus2_->urYNum() + rowOffset, -1.);
+      }
+    } else {  // Open switch : irsw = 0
       jt.addTerm(irYNum_ + rowOffset, +1);
-    } else {  // "Normal" case : ur1 - ur2 = 0
-      jt.addTerm(modelBus1_->urYNum() + rowOffset, +1.);
-      jt.addTerm(modelBus2_->urYNum() + rowOffset, -1.);
     }
-  } else {  // Open switch : irsw = 0
-    jt.addTerm(irYNum_ + rowOffset, +1);
-  }
 
-  // Column for node current / imaginary part of the voltage (i depending on im(V))
-  // ------------------------------------------------------------------------------
+    // Column for node current / imaginary part of the voltage (i depending on im(V))
+    // ------------------------------------------------------------------------------
 
-  // Switching column
-  jt.changeCol();
+    // Switching column
+    jt.changeCol();
 
-  if (getConnectionState() == CLOSED && !modelBus1_->getSwitchOff()) {  // Close switch
-    if (inLoop_) {  // Switch breaking a loop : iisw -1 = 0
+    if (getConnectionState() == CLOSED && !modelBus1_->getSwitchOff()) {  // Close switch
+      if (inLoop_) {  // Switch breaking a loop : iisw -1 = 0
+        jt.addTerm(iiYNum_ + rowOffset, +1.);
+      } else {  // "Normal" case : ui1 - ui2 = 0
+        jt.addTerm(modelBus1_->uiYNum() + rowOffset, +1.);
+        jt.addTerm(modelBus2_->uiYNum() + rowOffset, -1.);
+      }
+    } else {  // Open switch : iisw = 0
       jt.addTerm(iiYNum_ + rowOffset, +1.);
-    } else {  // "Normal" case : ui1 - ui2 = 0
-      jt.addTerm(modelBus1_->uiYNum() + rowOffset, +1.);
-      jt.addTerm(modelBus2_->uiYNum() + rowOffset, -1.);
     }
-  } else {  // Open switch : iisw = 0
-    jt.addTerm(iiYNum_ + rowOffset, +1.);
   }
 }
 

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNModelVoltageLevel.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNModelVoltageLevel.h
@@ -234,6 +234,16 @@ class ModelVoltageLevel : public NetworkComponent {
   StateChange_t evalState(double time) override;
 
   /**
+   * @copydoc NetworkComponent::hasPatternInvariantTopologyChange()
+   *
+   * Voltage-level topology events are switch/bus/injection connection
+   * changes; with superset switch sparsity they are downgradable.
+   */
+  bool hasPatternInvariantTopologyChange() const override {
+    return true;
+  }
+
+  /**
    * @copydoc NetworkComponent::evalNodeInjection()
    */
   void evalNodeInjection()  override;

--- a/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponent.h
+++ b/dynawo/sources/Models/CPP/ModelNetwork/DYNNetworkComponent.h
@@ -325,6 +325,21 @@ class NetworkComponent {  ///< Base class for network component models
   virtual StateChange_t evalState(double time) = 0;
 
   /**
+   * @brief whether topology changes reported by this component leave the
+   * Jacobian sparsity pattern unchanged
+   *
+   * With superset sparsity (structural zeros for inactive entries) a
+   * component's topology events no longer require a Jacobian structure
+   * update; ModelNetwork::evalMode can then report ALGEBRAIC_MODE instead
+   * of ALGEBRAIC_J_UPDATE_MODE for them.
+   *
+   * @return true if this component's topology changes preserve the pattern
+   */
+  virtual bool hasPatternInvariantTopologyChange() const {
+    return false;
+  }
+
+  /**
    * @brief set network
    * @param model model
    */

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestIIDMInitializationFlow.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestIIDMInitializationFlow.cpp
@@ -289,6 +289,32 @@ TEST(ModelsModelNetwork, ModelNetworkTwoWindingTransformerParam) {
   ASSERT_NO_THROW(modelNetwork->setSubModelParameters());
 }
 
+TEST(ModelsModelNetwork, ModelNetworkPatternInvariantTopologyParam) {
+  const NetworkProperty properties = {
+      false /*instantiateTwoWindingTransformer*/,
+      false /*instantiateRatioTap*/,
+      false /*instantiateDanglingLine*/,
+      false /*instantiateLine*/,
+      false /*instantiateLoad*/,
+      false /*instantiateCapacitorShuntCompensator*/,
+      false /*instantiateReactanceShuntCompensator*/,
+      true /*instantiateSwitch*/
+  };
+  shared_ptr<DataInterface> data = createDataItfFromNetwork(createNetwork(properties));
+  shared_ptr<SubModel> modelNetwork = initializeModelNetwork(data);
+
+  modelNetwork->defineParameters();
+  const bool isInitParam = false;
+  ASSERT_EQ(modelNetwork->hasParameter("patternInvariantTopology", isInitParam), true);
+
+  // absent from the .par: must not throw (flag keeps its default false)
+  ASSERT_NO_THROW(modelNetwork->setSubModelParameters());
+
+  // explicit value must be accepted and forwarded without throwing
+  modelNetwork->setParameterValue("patternInvariantTopology", PAR, false, isInitParam);
+  ASSERT_NO_THROW(modelNetwork->setSubModelParameters());
+}
+
 TEST(ModelsModelNetwork, ModelNetworkTwoWindingTransformerWithRatioTapChangerParam) {
   const NetworkProperty properties = {
       true /*instantiateTwoWindingTransformer*/,

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestLoad.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestLoad.cpp
@@ -197,6 +197,81 @@ fillParameters(std::shared_ptr<ModelLoad> load, std::string& startingPoint, bool
   load->setSubModelParameters(parametersModels);
 }
 
+// Minimal component stub: reports STATE_CHANGE from evalState so the
+// ModelVoltageLevel aggregation can be tested without graph machinery.
+class StubStateChangeComponent : public NetworkComponent {
+ public:
+  StubStateChangeComponent() : NetworkComponent("stub") { }
+  StateChange_t evalState(double /*time*/) override { return NetworkComponent::STATE_CHANGE; }
+  // every other pure virtual: empty body
+  void addBusNeighbors() override { }
+  void instantiateVariables(std::vector<boost::shared_ptr<Variable> >& /*variables*/) override { }
+  void defineNonGenericParameters(std::vector<ParameterModeler>& /*parameters*/) override { }
+  void defineElements(std::vector<Element>& /*elements*/, std::map<std::string, int>& /*mapElement*/) override { }
+  void evalNodeInjection() override { }
+  void evalDerivatives(const double /*cj*/) override { }
+  void evalDerivativesPrim() override { }
+  void evalF(propertyF_t /*type*/) override { }
+  void evalJt(double /*cj*/, int /*rowOffset*/, SparseMatrix& /*jt*/) override { }
+  void evalJtPrim(int /*rowOffset*/, SparseMatrix& /*jtPrim*/) override { }
+  void evalG(double /*t*/) override { }
+  StateChange_t evalZ(double /*t*/, bool /*onlyEvaluateStateChange*/) override { return NetworkComponent::NO_CHANGE; }
+  void evalCalculatedVars() override { }
+  void getIndexesOfVariablesUsedForCalculatedVarI(unsigned /*numCalculatedVar*/, std::vector<int>& /*numVars*/) const override { }
+  void evalJCalculatedVarI(unsigned /*numCalculatedVar*/, std::vector<double>& /*res*/) const override { }
+  double evalCalculatedVarI(unsigned /*numCalculatedVar*/) const override { return 0.; }
+  void evalStaticYType() override { }
+  void evalDynamicYType() override { }
+  void evalStaticFType() override { }
+  void evalDynamicFType() override { }
+  void collectSilentZ(BitMask* /*silentZTable*/) override { }
+  void evalYMat() override { }
+  void init(int& /*yNum*/) override { }
+  void getY0() override { }
+  void setSubModelParameters(const std::unordered_map<std::string, ParameterModeler>& /*params*/) override { }
+  void setFequations(std::map<int, std::string>& /*fEquationIndex*/) override { }
+  void setGequations(std::map<int, std::string>& /*gEquationIndex*/) override { }
+  void initSize() override { }
+};
+
+TEST(ModelsModelNetwork, ModelNetworkVoltageLevelNodeBreakerPromotionIsDowngradable) {
+  // NODE_BREAKER voltage level: a nested STATE_CHANGE is promoted to
+  // TOPO_CHANGE (ModelVoltageLevel::evalState) and the voltage level is
+  // classified downgradable, so non-switch events inside a voltage level
+  // (loads, generators, shunts) reach the same ALGEBRAIC_MODE path as
+  // switch events (covered end-to-end by
+  // testSolverSIMPatternInvariantTopologyDowngrade).
+  powsybl::iidm::Network networkNB("testNB", "testNB");
+  powsybl::iidm::Substation& sNB = networkNB.newSubstation().setId("S_NB").add();
+  powsybl::iidm::VoltageLevel& vlNBIIDM = sNB.newVoltageLevel()
+      .setId("MyNodeBreakerVoltageLevel")
+      .setNominalV(5.)
+      .setTopologyKind(powsybl::iidm::TopologyKind::NODE_BREAKER)
+      .setHighVoltageLimit(2.)
+      .setLowVoltageLimit(.5)
+      .add();
+  std::shared_ptr<VoltageLevelInterfaceIIDM> vlNBItf = std::make_shared<VoltageLevelInterfaceIIDM>(vlNBIIDM);
+  std::shared_ptr<ModelVoltageLevel> vlNB = std::make_shared<ModelVoltageLevel>(vlNBItf);
+  vlNB->addComponent(std::make_shared<StubStateChangeComponent>());
+  ASSERT_EQ(vlNB->evalState(0.), NetworkComponent::TOPO_CHANGE);
+  ASSERT_TRUE(vlNB->hasPatternInvariantTopologyChange());
+
+  // BUS_BREAKER contrast: the same nested STATE_CHANGE is NOT promoted.
+  powsybl::iidm::Network networkBB("testBB", "testBB");
+  powsybl::iidm::Substation& sBB = networkBB.newSubstation().setId("S_BB").add();
+  powsybl::iidm::VoltageLevel& vlBBIIDM = sBB.newVoltageLevel()
+      .setId("MyBusBreakerVoltageLevel")
+      .setNominalV(5.)
+      .setTopologyKind(powsybl::iidm::TopologyKind::BUS_BREAKER)
+      .setHighVoltageLimit(2.)
+      .setLowVoltageLimit(.5)
+      .add();
+  std::shared_ptr<VoltageLevelInterfaceIIDM> vlBBItf = std::make_shared<VoltageLevelInterfaceIIDM>(vlBBIIDM);
+  std::shared_ptr<ModelVoltageLevel> vlBB = std::make_shared<ModelVoltageLevel>(vlBBItf);
+  vlBB->addComponent(std::make_shared<StubStateChangeComponent>());
+  ASSERT_EQ(vlBB->evalState(0.), NetworkComponent::STATE_CHANGE);
+}
+
 TEST(ModelsModelNetwork, ModelNetworkLoadInitializationClosed) {
   powsybl::iidm::Network networkIIDM("MyNetwork", "MyNetwork");
   auto tuple = createModelLoad(false, false, networkIIDM);
@@ -714,6 +789,19 @@ TEST(ModelsModelNetwork, ModelNetworkLoadJt) {
   ASSERT_NO_THROW(loadInit->evalJt(1., 0, smjInit));
   ASSERT_EQ(smjInit.nbElem(), 0);
   delete[] zConnected;
+}
+
+TEST(ModelsModelNetwork, ModelNetworkHasPatternInvariantTopologyChange) {
+  powsybl::iidm::Network networkIIDM("test", "test");
+  auto tuple = createModelLoad(false, false, networkIIDM);
+  std::shared_ptr<ModelLoad> load = std::get<0>(tuple);
+  std::shared_ptr<ModelVoltageLevel> vl = std::get<1>(tuple);
+
+  // Voltage levels contain switches/buses whose Jacobian pattern is invariant
+  // with superset sparsity: their topology changes are downgradable.
+  ASSERT_TRUE(vl->hasPatternInvariantTopologyChange());
+  // Every other component keeps the structural default.
+  ASSERT_FALSE(load->hasPatternInvariantTopologyChange());
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Models/CPP/ModelNetwork/test/TestSwitch.cpp
+++ b/dynawo/sources/Models/CPP/ModelNetwork/test/TestSwitch.cpp
@@ -37,7 +37,7 @@ using boost::shared_ptr;
 namespace DYN {
 
 static std::shared_ptr<ModelSwitch>
-createModelSwitch(bool open, bool initModel) {
+createModelSwitch(bool open, bool initModel, ModelNetwork** networkOut = nullptr) {
   powsybl::iidm::Network networkIIDM("test", "test");
 
   powsybl::iidm::Substation& s = networkIIDM.newSubstation()
@@ -88,6 +88,8 @@ createModelSwitch(bool open, bool initModel) {
   sw->setNetwork(network);
   bus1->setNetwork(network);
   bus2->setNetwork(network);
+  if (networkOut)
+    *networkOut = network;
   return sw;
 }
 
@@ -518,7 +520,9 @@ TEST(ModelsModelNetwork, ModelNetworkSwitchDefineInstantiate) {
 }
 
 TEST(ModelsModelNetwork, ModelNetworkSwitchJt) {
-  std::shared_ptr<ModelSwitch> sw = createModelSwitch(false, false);
+  ModelNetwork* network = nullptr;
+  std::shared_ptr<ModelSwitch> sw = createModelSwitch(false, false, &network);
+  network->setPatternInvariantTopology(true);
   sw->initSize();
 
   std::shared_ptr<ModelBus> bus1 = sw->getModelBus1();
@@ -545,60 +549,194 @@ TEST(ModelsModelNetwork, ModelNetworkSwitchJt) {
   bus2->setReferenceZ(&z2[0], zConnected2, 0);
   bus2->setReferenceY(&y2[0], &yp2[0], &f2[0], 0, 0);
 
+  // Superset sparsity: every state emits 3 entries per column in fixed order
+  // (bus1, bus2, self); only the values change with the switch state.
   SparseMatrix smj;
   int size = sw->sizeY();
   smj.init(size, size);
   sw->evalJt(1., 0, smj);
-  ASSERT_EQ(smj.nbElem(), 4);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[0], 1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[1], -1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[2], 1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[3], -1.);
+  ASSERT_EQ(smj.nbElem(), 6);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[0], 1.);    // bus1
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[1], -1.);   // bus2
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[2], 0.);    // self (structural zero)
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[3], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[4], -1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[5], 0.);
   ASSERT_EQ(smj.Ap_[0], 0);
-  ASSERT_EQ(smj.Ap_[1], 2);
-  ASSERT_EQ(smj.Ap_[2], 4);
+  ASSERT_EQ(smj.Ap_[1], 3);
+  ASSERT_EQ(smj.Ap_[2], 6);
 
   sw->inLoop(true);
   SparseMatrix smj2;
   smj2.init(size, size);
   sw->evalJt(1., 0, smj2);
-  ASSERT_EQ(smj2.nbElem(), 2);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[0], 1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[1], 1.);
+  ASSERT_EQ(smj2.nbElem(), 6);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[0], 0.);   // bus1 (structural zero)
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[1], 0.);   // bus2 (structural zero)
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[2], 1.);   // self
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[3], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[4], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj2.Ax_[5], 1.);
   ASSERT_EQ(smj2.Ap_[0], 0);
-  ASSERT_EQ(smj2.Ap_[1], 1);
+  ASSERT_EQ(smj2.Ap_[1], 3);
+  ASSERT_EQ(smj2.Ap_[2], 6);
   sw->inLoop(false);
 
   sw->setConnectionState(OPEN);
   SparseMatrix smj3;
   smj3.init(size, size);
   sw->evalJt(1., 0, smj3);
-  ASSERT_EQ(smj3.nbElem(), 2);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[0], 1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[1], 1.);
+  ASSERT_EQ(smj3.nbElem(), 6);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[0], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[1], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[2], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[3], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[4], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj3.Ax_[5], 1.);
   ASSERT_EQ(smj3.Ap_[0], 0);
-  ASSERT_EQ(smj3.Ap_[1], 1);
+  ASSERT_EQ(smj3.Ap_[1], 3);
+  ASSERT_EQ(smj3.Ap_[2], 6);
   sw->setConnectionState(CLOSED);
 
   int offset = 3;
   sw->init(offset);
   SparseMatrix smj4;
-  smj4.init(size, size);
+  // Rows must cover the yNum offset: init(int&) moves irYNum_/iiYNum_ to offset and offset+1,
+  // and the superset always emits the self entry, as a structural zero in this branch. Columns
+  // stay at size, evalJt emitting exactly sw->sizeY() of them regardless of the row offset.
+  smj4.init(size + offset, size);
   sw->evalJt(1., 0, smj4);
-  ASSERT_EQ(smj.nbElem(), 4);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[0], 1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[1], -1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[2], 1.);
-  ASSERT_DOUBLE_EQUALS_DYNAWO(smj.Ax_[3], -1.);
-  ASSERT_EQ(smj.Ap_[0], 0);
-  ASSERT_EQ(smj.Ap_[1], 2);
-  ASSERT_EQ(smj.Ap_[2], 4);
+  ASSERT_EQ(smj4.nbElem(), 6);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj4.Ax_[0], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj4.Ax_[1], -1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj4.Ax_[2], 0.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj4.Ax_[3], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj4.Ax_[4], -1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smj4.Ax_[5], 0.);
+  ASSERT_EQ(smj4.Ap_[0], 0);
+  ASSERT_EQ(smj4.Ap_[1], 3);
+  ASSERT_EQ(smj4.Ap_[2], 6);
 
 
   SparseMatrix smjPrime;
   smjPrime.init(size, size);
   sw->evalJtPrim(0, smjPrime);
   ASSERT_EQ(smjPrime.nbElem(), 0);
+
+  // With the parameter off, entries are emitted only for the active form, so the element count
+  // follows the switch state: closed/normal 4, in-loop 2, open 2. The matrices are sized
+  // size + offset rows to hold the self entries the loop and open branches emit; the row count
+  // does not affect nbElem/Ap_/Ax_.
+  network->setPatternInvariantTopology(false);
+
+  SparseMatrix smjStockClosed;
+  smjStockClosed.init(size + offset, size);
+  sw->evalJt(1., 0, smjStockClosed);
+  ASSERT_EQ(smjStockClosed.nbElem(), 4);
+  ASSERT_EQ(smjStockClosed.Ap_[0], 0);
+  ASSERT_EQ(smjStockClosed.Ap_[1], 2);
+  ASSERT_EQ(smjStockClosed.Ap_[2], 4);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockClosed.Ax_[0], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockClosed.Ax_[1], -1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockClosed.Ax_[2], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockClosed.Ax_[3], -1.);
+
+  sw->inLoop(true);
+  SparseMatrix smjStockLoop;
+  smjStockLoop.init(size + offset, size);
+  sw->evalJt(1., 0, smjStockLoop);
+  ASSERT_EQ(smjStockLoop.nbElem(), 2);
+  ASSERT_EQ(smjStockLoop.Ap_[0], 0);
+  ASSERT_EQ(smjStockLoop.Ap_[1], 1);
+  ASSERT_EQ(smjStockLoop.Ap_[2], 2);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockLoop.Ax_[0], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockLoop.Ax_[1], 1.);
+  sw->inLoop(false);
+
+  sw->setConnectionState(OPEN);
+  SparseMatrix smjStockOpen;
+  smjStockOpen.init(size + offset, size);
+  sw->evalJt(1., 0, smjStockOpen);
+  ASSERT_EQ(smjStockOpen.nbElem(), 2);
+  ASSERT_EQ(smjStockOpen.Ap_[0], 0);
+  ASSERT_EQ(smjStockOpen.Ap_[1], 1);
+  ASSERT_EQ(smjStockOpen.Ap_[2], 2);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockOpen.Ax_[0], 1.);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(smjStockOpen.Ax_[1], 1.);
+  sw->setConnectionState(CLOSED);
+
+  delete[] zConnected1;
+  delete[] zConnected2;
+}
+
+TEST(ModelsModelNetwork, ModelNetworkSwitchJtPatternInvariance) {
+  ModelNetwork* network = nullptr;
+  std::shared_ptr<ModelSwitch> sw = createModelSwitch(false, false, &network);
+  network->setPatternInvariantTopology(true);
+  sw->initSize();
+
+  std::shared_ptr<ModelBus> bus1 = sw->getModelBus1();
+  bus1->initSize();
+  std::vector<double> y1(bus1->sizeY(), 0.);
+  std::vector<double> yp1(bus1->sizeY(), 0.);
+  std::vector<double> f1(bus1->sizeF(), 0.);
+  std::vector<double> z1(bus1->sizeZ(), 0.);
+  bool* zConnected1 = new bool[bus1->sizeZ()];
+  for (int i = 0; i < bus1->sizeZ(); ++i)
+    zConnected1[i] = true;
+  bus1->setReferenceZ(&z1[0], zConnected1, 0);
+  bus1->setReferenceY(&y1[0], &yp1[0], &f1[0], 0, 0);
+
+  std::shared_ptr<ModelBus> bus2 = sw->getModelBus2();
+  bus2->initSize();
+  std::vector<double> y2(bus2->sizeY(), 0.);
+  std::vector<double> yp2(bus2->sizeY(), 0.);
+  std::vector<double> f2(bus2->sizeF(), 0.);
+  std::vector<double> z2(bus2->sizeZ(), 0.);
+  bool* zConnected2 = new bool[bus2->sizeZ()];
+  for (int i = 0; i < bus2->sizeZ(); ++i)
+    zConnected2[i] = true;
+  bus2->setReferenceZ(&z2[0], zConnected2, 0);
+  bus2->setReferenceY(&y2[0], &yp2[0], &f2[0], 0, 0);
+
+  const int size = sw->sizeY();
+
+  // Build the Jacobian columns in CLOSED, OPEN, inLoop-CLOSED, and CLOSED again;
+  // Ap_ and Ai_ must be identical in all states (only Ax_ may differ).
+  SparseMatrix smjClosed;
+  smjClosed.init(size, size);
+  sw->evalJt(1., 0, smjClosed);
+
+  sw->setConnectionState(OPEN);
+  SparseMatrix smjOpen;
+  smjOpen.init(size, size);
+  sw->evalJt(1., 0, smjOpen);
+
+  sw->setConnectionState(CLOSED);
+  sw->inLoop(true);
+  SparseMatrix smjLoop;
+  smjLoop.init(size, size);
+  sw->evalJt(1., 0, smjLoop);
+  sw->inLoop(false);
+
+  SparseMatrix smjClosedAgain;
+  smjClosedAgain.init(size, size);
+  sw->evalJt(1., 0, smjClosedAgain);
+
+  ASSERT_EQ(smjClosed.nbElem(), smjOpen.nbElem());
+  ASSERT_EQ(smjClosed.nbElem(), smjLoop.nbElem());
+  ASSERT_EQ(smjClosed.nbElem(), smjClosedAgain.nbElem());
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_EQ(smjClosed.Ap_[i], smjOpen.Ap_[i]);
+    ASSERT_EQ(smjClosed.Ap_[i], smjLoop.Ap_[i]);
+    ASSERT_EQ(smjClosed.Ap_[i], smjClosedAgain.Ap_[i]);
+  }
+  for (int i = 0; i < smjClosed.nbElem(); ++i) {
+    ASSERT_EQ(smjClosed.Ai_[i], smjOpen.Ai_[i]);
+    ASSERT_EQ(smjClosed.Ai_[i], smjLoop.Ai_[i]);
+    ASSERT_EQ(smjClosed.Ai_[i], smjClosedAgain.Ai_[i]);
+    ASSERT_DOUBLE_EQUALS_DYNAWO(smjClosed.Ax_[i], smjClosedAgain.Ax_[i]);
+  }
   delete[] zConnected1;
   delete[] zConnected2;
 }

--- a/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.cpp
@@ -80,6 +80,7 @@ printfl_(0),
 skipNextNR_(false),
 skipAlgebraicResidualsEvaluation_(false),
 optimizeAlgebraicResidualsEvaluations_(true),
+algebraicRestorationOnInvariantTopology_(false),
 skipNRIfInitialGuessOK_(true),
 nbLastTimeSimulated_(0) {
   minimalAcceptableStep_ = 0.1;
@@ -104,6 +105,8 @@ SolverCommonFixedTimeStep::defineSpecificParametersCommon() {
   parameters_.insert(make_pair("mxiter", ParameterSolver("mxiter", VAR_TYPE_INT, optional)));
   parameters_.insert(make_pair("printfl", ParameterSolver("printfl", VAR_TYPE_INT, optional)));
   parameters_.insert(make_pair("optimizeAlgebraicResidualsEvaluations", ParameterSolver("optimizeAlgebraicResidualsEvaluations", VAR_TYPE_BOOL, optional)));
+  parameters_.insert(make_pair("algebraicRestorationOnInvariantTopology",
+      ParameterSolver("algebraicRestorationOnInvariantTopology", VAR_TYPE_BOOL, optional)));
   parameters_.insert(make_pair("skipNRIfInitialGuessOK", ParameterSolver("skipNRIfInitialGuessOK", VAR_TYPE_BOOL, optional)));
 }
 
@@ -138,6 +141,9 @@ SolverCommonFixedTimeStep::setSolverSpecificParametersCommon() {
   const ParameterSolver& optimizeAlgebraicResidualsEvaluations = findParameter("optimizeAlgebraicResidualsEvaluations");
   if (optimizeAlgebraicResidualsEvaluations.hasValue())
     optimizeAlgebraicResidualsEvaluations_ = optimizeAlgebraicResidualsEvaluations.getValue<bool>();
+  const ParameterSolver& algebraicRestorationOnInvariantTopology = findParameter("algebraicRestorationOnInvariantTopology");
+  if (algebraicRestorationOnInvariantTopology.hasValue())
+    algebraicRestorationOnInvariantTopology_ = algebraicRestorationOnInvariantTopology.getValue<bool>();
   const ParameterSolver& skipNRIfInitialGuessOK = findParameter("skipNRIfInitialGuessOK");
   if (skipNRIfInitialGuessOK.hasValue())
     skipNRIfInitialGuessOK_ = skipNRIfInitialGuessOK.getValue<bool>();
@@ -401,7 +407,12 @@ void SolverCommonFixedTimeStep::handleRoot(bool& redoStep) {
   if (model_->getModeChangeType() == ALGEBRAIC_J_UPDATE_MODE) {
     factorizationForced_ = true;
   } else {
-    factorizationForced_ = false;
+    // A topology event reported as ALGEBRAIC_MODE has moved the operating point while leaving
+    // the sparsity pattern fixed, so the next step must not start on the pre-event Jacobian.
+    // The factorization it forces is numeric only: the symbolic analysis is kept, because the
+    // pattern comparison in SolverCommon::propagateMatrixStructureChangeToKINSOL finds no
+    // change. getPatternInvariantTopoChange() is false for a plain algebraic event.
+    factorizationForced_ = model_->getPatternInvariantTopoChange();
     increaseStep();
   }
   redoStep = false;
@@ -430,7 +441,11 @@ bool SolverCommonFixedTimeStep::setupNewAlgRestoration(modeChangeType_t modeChan
     if (hasPrediction())
       getSolverKINYPrim().setupNewAlgebraicRestoration(fnormtolAlg_, initialaddtolAlg_, scsteptolAlg_, mxnewtstepAlg_, msbsetAlg_, mxiterAlg_, printflAlg_);
 
-    return false;  // no J factorization
+    // A pattern-invariant topology event reaches this branch as ALGEBRAIC_MODE, and the
+    // restoration solve needs a fresh factorization: the switch state moved the Jacobian's
+    // values, only its pattern is fixed. The factorization is numeric only, the symbolic
+    // analysis being retained because the pattern comparison finds no change.
+    return model_->getPatternInvariantTopoChange();
   } else if (modeChangeType == ALGEBRAIC_J_UPDATE_MODE) {
     solverKINAlgRestoration_->setupNewAlgebraicRestoration(fnormtolAlgJ_, initialaddtolAlgJ_, scsteptolAlgJ_, mxnewtstepAlgJ_, msbsetAlgJ_, mxiterAlgJ_,
                                                            printflAlgJ_);
@@ -454,8 +469,24 @@ SolverCommonFixedTimeStep::reinit() {
   int counter = 0;
   modeChangeType_t modeChangeType = model_->getModeChangeType();
 
-  if (modeChangeType < minimumModeChangeTypeForAlgebraicRestoration_)
+  // A pattern-invariant topology event is decided here rather than by
+  // minimumModeChangeTypeForAlgebraicRestoration, which compares severity only.
+  //
+  // By default such an event skips algebraic restoration: this solver re-solves F(y) = 0 over
+  // every variable on the next step, algebraic ones included, so the algebraic state is restored
+  // there instead, at the cost of the trajectory lagging by one step at the event instant. Set
+  // algebraicRestorationOnInvariantTopology to keep the restoration.
+  //
+  // The skip requires every event on the step to be pattern-invariant. A step also carrying a
+  // structural event reports ALGEBRAIC_J_UPDATE_MODE, and keeps its restoration.
+  const bool patternInvariantTopoEvent =
+      model_->getPatternInvariantTopoChange() && modeChangeType < ALGEBRAIC_J_UPDATE_MODE;
+  if (patternInvariantTopoEvent) {
+    if (!algebraicRestorationOnInvariantTopology_)
+      return;
+  } else if (modeChangeType < minimumModeChangeTypeForAlgebraicRestoration_) {
     return;
+  }
 
   const bool evaluateOnlyMode = optimizeReinitAlgebraicResidualsEvaluations_;
   skipAlgebraicResidualsEvaluation_ = false;

--- a/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.h
+++ b/dynawo/sources/Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.h
@@ -274,6 +274,7 @@ class SolverCommonFixedTimeStep : public Solver::Impl {
   std::vector<int> differentialVariablesIndices_;  ///< index of each differential variables
   bool skipAlgebraicResidualsEvaluation_;  ///< flag used to skip algebraic residuals evaluation after a convergence or a mode
   bool optimizeAlgebraicResidualsEvaluations_;  ///< enable or disable the optimization of the number of algebraic residuals evals
+  bool algebraicRestorationOnInvariantTopology_;  ///< keep algebraic restoration for a topology event whose Jacobian pattern is invariant; opt-in, default false (the next step's full solve restores the algebraic state)
   bool skipNRIfInitialGuessOK_;  ///< enable the possibility to skip next iterations if the simulation is stable
   int nbLastTimeSimulated_;  ///< nb times of simulation of the latest time
 };

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/TestBasics.cpp
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/TestBasics.cpp
@@ -1000,6 +1000,7 @@ TEST(ParametersTest, testParameters) {
   params->addParameter(parameters::ParameterFactory::newParameter("optimizeAlgebraicResidualsEvaluations", false));
   params->addParameter(parameters::ParameterFactory::newParameter("optimizeReinitAlgebraicResidualsEvaluations", false));
   params->addParameter(parameters::ParameterFactory::newParameter("skipNRIfInitialGuessOK", false));
+  params->addParameter(parameters::ParameterFactory::newParameter("algebraicRestorationOnInvariantTopology", false));
   params->addParameter(parameters::ParameterFactory::newParameter("minimumModeChangeTypeForAlgebraicRestoration", std::string("ALGEBRAIC_J_UPDATE")));
   params->addParameter(parameters::ParameterFactory::newParameter("order1Prediction", false));
   params->addParameter(parameters::ParameterFactory::newParameter("printResiduals", false));
@@ -1008,7 +1009,7 @@ TEST(ParametersTest, testParameters) {
   params->addParameter(parameters::ParameterFactory::newParameter("multipleStrategiesForAlgebraicRestoration", false));
   ASSERT_NO_THROW(solver->setParametersFromPARFile(params));
   ASSERT_NO_THROW(solver->setSolverParameters());
-  ASSERT_EQ(solver->getParametersMap().size(), 45);
+  ASSERT_EQ(solver->getParametersMap().size(), 46);
 }
 
 TEST(ParametersTest, testParametersInit) {
@@ -1059,7 +1060,7 @@ TEST(ParametersTest, testParametersInit) {
   params->addParameter(parameters::ParameterFactory::newParameter("multipleStrategiesForAlgebraicRestoration", false));
   ASSERT_NO_THROW(solver->setParametersFromPARFile(params));
   ASSERT_NO_THROW(solver->setSolverParameters());
-  ASSERT_EQ(solver->getParametersMap().size(), 45);
+  ASSERT_EQ(solver->getParametersMap().size(), 46);
 }
 
 TEST(SimulationTest, testSolverSIMTestPredictionOrder1) {
@@ -1150,6 +1151,44 @@ TEST(SimulationTest, testSolverSIMTestPredictionOrder0) {
   solver->solve(tStop, tCurrent);
   ASSERT_DOUBLE_EQUALS_DYNAWO(y[0], 0.980296);
   ASSERT_DOUBLE_EQUALS_DYNAWO(yp[0], -0.980296);
+}
+
+TEST(SimulationTest, testSolverSIMPatternInvariantTopologyDowngrade) {
+  const double tStart = 0.;
+  const double tStop = 5.;
+  std::pair<SolverFactory::SolverPtr, std::shared_ptr<Model> > p = initSolverAndModel("jobs/solverTestSwitch.dyd",
+  "jobs/solverTestSwitch.iidm", "jobs/solverTestSwitch.par", tStart, tStop, true, 3);
+  SolverFactory::SolverPtr& solver = p.first;
+  std::shared_ptr<Model>& model = p.second;
+
+  double tCurrent = tStart;
+  // step to just before the event at t=2 (same cadence as testSolverSIMAlgebraicMode)
+  solver->solve(tStop, tCurrent);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(tCurrent, 1.);
+  // the step where the switch event fires: voltage-level-internal topology change,
+  // par opts in (patternInvariantTopology=true) -> downgraded severity
+  solver->solve(tStop, tCurrent);
+  ASSERT_EQ(solver->getState().getFlags(ModeChange), true);
+  ASSERT_EQ(model->getModeChangeType(), ALGEBRAIC_MODE);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(tCurrent, 2.);
+}
+
+TEST(SimulationTest, testSolverSIMPatternInvariantTopologyFlagOff) {
+  const double tStart = 0.;
+  const double tStop = 5.;
+  std::pair<SolverFactory::SolverPtr, std::shared_ptr<Model> > p = initSolverAndModel("jobs/solverTestSwitch.dyd",
+  "jobs/solverTestSwitch.iidm", "jobs/solverTestSwitchFlagOff.par", tStart, tStop, true, 3);
+  SolverFactory::SolverPtr& solver = p.first;
+  std::shared_ptr<Model>& model = p.second;
+
+  double tCurrent = tStart;
+  solver->solve(tStop, tCurrent);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(tCurrent, 1.);
+  // flag off: today's behaviour, full J-update severity
+  solver->solve(tStop, tCurrent);
+  ASSERT_EQ(solver->getState().getFlags(ModeChange), true);
+  ASSERT_EQ(model->getModeChangeType(), ALGEBRAIC_J_UPDATE_MODE);
+  ASSERT_DOUBLE_EQUALS_DYNAWO(tCurrent, 2.);
 }
 
 }  // namespace DYN

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitch.dyd
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitch.dyd
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+    Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+    See AUTHORS.txt
+    All rights reserved.
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, you can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+    This file is part of Dynawo, a hybrid C++/Modelica open source time domain
+    simulation tool for power systems.
+-->
+<dyn:dynamicModelsArchitecture xmlns:dyn="http://www.rte-france.com/dynawo">
+  <dyn:modelicaModel id="lineDisconnection">
+    <dyn:unitDynamicModel id="event" name="DYNDisconnection" moFile="DYNSolverTest.mo"/>
+  </dyn:modelicaModel>
+  <dyn:modelicaModel id="infiniteBus" staticId="GEN">
+    <dyn:unitDynamicModel id="InfiniteBus" name="DYNInfiniteBus" moFile="DYNSolverTest.mo"/>
+  </dyn:modelicaModel>
+  <dyn:connect id1="lineDisconnection" var1="event_switchOff" id2="NETWORK" var2="SW_BUS2_state_value"/>
+  <dyn:connect id1="infiniteBus" var1="InfiniteBus_terminal" id2="NETWORK" var2="TN_ACPIN"/>
+</dyn:dynamicModelsArchitecture>

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitch.iidm
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitch.iidm
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<!--
+    Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+    See AUTHORS.txt
+    All rights reserved.
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, you can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+    This file is part of Dynawo, an hybrid C++/Modelica open source time domain
+    simulation tool for power systems.
+-->
+<network xmlns="http://www.itesla_project.eu/schema/iidm/1_0" id="testCSPR" caseDate="2017-07-25T09:39:00.000+01:00" forecastDistance="0" sourceFormat="NF">
+  <substation id="_BUS___1_SS" name="undefined" country="AF">
+    <voltageLevel id="_BUS___1" nominalV="380" topologyKind="BUS_BREAKER">
+      <busBreakerTopology>
+        <bus id="_BUS___11" v="390.7399770666463" angle="-3.3050095214880555"/>
+      </busBreakerTopology>
+    </voltageLevel>
+  </substation>
+  <substation id="_BUS___2_site" name="undefined" country="AF">
+    <voltageLevel id="_BUS___2" nominalV="380" lowVoltageLimit="0" topologyKind="BUS_BREAKER">
+      <busBreakerTopology>
+        <bus id="_BUS___21" v="390.48015721280433" angle="-6.7867020970046736"/>
+        <bus id="_BUS___22" v="390.48015721280433" angle="-6.7867020970046736"/>
+        <switch id="SW_BUS2" kind="BREAKER" open="false" bus1="_BUS___21" bus2="_BUS___22"/>
+      </busBreakerTopology>
+      <load id="_BUS___2_L" loadType="UNDEFINED" p0="1000" q0="300" bus="_BUS___22" connectableBus="_BUS___22" p="1000" q="300"/>
+    </voltageLevel>
+  </substation>
+  <substation id="VL_site" name="undefined" country="AF">
+    <voltageLevel id="VL" nominalV="380" topologyKind="BUS_BREAKER">
+      <property name="siteInit" value="undefined"/>
+      <busBreakerTopology>
+        <bus id="TN" v="415.0001220703125" angle="0"/>
+      </busBreakerTopology>
+      <generator id="GEN" energySource="HYDRO" minP="300" maxP="2000" voltageRegulatorOn="true" targetP="1000" targetQ="0" targetV="415.0001220703125" bus="TN" connectableBus="TN" p="-1021.0785447964267" q="-383.08791684564494">
+        <property name="genreCvg" value="POMPAGE"/>
+        <reactiveCapabilityCurve>
+          <point p="300" minQ="-9998" maxQ="9999"/>
+          <point p="2000" minQ="-9998" maxQ="9999"/>
+        </reactiveCapabilityCurve>
+      </generator>
+    </voltageLevel>
+  </substation>
+  <line id="_BUS___1__BUS___2_1" r="1.5000001192092896" x="10" g1="0" b1="1.9999999949504854e-06" g2="0" b2="1.9999999949504854e-06" voltageLevelId1="_BUS___1" bus1="_BUS___11" connectableBus1="_BUS___11" voltageLevelId2="_BUS___2" bus2="_BUS___21" connectableBus2="_BUS___21" p1="1010.7212885748779" q1="370.84590463856875" p2="-999.99999999606734" q2="-299.99999999643478">
+    <currentLimits1 permanentLimit="2000.0006103515625"/>
+    <currentLimits2 permanentLimit="2000.0006103515625"/>
+  </line>
+  <line id="_BUS___1__BUS___2_2" r="1.5000001192092896" x="10" g1="0" b1="1.9999999949504854e-06" g2="0" b2="1.9999999949504854e-06" voltageLevelId1="_BUS___1" bus1="_BUS___11" connectableBus1="_BUS___11" voltageLevelId2="_BUS___2" bus2="_BUS___21" connectableBus2="_BUS___21" p1="1010.7212885748779" q1="370.84590463856875" p2="-999.99999999606734" q2="-299.99999999643478">
+    <currentLimits1 permanentLimit="2000.0006103515625"/>
+    <currentLimits2 permanentLimit="2000.0006103515625"/>
+  </line>
+  <line id="TN__BUS___11_1" r="1.5000001192092896" x="10" g1="0" b1="1.9999999949504854e-06" g2="0" b2="1.9999999949504854e-06" voltageLevelId1="VL" bus1="TN" connectableBus1="TN" voltageLevelId2="_BUS___1" bus2="_BUS___11" connectableBus2="_BUS___11" p1="1021.0824068867491" q1="383.08791684564494" p2="-1010.7212885766298" q2="-314.68264788437955">
+    <currentLimits1 permanentLimit="2000.0006103515625"/>
+    <currentLimits2 permanentLimit="2000.0006103515625"/>
+  </line>
+</network>

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitch.par
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitch.par
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+    See AUTHORS.txt
+    All rights reserved.
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, you can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+    This file is part of Dynawo, a hybrid C++/Modelica open source time domain
+    simulation tool for power systems.
+-->
+<parametersSet xmlns="http://www.rte-france.com/dynawo">
+    <!--Network parameters-->
+    <set id="0">
+        <par type="DOUBLE" name="capacitor_no_reclosing_delay" value="300"/>
+        <par type="DOUBLE" name="dangling_line_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="line_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="load_Tp" value="90"/>
+        <par type="DOUBLE" name="load_Tq" value="90"/>
+        <par type="DOUBLE" name="load_alpha" value="1"/>
+        <par type="DOUBLE" name="load_alphaLong" value="0"/>
+        <par type="DOUBLE" name="load_beta" value="2"/>
+        <par type="DOUBLE" name="load_betaLong" value="0"/>
+        <par type="BOOL" name="load_isControllable" value="false"/>
+        <par type="BOOL" name="load_isRestorative" value="false"/>
+        <par type="DOUBLE" name="load_zPMax" value="100"/>
+        <par type="DOUBLE" name="load_zQMax" value="100"/>
+        <par type="DOUBLE" name="reactance_no_reclosing_delay" value="0"/>
+        <par type="DOUBLE" name="transformer_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="transformer_t1st_HT" value="60"/>
+        <par type="DOUBLE" name="transformer_t1st_THT" value="30"/>
+        <par type="DOUBLE" name="transformer_tNext_HT" value="10"/>
+        <par type="DOUBLE" name="transformer_tNext_THT" value="10"/>
+        <par type="DOUBLE" name="transformer_tolV" value="0.014999999700000001"/>
+        <par type="DOUBLE" name="CSPR_TEST_no_reclosing_delay" value="0"/>
+        <par type="DOUBLE" name="generator_alpha" value="1.5"/>
+        <par type="DOUBLE" name="generator_beta" value="2.5"/>
+        <par type="BOOL" name="generator_isVoltageDependent" value="false"/>
+        <par type="BOOL" name="deactivate_zero_crossing_functions" value="false"/>
+        <par type="BOOL" name="patternInvariantTopology" value="true"/>
+    </set>
+</parametersSet>

--- a/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitchFlagOff.par
+++ b/dynawo/sources/Solvers/FixedTimeStep/SolverSIM/test/jobs/solverTestSwitchFlagOff.par
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+    See AUTHORS.txt
+    All rights reserved.
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, you can obtain one at http://mozilla.org/MPL/2.0/.
+    SPDX-License-Identifier: MPL-2.0
+
+    This file is part of Dynawo, a hybrid C++/Modelica open source time domain
+    simulation tool for power systems.
+-->
+<parametersSet xmlns="http://www.rte-france.com/dynawo">
+    <!--Network parameters-->
+    <set id="0">
+        <par type="DOUBLE" name="capacitor_no_reclosing_delay" value="300"/>
+        <par type="DOUBLE" name="dangling_line_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="line_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="load_Tp" value="90"/>
+        <par type="DOUBLE" name="load_Tq" value="90"/>
+        <par type="DOUBLE" name="load_alpha" value="1"/>
+        <par type="DOUBLE" name="load_alphaLong" value="0"/>
+        <par type="DOUBLE" name="load_beta" value="2"/>
+        <par type="DOUBLE" name="load_betaLong" value="0"/>
+        <par type="BOOL" name="load_isControllable" value="false"/>
+        <par type="BOOL" name="load_isRestorative" value="false"/>
+        <par type="DOUBLE" name="load_zPMax" value="100"/>
+        <par type="DOUBLE" name="load_zQMax" value="100"/>
+        <par type="DOUBLE" name="reactance_no_reclosing_delay" value="0"/>
+        <par type="DOUBLE" name="transformer_currentLimit_maxTimeOperation" value="90"/>
+        <par type="DOUBLE" name="transformer_t1st_HT" value="60"/>
+        <par type="DOUBLE" name="transformer_t1st_THT" value="30"/>
+        <par type="DOUBLE" name="transformer_tNext_HT" value="10"/>
+        <par type="DOUBLE" name="transformer_tNext_THT" value="10"/>
+        <par type="DOUBLE" name="transformer_tolV" value="0.014999999700000001"/>
+        <par type="DOUBLE" name="CSPR_TEST_no_reclosing_delay" value="0"/>
+        <par type="DOUBLE" name="generator_alpha" value="1.5"/>
+        <par type="DOUBLE" name="generator_beta" value="2.5"/>
+        <par type="BOOL" name="generator_isVoltageDependent" value="false"/>
+        <par type="BOOL" name="deactivate_zero_crossing_functions" value="false"/>
+        <par type="BOOL" name="patternInvariantTopology" value="false"/>
+    </set>
+</parametersSet>

--- a/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp
+++ b/dynawo/sources/Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp
@@ -737,7 +737,11 @@ bool SolverIDA::setupNewAlgRestoration(modeChangeType_t modeChangeType) {
     solverKINNormal_->setupNewAlgebraicRestoration(fnormtolAlg_, initialaddtolAlg_, scsteptolAlg_, mxnewtstepAlg_, msbsetAlg_, mxiterAlg_, printflAlg_);
     setDifferentialVariablesIndices();
     solverKINYPrim_->setupNewAlgebraicRestoration(fnormtolAlg_, initialaddtolAlg_, scsteptolAlg_, mxnewtstepAlg_, msbsetAlg_, mxiterAlg_, printflAlg_);
-    return false;  // no J factorization
+    // A pattern-invariant topology event reaches this branch as ALGEBRAIC_MODE, and the
+    // restoration solve needs a fresh factorization: the switch state moved the Jacobian's
+    // values, only its pattern is fixed. The factorization is numeric only, the symbolic
+    // analysis being retained because the pattern comparison finds no change.
+    return model_->getPatternInvariantTopoChange();
   } else if (modeChangeType == ALGEBRAIC_J_UPDATE_MODE) {
     solverKINNormal_->setupNewAlgebraicRestoration(fnormtolAlgJ_, initialaddtolAlgJ_, scsteptolAlgJ_, mxnewtstepAlgJ_, msbsetAlgJ_, mxiterAlgJ_,
                                                    printflAlgJ_);
@@ -779,7 +783,11 @@ SolverIDA::reinit() {
   if (modeChangeType == NO_MODE) return;
 
   const bool evaluateOnlyMode = optimizeReinitAlgebraicResidualsEvaluations_;
-  if (modeChangeType >= minimumModeChangeTypeForAlgebraicRestoration_) {
+  // A pattern-invariant topology event is exempt from the severity threshold. IDA integrates
+  // from consistent initial conditions and has no per-step solve of the whole system to restore
+  // them, so its restoration is never skipped and no parameter offers to skip it.
+  const bool patternInvariantTopoEvent = model_->getPatternInvariantTopoChange();
+  if (patternInvariantTopoEvent || modeChangeType >= minimumModeChangeTypeForAlgebraicRestoration_) {
     do {
       model_->rotateBuffers();
       state_.reset();

--- a/dynawo/sources/Solvers/util/test/res/dumpSolver.desc.xml
+++ b/dynawo/sources/Solvers/util/test/res/dumpSolver.desc.xml
@@ -3,6 +3,7 @@
   <name>SimplifiedSolver</name>
   <elements>
     <parameters>
+      <parameter name="algebraicRestorationOnInvariantTopology" valueType="BOOL" cardinality="1"/>
       <parameter name="enableSilentZ" valueType="BOOL" cardinality="1"/>
       <parameter name="fnormtol" valueType="DOUBLE" cardinality="1"/>
       <parameter name="fnormtolAlg" valueType="DOUBLE" cardinality="1"/>


### PR DESCRIPTION
Closes #4196.

Adds two opt-in boolean parameters, both defaulting to false. With `patternInvariantTopology`
unset, no code path changes behaviour: the sparsity pattern, the mode classification and the
factorisation schedule are those of the current implementation.

### What the parameter gates

Two changes jointly, either applied alone being incorrect.

`ModelSwitch::evalJt` emits the union of the switch's three equation forms rather than only the
active one, through the new `SparseMatrix::addTermForced`, so that the inactive entries are
written as structural zeros instead of being discarded. The pattern becomes invariant across
switch states, at a fixed cost of three entries per switch column.

`ModelNetwork::evalMode` then returns `ALGEBRAIC_MODE` rather than `ALGEBRAIC_J_UPDATE_MODE`
for a component whose `hasPatternInvariantTopologyChange()` returns true. That method is
declared on `NetworkComponent` and returns false; the sole override returning true is
`ModelVoltageLevel`. Switch, bus and injection connection changes are consequently downgraded,
whereas line and transformer trips continue to request a full update.

### The solver still refreshes once after a downgraded event

The reclassification asserts that the pattern did not change, not that the values did not. A
switch opening moves the operating point, so `SolverCommonFixedTimeStep::handleRoot` sets
`factorizationForced_` when the model reports a downgraded topology event:

```cpp
factorizationForced_ = model_->getPatternInvariantTopoChange();
```

This costs a numeric refactorisation only. The symbolic analysis is retained because the
row-index comparison in `SolverCommon::propagateMatrixStructureChangeToKINSOL` finds no change,
which is what the invariant pattern buys. The expression is false whenever
`patternInvariantTopology` is unset, so the branch keeps its current value of `false` in that
case. The signal reaches the solver through a new virtual
`SubModel::getPatternInvariantTopoChange()`, defaulting to false, aggregated over sub models by
`ModelMulti` with the same set and reset lifecycle as `modeChangeType_`, and exposed on `Model`.

### `algebraicRestorationOnInvariantTopology`, fixed-time-step solvers

Default false: a step whose events are *all* pattern-invariant skips algebraic restoration.
`SolverKINEuler` re-solves `F(y) = 0` over every variable on the following step, algebraic ones
included, so the algebraic state is restored there instead; the trajectory lags by one step at
the event instant. Set the parameter to keep the restoration, in which case the trajectory is
unchanged to the curve export precision.

A step that also carries a line trip reports `ALGEBRAIC_J_UPDATE_MODE` and keeps its
restoration.

### `SolverIDA`

Supported. `SolverIDA::reinit()` exempts a pattern-invariant topology event from the severity
threshold unconditionally, and no equivalent parameter is defined for it: IDA integrates from
consistent initial conditions and has no per-step solve of the whole system. Solver-specific
parameters follow the existing convention that `hMax` belongs to the fixed-step solvers and
`maxStep` to IDA.

Forced Jacobian rebuilds fall on IDA, 4 to 0 on the 6000-bus RTE case and 5 to 4 on a Nordic
case. Execution time does not follow, since residual and Jacobian evaluation counts are
unchanged; IDA schedules its Jacobian from its own convergence history rather than from the
reported mode.

`evalJt` additionally tests `isInitModel()` and `getIsInitProcess()`, so the superset is not
used while the network initializes. `SolverKINAlgRestoration` erases structural zeros before
factorising and `SolverKINSubModel` does not, and initialization is the only point at which the
latter would reach KLU with explicit zeros in pivot positions, where a near-singular solve can
return NaN without raising. The exclusion costs nothing, the pattern only needing to be steady
across events.

### Files

| File | Change |
|---|---|
| `Common/DYNSparseMatrix.{h,cpp}` | `addTermForced`, being `addTerm` without the zero guard |
| `Models/CPP/ModelNetwork/DYNModelSwitch.cpp` | superset form of `evalJt`, behind the parameter and excluded during initialization |
| `Models/CPP/ModelNetwork/DYNModelNetwork.{h,cpp}` | the parameter, and the reclassification in `evalMode` |
| `Models/CPP/ModelNetwork/DYNNetworkComponent.h` | `hasPatternInvariantTopologyChange()`, returning false |
| `Models/CPP/ModelNetwork/DYNModelVoltageLevel.h` | the one override returning true |
| `Modeler/Common/DYNSubModel.h` | `getPatternInvariantTopoChange()`, returning false |
| `Modeler/Common/DYNModelMulti.{h,cpp}`, `DYNModel.h` | aggregation of that flag and its reset in `reinitMode()` |
| `Solvers/FixedTimeStep/DYNSolverCommonFixedTimeStep.{h,cpp}` | `handleRoot`, the restoration gate, and the new solver parameter |
| `Solvers/VariableTimeStep/SolverIDA/DYNSolverIDA.cpp` | the restoration gate and the factorisation for a downgraded event |
| `Solvers/util/test/res/dumpSolver.desc.xml` | the new solver parameter in the reference description |
| `Common/test/Test.cpp` | `addTermForced` |
| `Models/CPP/ModelNetwork/test/TestSwitch.cpp` | both branches of the switch Jacobian |
| `Models/CPP/ModelNetwork/test/TestLoad.cpp` | the classifier, aggregated over a voltage level's components |
| `Models/CPP/ModelNetwork/test/TestIIDMInitializationFlow.cpp` | the network parameter, declared, absent and set |
| `Solvers/FixedTimeStep/SolverSIM/test/TestBasics.cpp` and `test/jobs/solverTestSwitch.*` | a fixture exercising a downgraded and a structural topology event in one run |

24 files, 777 insertions, 63 deletions. The fixed-step solvers gain one parameter, 45 to 46;
`SolverIDA`'s parameter set is unchanged.

### Validation

Unit tests cover the new sparse-matrix entry point, both branches of the switch Jacobian, the
classifier default and its `ModelVoltageLevel` override, and the network parameter declared,
absent and set. The fixture `solverTestSwitch` runs one simulation containing a switch event
and a line trip, with a second parameter file holding the parameter off, so the downgraded
path, the structural path and the disabled path are all exercised end to end.

The solver's reaction itself is not unit tested. `factorizationForced_` has no public
observation point, and exposing one solely for a test would widen an interface this change
otherwise leaves untouched; a maintainer who would rather have the accessor need only say so.
The behaviour is covered by the corpus measurement in the attached report.

**Measured** on the 6000-bus RTE case at 400 s, five interleaved serial replicates per side: steps
exceeding a 1000 ms budget fall from 6 of 400 to 2, and the worst step from 2298 ms to 1086 ms.
Across a 61-case corpus, forced Jacobian rebuilds fall 623 to 392 with 60 cases improving and
none worse, status parity holds on all 61, and the worst settled deviation is 6.0e-04 pu against
a 1e-03 criterion.

The motivation, the profiling that identifies the cost, and the full figures are set out in a report that can be attached on request.
